### PR TITLE
Associate PLY file with the SuperSplat PWA

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
-    "name": "super-splat",
+    "name": "supersplat",
     "version": "0.16.0",
     "author": "PlayCanvas<support@playcanvas.com>",
-    "homepage": "https://playcanvas.com/super-splat",
-    "description": "All the splat things",
+    "homepage": "https://playcanvas.com/supersplat/editor",
+    "description": "3D Gaussian Splat Editor",
     "keywords": [
         "playcanvas",
         "ply",

--- a/src/main.ts
+++ b/src/main.ts
@@ -17,7 +17,14 @@ import { Events } from './events';
 import { PickerSelection } from './tools/picker-selection';
 
 declare global {
+    interface LaunchParams {
+        readonly files: FileSystemFileHandle[];
+    }
+    
     interface Window {
+        launchQueue: {
+            setConsumer: (callback: (launchParams: LaunchParams) => void) => void;
+        };
         scene: Scene;
         showError: (err: string) => void;
     }
@@ -189,6 +196,16 @@ const main = async () => {
     }
 
     window.scene = scene;
-}
+
+    // handle OS-based file association in PWA mode
+    if ("launchQueue" in window) {
+        window.launchQueue.setConsumer(async (launchParams: LaunchParams) => {
+            for (const file of launchParams.files) {
+                const blob = await file.getFile();
+                scene.loadModel(URL.createObjectURL(blob), file.name);
+            }
+        });
+    }
+};
 
 export { main };

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -30,5 +30,13 @@
             "sizes": "3840x2160",
             "form_factor": "wide"
         }
-      ]
+    ],
+    "file_handlers": [
+        {
+            "action": "/",
+            "accept": {
+                "application/ply": [".ply"]
+            }
+        }
+    ]
 }

--- a/src/ui/control-panel.ts
+++ b/src/ui/control-panel.ts
@@ -5,7 +5,7 @@ import { version as supersplatVersion } from '../../package.json';
 class ControlPanel extends Panel {
     constructor(events: Events, remoteStorageMode: boolean, args = { }) {
         Object.assign(args, {
-            headerText: `SUPER SPLAT v${supersplatVersion}`,
+            headerText: `SUPERSPLAT v${supersplatVersion}`,
             id: 'control-panel',
             resizable: 'right',
             resizeMax: 1000,


### PR DESCRIPTION
Now, when you install the SuperSplat PWA, PLY files will be associated with the app. Here is what that looks like on Windows:

![pwaopen2](https://github.com/playcanvas/supersplat/assets/697563/321a428b-d14c-456d-a61b-711741a5703e)

In the video about, I already have Paint3D associated with .PLY, so I use 'Open With' instead. I _could_ switch the SuperSplat PWA to always open .PLY instead, of course.

Fixes #91 