### PR TITLE
Support loading multiple splats and use File System Api

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "supersplat",
-    "version": "0.18.1",
+    "version": "0.19.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "supersplat",
-            "version": "0.18.1",
+            "version": "0.19.0",
             "license": "MIT",
             "devDependencies": {
                 "@playcanvas/eslint-config": "^1.7.1",
@@ -26,7 +26,7 @@
                 "cross-env": "^7.0.3",
                 "eslint": "^8.56.0",
                 "jest": "^29.7.0",
-                "playcanvas": "^1.71.2",
+                "playcanvas": "^1.71.5",
                 "rollup": "^4.18.0",
                 "rollup-plugin-sass": "^1.12.22",
                 "rollup-plugin-visualizer": "^5.12.0",
@@ -6299,9 +6299,9 @@
             }
         },
         "node_modules/playcanvas": {
-            "version": "1.71.2",
-            "resolved": "https://registry.npmjs.org/playcanvas/-/playcanvas-1.71.2.tgz",
-            "integrity": "sha512-kAx2xKUm+Cq2ryuBWB+/ZXIshaOd+xuRT2ghpZ1ialc0h7xO1ZWiaSC9gbcO0TEDPx7vWE7gbEaB+jX6oeeM1g==",
+            "version": "1.71.5",
+            "resolved": "https://registry.npmjs.org/playcanvas/-/playcanvas-1.71.5.tgz",
+            "integrity": "sha512-1Gba1sdye9HhcSl4DstBAxCgtnKy/oHFgDzmRxcOlcZLvlYIK+G7SxPluiXfRewnTpWIGn03yZ4841zhtNAZDg==",
             "dev": true,
             "dependencies": {
                 "@types/webxr": "^0.5.15",

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
                 "@rollup/plugin-strip": "^3.0.4",
                 "@rollup/plugin-terser": "^0.4.4",
                 "@rollup/plugin-typescript": "^11.1.6",
+                "@types/wicg-file-system-access": "^2023.10.5",
                 "@typescript-eslint/eslint-plugin": "^7.10.0",
                 "@typescript-eslint/parser": "^7.10.0",
                 "concurrently": "^8.2.2",
@@ -1857,6 +1858,12 @@
             "version": "0.5.16",
             "resolved": "https://registry.npmjs.org/@types/webxr/-/webxr-0.5.16.tgz",
             "integrity": "sha512-0E0Cl84FECtzrB4qG19TNTqpunw0F1YF0QZZnFMF6pDw1kNKJtrlTKlVB34stGIsHbZsYQ7H0tNjPfZftkHHoA==",
+            "dev": true
+        },
+        "node_modules/@types/wicg-file-system-access": {
+            "version": "2023.10.5",
+            "resolved": "https://registry.npmjs.org/@types/wicg-file-system-access/-/wicg-file-system-access-2023.10.5.tgz",
+            "integrity": "sha512-e9kZO9kCdLqT2h9Tw38oGv9UNzBBWaR1MzuAavxPcsV/7FJ3tWbU6RI3uB+yKIDPGLkGVbplS52ub0AcRLvrhA==",
             "dev": true
         },
         "node_modules/@types/yargs": {

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
         "@rollup/plugin-strip": "^3.0.4",
         "@rollup/plugin-terser": "^0.4.4",
         "@rollup/plugin-typescript": "^11.1.6",
+        "@types/wicg-file-system-access": "^2023.10.5",
         "@typescript-eslint/eslint-plugin": "^7.10.0",
         "@typescript-eslint/parser": "^7.10.0",
         "concurrently": "^8.2.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "supersplat",
-    "version": "0.18.1",
+    "version": "0.19.0",
     "author": "PlayCanvas<support@playcanvas.com>",
     "homepage": "https://playcanvas.com/supersplat/editor",
     "description": "3D Gaussian Splat Editor",
@@ -68,7 +68,7 @@
         "cross-env": "^7.0.3",
         "eslint": "^8.56.0",
         "jest": "^29.7.0",
-        "playcanvas": "^1.71.2",
+        "playcanvas": "^1.71.5",
         "rollup": "^4.18.0",
         "rollup-plugin-sass": "^1.12.22",
         "rollup-plugin-visualizer": "^5.12.0",

--- a/src/controllers.ts
+++ b/src/controllers.ts
@@ -66,8 +66,9 @@ class MouseController {
             return vec2.sub2(a, b).length();
         };
 
-        let closestP = null;
         let closestD = 0;
+        let closestP = new Vec3();
+        let closestSplat = null;
 
         for (let i = 0; i < splats.length; ++i) {
             const splat = splats[i] as Splat;
@@ -90,19 +91,18 @@ class MouseController {
                 // find intersection
                 if (plane.intersectsRay(ray, vec)) {
                     const distance = dist(vec, cameraPos);
-                    if (!closestP) {
-                        closestP = vec.clone();
+                    if (!closestSplat || distance < closestD) {
                         closestD = distance;
-                    } else if (distance < closestD) {
                         closestP.copy(vec);
-                        closestD = distance;
+                        closestSplat = splat;
                     }
                 }
             }
         }
 
-        if (closestP) {
+        if (closestSplat) {
             this.camera.setFocalPoint(closestP);
+            scene.events.fire('selection', closestSplat);
         }
     };
 

--- a/src/controllers.ts
+++ b/src/controllers.ts
@@ -26,7 +26,7 @@ import {
 const plane = new Plane();
 const ray = new Ray();
 const vec = new Vec3();
-const vec2 = new Vec3();
+const vecb = new Vec3();
 const fromWorldPoint = new Vec3();
 const toWorldPoint = new Vec3();
 const worldDiff = new Vec3();
@@ -63,7 +63,7 @@ class MouseController {
         const splats = scene.getElementsByType(ElementType.splat);
 
         const dist = (a: Vec3, b: Vec3) => {
-            return vec2.sub2(a, b).length();
+            return vecb.sub2(a, b).length();
         };
 
         let closestD = 0;

--- a/src/custom-shadow.ts
+++ b/src/custom-shadow.ts
@@ -241,13 +241,13 @@ class CustomShadow extends Element {
         this.scene.app.root.addChild(this.plane);
         this.scene.app.root.addChild(this.camera);
 
-        this.scene.events.on('scene.boundUpdated', this.regenerate, this);
+        this.scene.events.on('scene.boundChanged', this.regenerate, this);
         this.scene.graphicsDevice.on('devicerestored', this.regenerate, this);
     }
 
     remove() {
         this.scene.graphicsDevice.off('devicerestored', this.regenerate, this);
-        this.scene.events.off('scene.boundUpdated', this.regenerate, this);
+        this.scene.events.off('scene.boundChanged', this.regenerate, this);
 
         this.scene.app.root.removeChild(this.camera);
         this.scene.app.root.removeChild(this.plane);

--- a/src/edit-ops.ts
+++ b/src/edit-ops.ts
@@ -110,7 +110,7 @@ interface EntityTransform {
 };
 
 interface EntityOp {
-    element: Element;
+    splat: Splat;
     old: EntityTransform;
     new: EntityTransform;
 }
@@ -127,13 +127,13 @@ class EntityTransformOp {
 
     do() {
         this.entityOps.forEach((entityOp) => {
-            entityOp.element.move(entityOp.new.position, entityOp.new.rotation, entityOp.new.scale);
+            entityOp.splat.move(entityOp.new.position, entityOp.new.rotation, entityOp.new.scale);
         });
     }
 
     undo() {
         this.entityOps.forEach((entityOp) => {
-            entityOp.element.move(entityOp.old.position, entityOp.old.rotation, entityOp.old.scale);
+            entityOp.splat.move(entityOp.old.position, entityOp.old.rotation, entityOp.old.scale);
         });
     }
 

--- a/src/edit-ops.ts
+++ b/src/edit-ops.ts
@@ -1,5 +1,7 @@
-import { Entity, GSplatData, Quat, Vec3 } from 'playcanvas';
+import { GSplatData, Quat, Vec3 } from 'playcanvas';
 import { Scene } from './scene';
+import { Element } from './element';
+import { Splat } from './splat';
 
 enum State {
     selected = 1,
@@ -27,66 +29,76 @@ const buildIndex = (splatData: GSplatData, pred: (i: number) => boolean) => {
 
 class DeleteSelectionEditOp {
     name = 'deleteSelection';
-    splatData: GSplatData;
+    splat: Splat;
     indices: Uint32Array;
 
-    constructor(splatData: GSplatData) {
+    constructor(splat: Splat) {
+        const splatData = splat.splatData;
         const state = splatData.getProp('state') as Uint8Array;
         const indices = buildIndex(splatData, (i) => !!(state[i] & State.selected));
 
-        this.splatData = splatData;
+        this.splat = splat;
         this.indices = indices;
     }
 
     do() {
-        const state = this.splatData.getProp('state') as Uint8Array;
+        const splatData = this.splat.splatData;
+        const state = splatData.getProp('state') as Uint8Array;
         for (let i = 0; i < this.indices.length; ++i) {
             state[this.indices[i]] |= State.deleted;
         }
+        this.splat.updateState(true);
     }
 
     undo() {
-        const state = this.splatData.getProp('state') as Uint8Array;
+        const splatData = this.splat.splatData;
+        const state = splatData.getProp('state') as Uint8Array;
         for (let i = 0; i < this.indices.length; ++i) {
             state[this.indices[i]] &= ~State.deleted;
         }
+        this.splat.updateState(true);
     }
 
     destroy() {
-        this.splatData = null;
+        this.splat = null;
         this.indices = null;
     }
 }
 
 class ResetEditOp {
     name = 'reset';
-    splatData: GSplatData;
+    splat: Splat;
     indices: Uint32Array;
 
-    constructor(splatData: GSplatData) {
+    constructor(splat: Splat) {
+        const splatData = splat.splatData;
         const state = splatData.getProp('state') as Uint8Array;
         const indices = buildIndex(splatData, (i) => !!(state[i] & State.deleted));
 
-        this.splatData = splatData;
+        this.splat = splat;
         this.indices = indices;
     }
 
     do() {
-        const state = this.splatData.getProp('state') as Uint8Array;
+        const splatData = this.splat.splatData;
+        const state = splatData.getProp('state') as Uint8Array;
         for (let i = 0; i < this.indices.length; ++i) {
             state[this.indices[i]] &= ~State.deleted;
         }
+        this.splat.updateState(true);
     }
 
     undo() {
-        const state = this.splatData.getProp('state') as Uint8Array;
+        const splatData = this.splat.splatData;
+        const state = splatData.getProp('state') as Uint8Array;
         for (let i = 0; i < this.indices.length; ++i) {
             state[this.indices[i]] |= State.deleted;
         }
+        this.splat.updateState(true);
     }
 
     destroy() {
-        this.splatData = null;
+        this.splat = null;
         this.indices = null;
     }
 }
@@ -98,7 +110,7 @@ interface EntityTransform {
 };
 
 interface EntityOp {
-    entity: Entity;
+    element: Element;
     old: EntityTransform;
     new: EntityTransform;
 }
@@ -115,20 +127,14 @@ class EntityTransformOp {
 
     do() {
         this.entityOps.forEach((entityOp) => {
-            entityOp.entity.setLocalPosition(entityOp.new.position);
-            entityOp.entity.setLocalRotation(entityOp.new.rotation);
-            entityOp.entity.setLocalScale(entityOp.new.scale);
+            entityOp.element.move(entityOp.new.position, entityOp.new.rotation, entityOp.new.scale);
         });
-        this.scene.updateBound();
     }
 
     undo() {
         this.entityOps.forEach((entityOp) => {
-            entityOp.entity.setLocalPosition(entityOp.old.position);
-            entityOp.entity.setLocalRotation(entityOp.old.rotation);
-            entityOp.entity.setLocalScale(entityOp.old.scale);
+            entityOp.element.move(entityOp.old.position, entityOp.old.rotation, entityOp.old.scale);
         });
-        this.scene.updateBound();
     }
 
     destroy() {
@@ -140,5 +146,6 @@ export {
     State,
     DeleteSelectionEditOp,
     ResetEditOp,
+    EntityOp,
     EntityTransformOp
 };

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -137,13 +137,14 @@ const registerEditorEvents = (events: Events, editHistory: EditHistory, scene: S
         if (splat) {
             const splatData = splat.splatData;
             const state = splatData.getProp('state') as Uint8Array;
-            const deletedPred = (i: number) => (state[i] & (State.hidden | State.deleted)) === 0;
-            const selectionPred = (i: number) => (state[i] & State.selected) === State.selected;
+
+            const visiblePred = (i: number) => (state[i] & (State.hidden | State.deleted)) === 0;
+            const selectionPred = (i: number) => visiblePred(i) && ((state[i] & State.selected) === State.selected);
 
             if (splatData.calcAabb(aabb, selectionPred)) {
                 splatData.calcFocalPoint(vec, selectionPred);
-            } else if (splatData.calcAabb(aabb, deletedPred)) {
-                splatData.calcFocalPoint(vec, deletedPred);
+            } else if (splatData.calcAabb(aabb, visiblePred)) {
+                splatData.calcFocalPoint(vec, visiblePred);
             } else {
                 return;
             }

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -34,10 +34,6 @@ const registerEditorEvents = (events: Events, editHistory: EditHistory, scene: S
     const aabb = new BoundingBox();
     const splatDefs: SplatDef[] = [];
 
-    events.on('error', (err: any) => {
-        editorUI.showError(err);
-    });
-
     events.on('loaded', (filename: string) => {
         editorUI.setFilename(filename);
     });
@@ -183,6 +179,10 @@ const registerEditorEvents = (events: Events, editHistory: EditHistory, scene: S
         const msg = 'You have unsaved changes. Are you sure you want to leave?';
         e.returnValue = msg;
         return msg;
+    });
+
+    events.on('scene.saved', () => {
+        lastExportCursor = editHistory.cursor;
     });
 
     events.on('camera.mode', (mode: string) => {

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -1,29 +1,16 @@
 import {
     BoundingBox,
     Color,
-    GSplat as SplatRender,
-    GSplatData,
-    GSplatInstance,
     Mat4,
     Vec3,
     Vec4,
 } from 'playcanvas';
 import { Scene } from './scene';
 import { EditorUI } from './ui/editor';
-import { EditHistory, EditOp } from './edit-history';
-import { Element, ElementType } from './element';
+import { EditHistory } from './edit-history';
 import { Splat } from './splat';
 import { State, DeleteSelectionEditOp, ResetEditOp } from './edit-ops';
-import { SplatDebug } from './splat-debug';
 import { Events } from './events';
-
-interface SplatDef {
-    element: Splat,
-    data: GSplatData,
-    render: SplatRender,
-    instance: GSplatInstance,
-    debug: SplatDebug
-};
 
 // register for editor and scene events
 const registerEditorEvents = (events: Events, editHistory: EditHistory, scene: Scene, editorUI: EditorUI) => {
@@ -32,40 +19,16 @@ const registerEditorEvents = (events: Events, editHistory: EditHistory, scene: S
     const vec4 = new Vec4();
     const mat = new Mat4();
     const aabb = new BoundingBox();
-    const splatDefs: SplatDef[] = [];
 
     events.on('loaded', (filename: string) => {
         editorUI.setFilename(filename);
     });
 
-    // make a copy of the opacity channel because that's what we'll be modifying
-    events.on('scene.elementAdded', (element: Element) => {
-        if (element.type === ElementType.splat) {
-            const splatElement = element as Splat;
-            const resource = splatElement.asset.resource;
-            const splatData = resource.splatData;
-            const splatRender = resource.splat;
-
-            if (splatData && splatRender) {
-                // added splat state channel
-                // bit 1: selected
-                // bit 2: deleted
-                // bit 3: hidden
-                splatData.addProp('state', new Uint8Array(splatData.numSplats));
-
-                // store splat info
-                splatDefs.push({
-                    element: splatElement,
-                    data: splatData,
-                    render: splatRender,
-                    instance: splatElement.root.gsplat.instance,
-                    debug: new SplatDebug(scene, splatElement, splatData)
-                });
-            }
-        }
-    });
-
-    let selectedSplats = 0;
+    // get the list of selected splats (currently limited to just a single one)
+    const selectedSplats = () => {
+        const selected = events.invoke('selection') as Splat;
+        return [selected];
+    };
 
     const debugSphereCenter = new Vec3();
     let debugSphereRadius = 0;
@@ -77,68 +40,28 @@ const registerEditorEvents = (events: Events, editHistory: EditHistory, scene: S
     events.on('prerender', () => {
         const app = scene.app;
 
-        splatDefs.forEach((splatDef) => {
-            const debug = splatDef.debug;
-
-            if (events.invoke('camera.mode') === 'centers' && debug.splatSize > 0) {
-                app.drawMeshInstance(debug.meshInstance);
-            }
-
-            if (debugSphereRadius > 0) {
-                app.drawWireSphere(debugSphereCenter, debugSphereRadius, Color.RED, 40);
-            }
-
-            if (debugPlane.length() > 0) {
-                vec.copy(debugPlane).mulScalar(debugPlaneDistance);
-                vec2.add2(vec, debugPlane);
-
-                mat.setLookAt(vec, vec2, Math.abs(Vec3.UP.dot(debugPlane)) > 0.99 ? Vec3.FORWARD : Vec3.UP);
-
-                const lines = [
-                    new Vec3(-1,-1, 0), new Vec3( 1,-1, 0),
-                    new Vec3( 1,-1, 0), new Vec3( 1, 1, 0),
-                    new Vec3( 1, 1, 0), new Vec3(-1, 1, 0),
-                    new Vec3(-1, 1, 0), new Vec3(-1,-1, 0),
-                    new Vec3( 0, 0, 0), new Vec3( 0, 0,-1)
-                ];
-                for (let i = 0; i < lines.length; ++i) {
-                    mat.transformPoint(lines[i], lines[i]);
-                }
-
-                app.drawLines(lines, Color.RED);
-            }
-        });
-    });
-
-    // update the splat state data
-    const updateState = (updateBound = false) => {
-        selectedSplats = 0;
-        splatDefs.forEach((splatDef) => {
-            selectedSplats += splatDef.debug.update();
-
-            const state = splatDef.data.getProp('state') as Uint8Array;
-            splatDef.element.updateState(state);
-            if (updateBound) {
-                splatDef.element.recalcBound();
-            }
-        });
-
-        events.fire('splat.count', selectedSplats);
-
-        if (updateBound) {
-            scene.updateBound();
-
-            // fire new scene bound
-            events.fire('scene.boundChanged');
+        if (debugSphereRadius > 0) {
+            app.drawWireSphere(debugSphereCenter, debugSphereRadius, Color.RED, 40);
         }
 
-        scene.forceRender = true;
-    };
+        if (debugPlane.length() > 0) {
+            vec.copy(debugPlane).mulScalar(debugPlaneDistance);
+            vec2.add2(vec, debugPlane);
 
-    // handle a splat edit event
-    events.on('edit.apply', (editOp: EditOp) => {
-        if (editOp instanceof DeleteSelectionEditOp || editOp instanceof ResetEditOp) {
-            updateState(true);
+            mat.setLookAt(vec, vec2, Math.abs(Vec3.UP.dot(debugPlane)) > 0.99 ? Vec3.FORWARD : Vec3.UP);
+
+            const lines = [
+                new Vec3(-1,-1, 0), new Vec3( 1,-1, 0),
+                new Vec3( 1,-1, 0), new Vec3( 1, 1, 0),
+                new Vec3( 1, 1, 0), new Vec3(-1, 1, 0),
+                new Vec3(-1, 1, 0), new Vec3(-1,-1, 0),
+                new Vec3( 0, 0, 0), new Vec3( 0, 0,-1)
+            ];
+            for (let i = 0; i < lines.length; ++i) {
+                mat.transformPoint(lines[i], lines[i]);
+            }
+
+            app.drawLines(lines, Color.RED);
         }
     });
 
@@ -186,15 +109,10 @@ const registerEditorEvents = (events: Events, editHistory: EditHistory, scene: S
     });
 
     events.on('camera.mode', (mode: string) => {
-        scene.graphicsDevice.scope.resolve('ringSize').setValue(mode === 'rings' && events.invoke('splatSize') ? 0.04 : 0);
         scene.forceRender = true;
     });
 
     events.on('splatSize', (value: number) => {
-        splatDefs.forEach((splatDef) => {
-            splatDef.debug.splatSize = value;
-        });
-        scene.graphicsDevice.scope.resolve('ringSize').setValue(events.invoke('camera.mode') === 'rings' && value ? 0.04 : 0);
         scene.forceRender = true;
     });
 
@@ -215,16 +133,22 @@ const registerEditorEvents = (events: Events, editHistory: EditHistory, scene: S
     });
 
     events.on('camera.focus', () => {
-        const splatDef = splatDefs[0];
-        if (splatDef) {
-            const splatData = splatDef.data;
+        const splat = selectedSplats()[0];
+        if (splat) {
+            const splatData = splat.splatData;
             const state = splatData.getProp('state') as Uint8Array;
             const deletedPred = (i: number) => (state[i] & (State.hidden | State.deleted)) === 0;
             const selectionPred = (i: number) => (state[i] & State.selected) === State.selected;
-            splatData.calcAabb(aabb, selectedSplats ? selectionPred : deletedPred);
-            splatData.calcFocalPoint(vec, selectedSplats ? selectionPred : deletedPred);
 
-            const worldTransform = splatDef.element.worldTransform;
+            if (splatData.calcAabb(aabb, selectionPred)) {
+                splatData.calcFocalPoint(vec, selectionPred);
+            } else if (splatData.calcAabb(aabb, deletedPred)) {
+                splatData.calcFocalPoint(vec, deletedPred);
+            } else {
+                return;
+            }
+
+            const worldTransform = splat.worldTransform;
             worldTransform.transformPoint(vec, vec);
             worldTransform.getScale(vec2);
 
@@ -236,35 +160,35 @@ const registerEditorEvents = (events: Events, editHistory: EditHistory, scene: S
     });
 
     events.on('select.all', () => {
-        splatDefs.forEach((splatDef) => {
-            const splatData = splatDef.data;
+        selectedSplats().forEach((splat) => {
+            const splatData = splat.splatData;
             const state = splatData.getProp('state') as Uint8Array;
             processSelection(state, 'set', (i) => true);
+            splat.updateState();
         });
-        updateState();
     });
 
     events.on('select.none', () => {
-        splatDefs.forEach((splatDef) => {
-            const splatData = splatDef.data;
+        selectedSplats().forEach((splat) => {
+            const splatData = splat.splatData;
             const state = splatData.getProp('state') as Uint8Array;
             processSelection(state, 'set', (i) => false);
+            splat.updateState();
         });
-        updateState();
     });
 
     events.on('select.invert', () => {
-        splatDefs.forEach((splatDef) => {
-            const splatData = splatDef.data;
+        selectedSplats().forEach((splat) => {
+            const splatData = splat.splatData;
             const state = splatData.getProp('state') as Uint8Array;
             processSelection(state, 'set', (i) => !(state[i] & State.selected));
+            splat.updateState();
         });
-        updateState();
     });
 
     events.on('select.bySize', (op: string, value: number) => {
-        splatDefs.forEach((splatDef) => {
-            const splatData = splatDef.data;
+        selectedSplats().forEach((splat) => {
+            const splatData = splat.splatData;
             const state = splatData.getProp('state') as Uint8Array;
             const scale_0 = splatData.getProp('scale_0');
             const scale_1 = splatData.getProp('scale_1');
@@ -289,13 +213,14 @@ const registerEditorEvents = (events: Events, editHistory: EditHistory, scene: S
             const maxScale = Math.log(Math.exp(scaleMin) + value * (Math.exp(scaleMax) - Math.exp(scaleMin)));
 
             processSelection(state, op, (i) => scale_0[i] > maxScale || scale_1[i] > maxScale || scale_2[i] > maxScale);
+
+            splat.updateState();
         });
-        updateState();
     });
 
     events.on('select.byOpacity', (op: string, value: number) => {
-        splatDefs.forEach((splatDef) => {
-            const splatData = splatDef.data;
+        selectedSplats().forEach((splat) => {
+            const splatData = splat.splatData;
             const state = splatData.getProp('state') as Uint8Array;
             const opacity = splatData.getProp('opacity') as Float32Array;
 
@@ -303,8 +228,9 @@ const registerEditorEvents = (events: Events, editHistory: EditHistory, scene: S
                 const t = Math.exp(opacity[i]);
                 return ((1 / (1 + t)) < value);
             });
+
+            splat.updateState();
         });
-        updateState();
     });
 
     events.on('select.bySpherePlacement', (sphere: number[]) => {
@@ -322,8 +248,8 @@ const registerEditorEvents = (events: Events, editHistory: EditHistory, scene: S
     });
 
     events.on('select.bySphere', (op: string, sphere: number[]) => {
-        splatDefs.forEach((splatDef) => {
-            const splatData = splatDef.data;
+        selectedSplats().forEach((splat) => {
+            const splatData = splat.splatData;
             const state = splatData.getProp('state') as Uint8Array;
             const x = splatData.getProp('x');
             const y = splatData.getProp('y');
@@ -332,20 +258,21 @@ const registerEditorEvents = (events: Events, editHistory: EditHistory, scene: S
             const radius2 = sphere[3] * sphere[3];
             vec.set(sphere[0], sphere[1], sphere[2]);
 
-            mat.invert(splatDef.element.worldTransform);
+            mat.invert(splat.worldTransform);
             mat.transformPoint(vec, vec);
 
             processSelection(state, op, (i) => {
                 vec2.set(x[i], y[i], z[i]);
                 return vec2.sub(vec).lengthSq() < radius2;
             });
+
+            splat.updateState();
         });
-        updateState();
     });
 
     events.on('select.byPlane', (op: string, axis: number[], distance: number) => {
-        splatDefs.forEach((splatDef) => {
-            const splatData = splatDef.data;
+        selectedSplats().forEach((splat) => {
+            const splatData = splat.splatData;
             const state = splatData.getProp('state') as Uint8Array;
             const x = splatData.getProp('x');
             const y = splatData.getProp('y');
@@ -355,7 +282,7 @@ const registerEditorEvents = (events: Events, editHistory: EditHistory, scene: S
             vec2.set(axis[0] * distance, axis[1] * distance, axis[2] * distance);
 
             // transform the plane to local space
-            mat.invert(splatDef.element.worldTransform);
+            mat.invert(splat.worldTransform);
             mat.transformVector(vec, vec);
             mat.transformPoint(vec2, vec2);
 
@@ -365,14 +292,16 @@ const registerEditorEvents = (events: Events, editHistory: EditHistory, scene: S
                 vec2.set(x[i], y[i], z[i]);
                 return vec.dot(vec2) - localDistance > 0;
             });
+
+            splat.updateState();
         });
-        updateState();
     });
 
     events.on('select.rect', (op: string, rect: any) => {
         const mode = events.invoke('camera.mode');
-        splatDefs.forEach((splatDef) => {
-            const splatData = splatDef.data;
+
+        selectedSplats().forEach((splat) => {
+            const splatData = splat.splatData;
             const state = splatData.getProp('state') as Uint8Array;
 
             if (mode === 'centers') {
@@ -384,7 +313,7 @@ const registerEditorEvents = (events: Events, editHistory: EditHistory, scene: S
                 const camera = scene.camera.entity.camera;
 
                 // calculate final matrix
-                mat.mul2(camera.camera._viewProjMat, splatDef.element.worldTransform);
+                mat.mul2(camera.camera._viewProjMat, splat.worldTransform);
                 const sx = rect.start.x * 2 - 1;
                 const sy = rect.start.y * 2 - 1;
                 const ex = rect.end.x * 2 - 1;
@@ -403,7 +332,7 @@ const registerEditorEvents = (events: Events, editHistory: EditHistory, scene: S
             } else if (mode === 'rings') {
                 const { width, height } = scene.targetSize;
 
-                scene.camera.pickPrep();
+                scene.camera.pickPrep(splat);
                 const pick = scene.camera.pickRect(
                     Math.floor(rect.start.x * width),
                     Math.floor(rect.start.y * height),
@@ -415,14 +344,16 @@ const registerEditorEvents = (events: Events, editHistory: EditHistory, scene: S
                     return selected.has(i);
                 });
             }
+
+            splat.updateState();
         });
-        updateState();
     });
 
     events.on('select.byMask', (op: string, mask: ImageData) => {
         const mode = events.invoke('camera.mode');
-        splatDefs.forEach((splatDef) => {
-            const splatData = splatDef.data;
+
+        selectedSplats().forEach((splat) => {
+            const splatData = splat.splatData;
             const state = splatData.getProp('state') as Uint8Array;
 
             if (mode === 'centers') {
@@ -434,7 +365,7 @@ const registerEditorEvents = (events: Events, editHistory: EditHistory, scene: S
                 const camera = scene.camera.entity.camera;
 
                 // calculate final matrix
-                mat.mul2(camera.camera._viewProjMat, splatDef.element.worldTransform);
+                mat.mul2(camera.camera._viewProjMat, splat.worldTransform);
 
                 processSelection(state, op, (i) => {
                     vec4.set(x[i], y[i], z[i], 1.0);
@@ -454,7 +385,7 @@ const registerEditorEvents = (events: Events, editHistory: EditHistory, scene: S
             } else if (mode === 'rings') {
                 const { width, height } = scene.targetSize;
 
-                scene.camera.pickPrep();
+                scene.camera.pickPrep(splat);
                 const pick = scene.camera.pickRect(0, 0, width, height);
 
                 const selected = new Set<number>();
@@ -480,20 +411,17 @@ const registerEditorEvents = (events: Events, editHistory: EditHistory, scene: S
                     return selected.has(i);
                 });
             }
+
+            splat.updateState();
         });
-        updateState();
     });
 
     events.on('select.point', (op: string, point: { x: number, y: number }) => {
         const { width, height } = scene.targetSize;
-
         const mode = events.invoke('camera.mode');
-        if (mode === 'rings') {
-            scene.camera.pickPrep();
-        }
 
-        splatDefs.forEach((splatDef) => {
-            const splatData = splatDef.data;
+        selectedSplats().forEach((splat) => {
+            const splatData = splat.splatData;
             const state = splatData.getProp('state') as Uint8Array;
 
             if (mode === 'centers') {
@@ -507,7 +435,7 @@ const registerEditorEvents = (events: Events, editHistory: EditHistory, scene: S
                 const sy = point.y * height;
 
                 // calculate final matrix
-                mat.mul2(camera.camera._viewProjMat, splatDef.element.worldTransform);
+                mat.mul2(camera.camera._viewProjMat, splat.worldTransform);
 
                 processSelection(state, op, (i) => {
                     vec4.set(x[i], y[i], z[i], 1.0);
@@ -517,6 +445,8 @@ const registerEditorEvents = (events: Events, editHistory: EditHistory, scene: S
                     return Math.abs(px - sx) < splatSize && Math.abs(py - sy) < splatSize;
                 });
             } else if (mode === 'rings') {
+                scene.camera.pickPrep(splat);
+
                 const pickId = scene.camera.pickRect(
                     Math.floor(point.x * width),
                     Math.floor(point.y * height),
@@ -526,73 +456,54 @@ const registerEditorEvents = (events: Events, editHistory: EditHistory, scene: S
                     return i === pickId;
                 });
             }
-        });
-        updateState();
 
+            splat.updateState();
+        });
     });
 
     events.on('select.hide', () => {
-        splatDefs.forEach((splatDef) => {
-            const splatData = splatDef.data;
+        selectedSplats().forEach((splat) => {
+            const splatData = splat.splatData;
             const state = splatData.getProp('state') as Uint8Array;
+
             for (let i = 0; i < state.length; ++i) {
                 if (state[i] & State.selected) {
                     state[i] &= ~State.selected;
                     state[i] |= State.hidden;
                 }
             }
+
+            splat.updateState();
         });
-        updateState();
     });
 
     events.on('select.unhide', () => {
-        splatDefs.forEach((splatDef) => {
-            const splatData = splatDef.data;
+        selectedSplats().forEach((splat) => {
+            const splatData = splat.splatData;
             const state = splatData.getProp('state') as Uint8Array;
+
             for (let i = 0; i < state.length; ++i) {
                 state[i] &= ~State.hidden;
             }
+
+            splat.updateState();
         });
-        updateState();
     });
 
     events.on('select.delete', () => {
-        splatDefs.forEach((splatDef) => {
-            const splatData = splatDef.data;
-            editHistory.add(new DeleteSelectionEditOp(splatData));
+        selectedSplats().forEach((splat) => {
+            editHistory.add(new DeleteSelectionEditOp(splat));
         });
     });
 
     events.on('scene.reset', () => {
-        splatDefs.forEach((splatDef) => {
-            const splatData = splatDef.data;
-            editHistory.add(new ResetEditOp(splatData));
+        selectedSplats().forEach((splat) => {
+            editHistory.add(new ResetEditOp(splat));
         });
     });
 
     events.on('allData', (value: boolean) => {
         scene.assetLoader.loadAllData = value;
-    });
-
-    events.function('splat.getWorldPosition', (id: number) => {
-        const result = new Vec3();
-        splatDefs.forEach((splatDef) => {
-            const splatData = splatDef.data;
-            if (id >= splatData.numSplats) {
-                return;
-            }
-
-            // get splat position
-            result.set(
-                splatData.getProp('x')[id],
-                splatData.getProp('y')[id],
-                splatData.getProp('z')[id]
-            );
-
-            // transform world space
-            splatDef.element.worldTransform.transformPoint(result, result);
-        });
-        return result;
     });
 }
 

--- a/src/element.ts
+++ b/src/element.ts
@@ -1,6 +1,6 @@
-import {BoundingBox} from 'playcanvas';
-import {Serializer} from './serializer';
-import {Scene} from './scene';
+import { BoundingBox, Quat, Vec3 } from 'playcanvas';
+import { Serializer } from './serializer';
+import { Scene } from './scene';
 
 enum ElementType {
     camera = 'camera',
@@ -20,12 +20,16 @@ const ElementTypeList = [
     ElementType.other
 ];
 
+let nextUid = 1;
+
 class Element {
     type: ElementType;
     scene: Scene = null;
+    uid: number;
 
     constructor(type: ElementType) {
         this.type = type;
+        this.uid = nextUid++;
     }
 
     destroy() {
@@ -37,10 +41,6 @@ class Element {
     add() {}
 
     remove() {}
-
-    calcBound(result: BoundingBox): boolean {
-        return false;
-    }
 
     serialize(serializer: Serializer) {}
 
@@ -55,6 +55,12 @@ class Element {
     onAdded(element: Element) {}
 
     onRemoved(element: Element) {}
+
+    move(position?: Vec3, rotation?: Quat, scale?: Vec3) {}
+
+    get worldBound(): BoundingBox | null {
+        return null;
+    }
 }
 
 export {ElementType, ElementTypeList, Element};

--- a/src/events.ts
+++ b/src/events.ts
@@ -24,15 +24,6 @@ class Events extends EventHandler {
         }
         return fn(...args);
     }
-
-    // fire an event or invoke a function
-    fire(name: string, ...args: any[]) {
-        const fn = this.functions.get(name);
-        if (!fn) {
-            return super.fire(name, ...args);
-        }
-        return fn(...args);
-    }
 }
 
 export { Events };

--- a/src/events.ts
+++ b/src/events.ts
@@ -18,12 +18,20 @@ class Events extends EventHandler {
     // invoke an editor function
     invoke(name: string, ...args: any[]) {
         const fn = this.functions.get(name);
-        try {
-            return fn(...args);
-        } catch (error) {
-            console.log(`error invoking editor function '${name}': ${error}`);
+        if (!fn) {
+            console.log(`error: function not found '${name}'`);
+            return;
         }
-        return null;
+        return fn(...args);
+    }
+
+    // fire an event or invoke a function
+    fire(name: string, ...args: any[]) {
+        const fn = this.functions.get(name);
+        if (!fn) {
+            return super.fire(name, ...args);
+        }
+        return fn(...args);
     }
 }
 

--- a/src/file-handler.ts
+++ b/src/file-handler.ts
@@ -2,7 +2,7 @@ import { path } from 'playcanvas';
 import { Scene } from './scene';
 import { Events } from './events';
 import { CreateDropHandler } from './drop-handler';
-import { convertPly, convertPlyCompressed, convertSplat } from './splat-convert';
+import { convertPly, convertPlyCompressed } from './splat-convert';
 import { startSpinner, stopSpinner } from './ui/spinner';
 import { ElementType } from './element';
 import { Splat } from './splat';
@@ -12,7 +12,7 @@ interface RemoteStorageDetails {
     url: string;
 };
 
-type ExportType = 'ply' | 'compressed-ply' | 'splat';
+type ExportType = 'ply' | 'compressed-ply';
 
 interface SceneWriteOptions {
     type: ExportType;
@@ -31,12 +31,6 @@ const filePickerTypes = {
         description: 'Compressed Gaussian Splat PLY File',
         accept: {
             'application/ply': ['.ply']
-        }
-    }],
-    'splat': [{
-        description: 'Gaussian Splat File',
-        accept: {
-            'application/octet-stream': ['.splat']
         }
     }]
 };
@@ -204,8 +198,7 @@ const initFileHandler = async (scene: Scene, events: Events, canvas: HTMLCanvasE
     events.function('scene.export', async (type: ExportType, outputFilename: string = null) => {
         const extensions = {
             'ply': '.ply',
-            'compressed-ply': '.compressed.ply',
-            'splat': '.splat'
+            'compressed-ply': '.compressed.ply'
         };
 
         const replaceExtension = (filename: string, extension: string) => {
@@ -264,8 +257,6 @@ const initFileHandler = async (scene: Scene, events: Events, canvas: HTMLCanvasE
                 return convertPly(convertData);
             case 'compressed-ply':
                 return convertPlyCompressed(convertData);
-            case 'splat':
-                return convertSplat(convertData);
         }
     };
 

--- a/src/file-handler.ts
+++ b/src/file-handler.ts
@@ -109,11 +109,13 @@ const initFileHandler = async (scene: Scene, events: Events, canvas: HTMLCanvasE
     }
 
     // create the file drag & drop handler
-    CreateDropHandler(canvas, urls => {
+    CreateDropHandler(canvas, async (entries) => {
         const modelExtensions = ['.ply'];
-        const model = urls.find(url => modelExtensions.some(extension => url.filename.endsWith(extension)));
-        if (model) {
-            scene.loadModel(model.url, model.filename);
+        for (let i = 0; i < entries.length; i++) {
+            const entry = entries[i];
+            if (modelExtensions.some(extension => entry.filename.endsWith(extension))) {
+                await scene.loadModel(entry.url, entry.filename);
+            }
         }
     });
 
@@ -128,7 +130,7 @@ const initFileHandler = async (scene: Scene, events: Events, canvas: HTMLCanvasE
     });
 
     events.on('scene.new', () => {
-        // TODO
+        scene.clear();
     });
 
     events.on('scene.open', async () => {

--- a/src/file-handler.ts
+++ b/src/file-handler.ts
@@ -2,7 +2,7 @@ import { path } from 'playcanvas';
 import { Scene } from './scene';
 import { Events } from './events';
 import { CreateDropHandler } from './drop-handler';
-import { convertPly, convertPlyCompressed } from './splat-convert';
+import { convertPly, convertPlyCompressed, convertSplat } from './splat-convert';
 import { startSpinner, stopSpinner } from './ui/spinner';
 import { ElementType } from './element';
 import { Splat } from './splat';
@@ -12,7 +12,7 @@ interface RemoteStorageDetails {
     url: string;
 };
 
-type ExportType = 'ply' | 'compressed-ply';
+type ExportType = 'ply' | 'compressed-ply' | 'splat';
 
 interface SceneWriteOptions {
     type: ExportType;
@@ -32,6 +32,12 @@ const filePickerTypes = {
         accept: {
             'application/ply': ['.ply']
         }
+    }],
+    'splat': [{
+            description: 'Gaussian Splat File',
+            accept: {
+                'application/octet-stream': ['.splat']
+            }
     }]
 };
 
@@ -198,7 +204,8 @@ const initFileHandler = async (scene: Scene, events: Events, canvas: HTMLCanvasE
     events.function('scene.export', async (type: ExportType, outputFilename: string = null) => {
         const extensions = {
             'ply': '.ply',
-            'compressed-ply': '.compressed.ply'
+            'compressed-ply': '.compressed.ply',
+            'splat': '.splat'
         };
 
         const replaceExtension = (filename: string, extension: string) => {
@@ -257,6 +264,8 @@ const initFileHandler = async (scene: Scene, events: Events, canvas: HTMLCanvasE
                 return convertPly(convertData);
             case 'compressed-ply':
                 return convertPlyCompressed(convertData);
+            case 'splat':
+                return convertSplat(convertData);
         }
     };
 

--- a/src/file-handler.ts
+++ b/src/file-handler.ts
@@ -1,0 +1,288 @@
+import { path } from 'playcanvas';
+import { Scene } from './scene';
+import { Events } from './events';
+import { CreateDropHandler } from './drop-handler';
+import { convertPly, convertPlyCompressed, convertSplat } from './splat-convert';
+import { startSpinner, stopSpinner } from './ui/spinner';
+import { ElementType } from './element';
+import { Splat } from './splat';
+
+interface RemoteStorageDetails {
+    method: string;
+    url: string;
+};
+
+type ExportType = 'ply' | 'compressed-ply' | 'splat';
+
+interface SceneWriteOptions {
+    type: ExportType;
+    filename?: string;
+    stream?: FileSystemWritableFileStream;
+};
+
+const filePickerTypes = {
+    'ply': [{
+        description: 'Gaussian Splat PLY File',
+        accept: {
+            'application/ply': ['.ply']
+        }
+    }],
+    'compressed-ply': [{
+        description: 'Compressed Gaussian Splat PLY File',
+        accept: {
+            'application/ply': ['.ply']
+        }
+    }],
+    'splat': [{
+        description: 'Gaussian Splat File',
+        accept: {
+            'application/octet-stream': ['.splat']
+        }
+    }]
+};
+
+let fileHandle: FileSystemFileHandle = null;
+
+// download the data to the given filename
+const download = (filename: string, data: ArrayBuffer) => {
+    const blob = new Blob([data], { type: "octet/stream" });
+    const url = window.URL.createObjectURL(blob);
+
+    const lnk = document.createElement('a');
+    lnk.download = filename;
+    lnk.href = url;
+
+    // create a "fake" click-event to trigger the download
+    if (document.createEvent) {
+        const e = document.createEvent("MouseEvents");
+        e.initMouseEvent("click", true, true, window,
+                         0, 0, 0, 0, 0, false, false, false,
+                         false, 0, null);
+        lnk.dispatchEvent(e);
+    } else {
+        // @ts-ignore
+        lnk.fireEvent?.("onclick");
+    }
+
+    window.URL.revokeObjectURL(url);
+};
+
+// send the file to the remote storage
+const sendToRemoteStorage = async (filename: string, data: ArrayBuffer, remoteStorageDetails: RemoteStorageDetails) => {
+    const formData = new FormData();
+    formData.append('file', new Blob([data], { type: "octet/stream" }), filename);
+    formData.append('preserveThumbnail', 'true');
+    await fetch(remoteStorageDetails.url, {
+        method: remoteStorageDetails.method,
+        body: formData
+    });
+};
+
+// write the data to file
+const writeToFile = async (stream: FileSystemWritableFileStream, data: ArrayBuffer) => {
+    await stream.seek(0);
+    await stream.write(data);
+    await stream.truncate(data.byteLength);
+    await stream.close();
+};
+
+// initialize file handler events
+const initFileHandler = async (scene: Scene, events: Events, canvas: HTMLCanvasElement, remoteStorageDetails: RemoteStorageDetails) => {
+
+    // create a file selector element as fallback when showOpenFilePicker isn't available
+    let fileSelector: HTMLInputElement;
+    if (!window.showOpenFilePicker) {
+        fileSelector = document.createElement('input');
+        fileSelector.setAttribute('id', 'file-selector');
+        fileSelector.setAttribute('type', 'file');
+        fileSelector.setAttribute('accept', '.ply');
+        fileSelector.onchange = async () => {
+            const files = fileSelector.files;
+            if (files.length > 0) {
+                const file = fileSelector.files[0];
+                const url = URL.createObjectURL(file);
+                await scene.loadModel(url, file.name);
+                URL.revokeObjectURL(url);
+            }
+        };
+        document.body.append(fileSelector);
+    }
+
+    // create the file drag & drop handler
+    CreateDropHandler(canvas, urls => {
+        const modelExtensions = ['.ply'];
+        const model = urls.find(url => modelExtensions.some(extension => url.filename.endsWith(extension)));
+        if (model) {
+            scene.loadModel(model.url, model.filename);
+        }
+    });
+
+    // get the active splat
+    const getSplat = () => {
+        const splats = scene.getElementsByType(ElementType.splat) as Splat[];
+        return splats.length > 0 ? splats[0] : null;
+    };
+
+    events.function('scene.canSave', () => {
+        return getSplat() !== null;
+    });
+
+    events.on('scene.new', () => {
+        // TODO
+    });
+
+    events.on('scene.open', async () => {
+        if (fileSelector) {
+            fileSelector.click();
+        } else {
+            try {
+                const handle = (await window.showOpenFilePicker({
+                    id: 'SuperSplatFileOpen',
+                    types: filePickerTypes.ply as FilePickerAcceptType[]
+                }))[0];
+                const file = await handle.getFile();
+                const url = URL.createObjectURL(file);
+                await scene.loadModel(url, file.name);
+                URL.revokeObjectURL(url);
+
+                fileHandle = handle;
+            } catch (error) {
+                if (error.name !== 'AbortError') {
+                    console.error(error);
+                }
+            }
+        }
+    });
+
+    events.on('scene.save', async () => {
+        if (fileHandle) {
+            try {
+                await events.invoke('scene.write', {
+                    type: 'ply',
+                    stream: await fileHandle.createWritable()
+                });
+                events.fire('scene.saved');
+            } catch (error) {
+                if (error.name !== 'AbortError') {
+                    console.error(error);
+                }
+            }
+        } else {
+            events.fire('scene.saveAs');
+        }
+    });
+
+    events.on('scene.saveAs', async () => {
+        const splat = getSplat();
+        if (window.showSaveFilePicker) {
+            try {
+                const handle = await window.showSaveFilePicker({
+                    id: 'SuperSplatFileSave',
+                    types: filePickerTypes.ply as FilePickerAcceptType[],
+                    suggestedName: fileHandle?.name ?? splat.filename ?? 'scene.ply'
+                });
+                await events.invoke('scene.write', {
+                    type: 'ply',
+                    stream: await handle.createWritable()
+                });
+                fileHandle = handle;
+                events.fire('scene.saved');
+            } catch (error) {
+                if (error.name !== 'AbortError') {
+                    console.error(error);
+                }
+            }
+        } else {
+            await events.invoke('scene.export', 'ply', splat.filename);
+            events.fire('scene.saved');
+        }
+    });
+
+    events.function('scene.export', async (type: ExportType, outputFilename: string = null) => {
+        const extensions = {
+            'ply': '.ply',
+            'compressed-ply': '.compressed.ply',
+            'splat': '.splat'
+        };
+
+        const replaceExtension = (filename: string, extension: string) => {
+            const removeExtension = (filename: string) => {
+                return filename.substring(0, filename.length - path.getExtension(filename).length);
+            };
+            return `${removeExtension(filename)}${extension}`;
+        }
+
+        const splat = getSplat();
+        const filename = outputFilename ?? replaceExtension(splat.filename, extensions[type]);
+
+        if (window.showSaveFilePicker) {
+            try {
+                const fileHandle = await window.showSaveFilePicker({
+                    id: 'SuperSplatFileExport',
+                    types: filePickerTypes[type] as FilePickerAcceptType[],
+                    suggestedName: filename
+                });
+                await events.invoke('scene.write', {
+                    type: type,
+                    stream: await fileHandle.createWritable()
+                });
+            } catch (error) {
+                if (error.name !== 'AbortError') {
+                    console.error(error);
+                }
+            }
+        } else {
+            const result = await events.invoke('showPopup', {
+                type: 'okcancel',
+                message: 'Enter filename:',
+                value: filename
+            });
+
+            if (result.action === 'ok') {
+                await events.invoke('scene.write', {
+                    type: type,
+                    filename: result.value
+                });
+            }
+        }
+    });
+
+    const convertData = (splat: Splat, type: ExportType) => {
+        switch (type) {
+            case 'ply':
+                return convertPly(splat.splatData, splat.root.getWorldTransform());
+            case 'compressed-ply':
+                return convertPlyCompressed(splat.splatData, splat.root.getWorldTransform());
+            case 'splat':
+                return convertSplat(splat.splatData, splat.root.getWorldTransform());
+        }
+    };
+
+    events.function('scene.write', async (options: SceneWriteOptions) => {
+        const splat = getSplat();
+
+        startSpinner();
+
+        // setTimeout so spinner has a chance to activate
+        await new Promise<void>((resolve) => {
+            setTimeout(resolve);
+        });
+
+        const data = convertData(splat, options.type);
+
+        if (options.stream) {
+            // write to stream
+            await writeToFile(options.stream, data);
+        } else if (remoteStorageDetails) {
+            // write data to remote storage
+            await sendToRemoteStorage(options.filename, data, remoteStorageDetails);
+        } else if (options.filename) {
+            // download file to local machine
+            download(options.filename, data);
+        }
+
+        stopSpinner();
+    });
+};
+
+export { initFileHandler };

--- a/src/main.ts
+++ b/src/main.ts
@@ -61,6 +61,7 @@ const initShortcuts = (events: Events) => {
 
     shortcuts.register(['Delete', 'Backspace'], { event: 'select.delete' });
     shortcuts.register(['Escape'], { event: 'tool.deactivate' });
+    shortcuts.register(['Tab'], { event: 'selection.next' });
     shortcuts.register(['1'], { event: 'tool.move' });
     shortcuts.register(['2'], { event: 'tool.rotate' });
     shortcuts.register(['3'], { event: 'tool.scale' });

--- a/src/main.ts
+++ b/src/main.ts
@@ -26,8 +26,6 @@ declare global {
             setConsumer: (callback: (launchParams: LaunchParams) => void) => void;
         };
         scene: Scene;
-        showOpenFilePicker: (options: { id: string, types: { description: string, accept: { 'model/ply': string[] } }[] }) => Promise<FileSystemFileHandle[]>;
-        showSaveFilePicker: (options: { id: string, types: { description: string, accept: { 'model/ply': string[] } }[] }, suggestedName: string) => Promise<FileSystemFileHandle>;
     }
 }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -6,6 +6,7 @@ import { EditHistory } from './edit-history';
 import { EditorUI } from './ui/editor';
 import { registerEditorEvents } from './editor';
 import { initFileHandler } from './file-handler';
+import { initSelection } from './selection';
 import { ToolManager } from './tools/tool-manager';
 import { MoveTool } from './tools/move-tool';
 import { RotateTool } from './tools/rotate-tool';
@@ -158,6 +159,7 @@ const main = async () => {
     window.scene = scene;
 
     registerEditorEvents(events, editHistory, scene, editorUI);
+    initSelection(events, scene);
     initShortcuts(events);
     await initFileHandler(scene, events, editorUI.canvas, remoteStorageDetails);
 

--- a/src/scene.ts
+++ b/src/scene.ts
@@ -21,8 +21,6 @@ import { Camera } from './camera';
 import { CustomShadow as Shadow } from './custom-shadow';
 import { Grid } from './grid';
 
-const bound = new BoundingBox();
-
 class Scene {
     events: Events;
     config: SceneConfig;
@@ -34,7 +32,8 @@ class Scene {
     gizmoLayer: Layer;
     sceneState = [new SceneState(), new SceneState()];
     elements: Element[] = [];
-    bound = new BoundingBox();
+    boundStorage = new BoundingBox();
+    boundDirty = true;
     forceRender = false;
 
     canvasResize: {width: number; height: number} | null = null;
@@ -208,7 +207,6 @@ class Scene {
         // add them to the scene
         elements.forEach(e => this.add(e));
 
-        this.updateBound();
         this.camera.focus();
 
         // start the app
@@ -219,7 +217,6 @@ class Scene {
         try {
             const model = await this.assetLoader.loadModel({ url, filename });
             this.add(model);
-            this.updateBound();
             this.camera.focus();
             this.events.fire('loaded', filename);
         } catch (err) {
@@ -260,31 +257,41 @@ class Scene {
     // remove an element from the scene
     remove(element: Element) {
         if (element.scene === this) {
+            // remove from list
+            this.elements.splice(this.elements.indexOf(element), 1);
+
             // notify listeners
             this.events.fire('scene.elementRemoved', element);
 
             // notify all elements of scene removal
-            this.forEachElement(e => e !== element && e.onRemoved(element));
+            this.forEachElement(e => e.onRemoved(element));
 
             element.remove();
             element.scene = null;
-            this.elements.splice(this.elements.indexOf(element), 1);
         }
     }
 
-    // get scene bounds
-    updateBound() {
-        let valid = false;
-        this.forEachElement(e => {
-            if (e.calcBound(bound)) {
-                if (!valid) {
-                    valid = true;
-                    this.bound.copy(bound);
-                } else {
-                    this.bound.add(bound);
+    // get the scene bound
+    get bound() {
+        if (this.boundDirty) {
+            let valid = false;
+            this.forEachElement(e => {
+                const bound = e.worldBound;
+                if (bound) {
+                    if (!valid) {
+                        valid = true;
+                        this.boundStorage.copy(bound);
+                    } else {
+                        this.boundStorage.add(bound);
+                    }
                 }
-            }
-        });
+            });
+
+            this.boundDirty = false;
+            this.events.fire('scene.boundChanged');
+        }
+
+        return this.boundStorage;
     }
 
     getElementsByType(elementType: ElementType) {
@@ -321,12 +328,6 @@ class Scene {
             this.app.renderNextFrame = this.forceRender || all.size > 0;
         }
         this.forceRender = false;
-
-        // update scene bound if models were updated
-        if (all.has(ElementType.model)) {
-            this.updateBound();
-            this.events.fire('scene.boundUpdated');
-        }
 
         // raise per-type update events
         ElementTypeList.forEach(type => {

--- a/src/scene.ts
+++ b/src/scene.ts
@@ -216,9 +216,6 @@ class Scene {
     }
 
     async loadModel(url: string, filename: string) {
-        // clear error
-        this.events.fire('error', null);
-
         try {
             const model = await this.assetLoader.loadModel({ url, filename });
             this.add(model);

--- a/src/scene.ts
+++ b/src/scene.ts
@@ -357,9 +357,6 @@ class Scene {
 
         // debug - display scene bound
         if (this.config.debug.showBound) {
-            // draw scene bound
-            this.app.drawWireAlignedBox(this.bound.getMin(), this.bound.getMax(), Color.GREEN);
-
             // draw element bounds
             this.forEachElement((e: Element) => {
                 if (e.type === ElementType.splat) {
@@ -369,7 +366,7 @@ class Scene {
                     this.app.drawWireAlignedBox(
                         local.getMin(),
                         local.getMax(),
-                        Color.BLUE,
+                        Color.RED,
                         true,
                         undefined,
                         splat.root.getWorldTransform());
@@ -378,9 +375,12 @@ class Scene {
                     this.app.drawWireAlignedBox(
                         world.getMin(),
                         world.getMax(),
-                        Color.GRAY);
+                        Color.GREEN);
                 }
             });
+
+            // draw scene bound
+            this.app.drawWireAlignedBox(this.bound.getMin(), this.bound.getMax(), Color.BLUE);
         }
     }
 

--- a/src/selection.ts
+++ b/src/selection.ts
@@ -36,6 +36,14 @@ const initSelection = (events: Events, scene: Scene) => {
     events.function('selection', () => {
         return selection;
     });
+
+    events.on('selection.next', () => {
+        const splats = scene.getElementsByType(ElementType.splat);
+        if (splats.length > 1) {
+            const idx = splats.indexOf(selection);
+            events.fire('selection', splats[(idx + 1) % splats.length]);
+        }
+    });
 };
 
 export { initSelection };

--- a/src/selection.ts
+++ b/src/selection.ts
@@ -6,8 +6,10 @@ let selection: Element = null;
 
 const initSelection = (events: Events, scene: Scene) => {
     events.on('scene.elementAdded', (element: Element) => {
-        if (element.type === ElementType.splat && !selection) {
-            events.fire('selection', element);
+        if (element.type === ElementType.splat) {
+            setTimeout(() => {
+                events.fire('selection', element);
+            });
         }
     });
 

--- a/src/selection.ts
+++ b/src/selection.ts
@@ -1,0 +1,41 @@
+import { Element, ElementType } from './element';
+import { Events } from './events';
+import { Scene } from './scene';
+
+let selection: Element = null;
+
+const initSelection = (events: Events, scene: Scene) => {
+    events.on('scene.elementAdded', (element: Element) => {
+        if (element.type === ElementType.splat && selection === null) {
+            events.fire('selection', element);
+        }
+    });
+
+    events.on('scene.elementRemoved', (element: Element) => {
+        if (element === selection) {
+            const splats = scene.getElementsByType(ElementType.splat);
+            events.fire('selection', splats.length === 1 ? null : splats.find(v => v !== element));
+        }
+    });
+
+    events.on('selection', (element: Element) => {
+        if (element !== selection) {
+            selection = element;
+            events.fire('selection.changed', selection);
+            scene.forceRender = true;
+        }
+    });
+
+    events.on('selection.byUid', (uid: number) => {
+        const splat = scene.getElementsByType(ElementType.splat).find(v => v.uid === uid);
+        if (splat) {
+            events.fire('selection', splat);
+        }
+    });
+
+    events.function('selection', () => {
+        return selection;
+    });
+};
+
+export { initSelection };

--- a/src/selection.ts
+++ b/src/selection.ts
@@ -6,7 +6,7 @@ let selection: Element = null;
 
 const initSelection = (events: Events, scene: Scene) => {
     events.on('scene.elementAdded', (element: Element) => {
-        if (element.type === ElementType.splat && selection === null) {
+        if (element.type === ElementType.splat && !selection) {
             events.fire('selection', element);
         }
     });

--- a/src/shortcuts.ts
+++ b/src/shortcuts.ts
@@ -15,6 +15,9 @@ class Shortcuts {
 
         // register keyboard handler
         document.addEventListener('keydown', (e) => {
+            // skip keys in input fields
+            if (e.target !== document.body) return;
+
             for (let i = 0; i < shortcuts.length; i++) {
                 if (shortcuts[i].keys.includes(e.key) &&
                     !!shortcuts[i].options.ctrl === !!(e.ctrlKey || e.metaKey) &&

--- a/src/splat-convert.ts
+++ b/src/splat-convert.ts
@@ -41,7 +41,6 @@ const getCommonPropNames = (convertData: ConvertEntry[]) => {
     return [...result];
 };
 
-const internalProps = ['state'];
 const mat = new Mat4();
 const quat = new Quat();
 const scale = new Vec3();
@@ -52,13 +51,24 @@ const convertPly = (convertData: ConvertEntry[]) => {
     // count the number of non-deleted splats
     const totalSplats = countTotalSplats(convertData);
 
+    const internalProps = ['state'];
+
     // get the vertex properties common to all splats
     const propNames = getCommonPropNames(convertData).filter((p) => !internalProps.includes(p));
     const hasPosition = ['x', 'y', 'z'].every(v => propNames.includes(v));
     const hasRotation = ['rot_0', 'rot_1', 'rot_2', 'rot_3'].every(v => propNames.includes(v));
     const hasScale = ['scale_0', 'scale_1', 'scale_2'].every(v => propNames.includes(v));
 
-    const header = (new TextEncoder()).encode(`ply\nformat binary_little_endian 1.0\nelement vertex ${totalSplats}\n` + propNames.map(p => `property float ${p}`).join('\n') + `\nend_header\n`);
+    const headerText = [
+        `ply`,
+        `format binary_little_endian 1.0`,
+        `element vertex ${totalSplats}`,
+         propNames.map(p => `property float ${p}`),
+         `end_header`,
+         ``
+    ].flat().join('\n');
+
+    const header = (new TextEncoder()).encode(headerText);
     const result = new Uint8Array(header.byteLength + totalSplats * propNames.length * 4);
     const dataView = new DataView(result.buffer);
 
@@ -124,23 +134,65 @@ const convertPly = (convertData: ConvertEntry[]) => {
     return result;
 };
 
-const calcMinMax = (data: Float32Array, indices?: number[]) => {
-    let min;
-    let max;
-    if (indices) {
-        min = max = data[indices[0]];
-        for (let i = 1; i < indices.length; ++i) {
-            const v = data[indices[i]];
-            min = Math.min(min, v);
-            max = Math.max(max, v);
-        }
-    } else {
-        min = max = data[0];
-        for (let i = 1; i < data.length; ++i) {
-            const v = data[i];
-            min = Math.min(min, v);
-            max = Math.max(max, v);
-        }
+interface CompressedIndex {
+    entry: ConvertEntry;
+    entryIndex: number;
+    i: number;
+    globalIndex: number;
+};
+
+class SingleSplat {
+    x = 0;
+    y = 0;
+    z = 0;
+    scale_0 = 0;
+    scale_1 = 0;
+    scale_2 = 0;
+    f_dc_0 = 0;
+    f_dc_1 = 0;
+    f_dc_2 = 0;
+    opacity = 0;
+    rot_0 = 0;
+    rot_1 = 0;
+    rot_2 = 0;
+    rot_3 = 0;
+
+    read(index: CompressedIndex) {
+        const val = (prop: string) => index.entry.splatData.getProp(prop)[index.i];
+        [this.x, this.y, this.z] = [val('x'), val('y'), val('z')];
+        [this.scale_0, this.scale_1, this.scale_2] = [val('scale_0'), val('scale_1'), val('scale_2')];
+        [this.f_dc_0, this.f_dc_1, this.f_dc_2, this.opacity] = [val('f_dc_0'), val('f_dc_1'), val('f_dc_2'), val('opacity')];
+        [this.rot_0, this.rot_1, this.rot_2, this.rot_3] = [val('rot_0'), val('rot_1'), val('rot_2'), val('rot_3')];
+    }
+
+    transform(mat: Mat4, quat: Quat, scale: Vec3) {
+        // position
+        v.set(this.x, this.y, this.z);
+        mat.transformPoint(v, v);
+        [this.x, this.y, this.z] = [v.x, v.y, v.z];
+
+        // rotation
+        q.set(this.rot_1, this.rot_2, this.rot_3, this.rot_0).mul2(quat, q);
+        [this.rot_1, this.rot_2, this.rot_3, this.rot_0] = [q.x, q.y, q.z, q.w];
+
+        // scale
+        this.scale_0 = Math.log(Math.exp(this.scale_0) * scale.x);
+        this.scale_1 = Math.log(Math.exp(this.scale_1) * scale.y);
+        this.scale_2 = Math.log(Math.exp(this.scale_2) * scale.z);
+    }
+};
+
+const compressedVal = (prop: string, index: CompressedIndex) => {
+    return index.entry.splatData.getProp(prop)[index.i];
+};
+
+const compressedMinMax = (prop: string, indices: CompressedIndex[]) => {
+    let min, max;
+    min = max = compressedVal(prop, indices[0]);
+    for (let i = 1; i < indices.length; ++i) {
+        const v = compressedVal(prop, indices[i]);
+        min = Math.min(min, v);
+        max = Math.max(max, v);
     }
     return { min, max };
 };
@@ -152,7 +204,10 @@ const normalize = (x: number, min: number, max: number) => {
 // process and compress a chunk of 256 splats
 class Chunk {
     static members = [
-        'x', 'y', 'z', 'scale_0', 'scale_1', 'scale_2', 'f_dc_0', 'f_dc_1', 'f_dc_2', 'opacity', 'rot_0', 'rot_1', 'rot_2', 'rot_3'
+        'x', 'y', 'z',
+        'scale_0', 'scale_1', 'scale_2',
+        'f_dc_0', 'f_dc_1', 'f_dc_2', 'opacity',
+        'rot_0', 'rot_1', 'rot_2', 'rot_3'
     ];
 
     size: number;
@@ -175,56 +230,25 @@ class Chunk {
         this.color = new Uint32Array(size);
     }
 
-    set(splatData: GSplatData, indices: number[]) {
+    set(index: number, splat: SingleSplat) {
         Chunk.members.forEach((name) => {
-            const prop = splatData.getProp(name);
-            const m = this.data[name];
-            indices.forEach((idx, i) => {
-                m[i] = prop[idx];
-            });
+            this.data[name][index] = (splat as any)[name];
         });
     }
 
-    transform(mat: Mat4) {
-        quat.setFromMat4(mat);
-        mat.getScale(scale);
-
-        const data = this.data;
-
-        const x = data.x;
-        const y = data.y;
-        const z = data.z;
-        const scale_0 = data.scale_0;
-        const scale_1 = data.scale_1;
-        const scale_2 = data.scale_2;
-        const rot_0 = data.rot_0;
-        const rot_1 = data.rot_1;
-        const rot_2 = data.rot_2;
-        const rot_3 = data.rot_3;
-
-        for (let i = 0; i < this.size; ++i) {
-            // position
-            v.set(x[i], y[i], z[i]);
-            mat.transformPoint(v, v);
-            x[i] = v.x;
-            y[i] = v.y;
-            z[i] = v.z;
-
-            // rotation
-            q.set(rot_1[i], rot_2[i], rot_3[i], rot_0[i]).mul2(quat, q);
-            rot_0[i] = q.w;
-            rot_1[i] = q.x;
-            rot_2[i] = q.y;
-            rot_3[i] = q.z;
-
-            // scale
-            scale_0[i] = Math.log(Math.exp(scale_0[i]) * scale.x);
-            scale_1[i] = Math.log(Math.exp(scale_1[i]) * scale.y);
-            scale_2[i] = Math.log(Math.exp(scale_2[i]) * scale.z);
-        }
-    }
-
     pack() {
+        const calcMinMax = (data: Float32Array) => {
+            let min;
+            let max;
+            min = max = data[0];
+            for (let i = 1; i < data.length; ++i) {
+                const v = data[i];
+                min = Math.min(min, v);
+                max = Math.max(max, v);
+            }
+            return { min, max };
+        };
+
         const data = this.data;
 
         const x = data.x;
@@ -325,50 +349,74 @@ class Chunk {
     }
 }
 
-const convertPlyCompressed = (convertData: ConvertEntry[]) => {
-    const sortSplats = (indices: number[]) => {
-        // https://fgiesen.wordpress.com/2009/12/13/decoding-morton-codes/
-        const encodeMorton3 = (x: number, y: number, z: number) : number => {
-            const Part1By2 = (x: number) => {
-                x &= 0x000003ff;
-                x = (x ^ (x << 16)) & 0xff0000ff;
-                x = (x ^ (x <<  8)) & 0x0300f00f;
-                x = (x ^ (x <<  4)) & 0x030c30c3;
-                x = (x ^ (x <<  2)) & 0x09249249;
-                return x;
-            };
-
-            return (Part1By2(z) << 2) + (Part1By2(y) << 1) + Part1By2(x);
+// sort the compressed indices into morton order
+const sortSplats = (indices: CompressedIndex[]) => {
+    // https://fgiesen.wordpress.com/2009/12/13/decoding-morton-codes/
+    const encodeMorton3 = (x: number, y: number, z: number) : number => {
+        const Part1By2 = (x: number) => {
+            x &= 0x000003ff;
+            x = (x ^ (x << 16)) & 0xff0000ff;
+            x = (x ^ (x <<  8)) & 0x0300f00f;
+            x = (x ^ (x <<  4)) & 0x030c30c3;
+            x = (x ^ (x <<  2)) & 0x09249249;
+            return x;
         };
 
-        const x = splatData.getProp('x') as Float32Array;
-        const y = splatData.getProp('y') as Float32Array;
-        const z = splatData.getProp('z') as Float32Array;
-
-        const bx = calcMinMax(x, indices);
-        const by = calcMinMax(y, indices);
-        const bz = calcMinMax(z, indices);
-
-        // generate morton codes
-        const morton = indices.map((i) => {
-            const ix = Math.floor(1024 * (x[i] - bx.min) / (bx.max - bx.min));
-            const iy = Math.floor(1024 * (y[i] - by.min) / (by.max - by.min));
-            const iz = Math.floor(1024 * (z[i] - bz.min) / (bz.max - bz.min));
-            return encodeMorton3(ix, iy, iz);
-        });
-
-        // order splats by morton code
-        indices.sort((a, b) => morton[a] - morton[b]);
+        return (Part1By2(z) << 2) + (Part1By2(y) << 1) + Part1By2(x);
     };
 
-    // generate index list of surviving splats
-    const state = splatData.getProp('state') as Uint8Array;
-    const indices = [];
-    for (let i = 0; i < splatData.numSplats; ++i) {
-        if ((state[i] & State.deleted) === 0) {
-            indices.push(i);
+    const bx = compressedMinMax('x', indices);
+    const by = compressedMinMax('y', indices);
+    const bz = compressedMinMax('z', indices);
+
+    const xlen = bx.max - bx.min;
+    const ylen = by.max - by.min;
+    const zlen = bz.max - bz.min;
+
+    // generate morton codes
+    const morton = indices.map((i) => {
+        const ix = Math.floor(1024 * (compressedVal('x', i) - bx.min) / xlen);
+        const iy = Math.floor(1024 * (compressedVal('y', i) - by.min) / ylen);
+        const iz = Math.floor(1024 * (compressedVal('z', i) - bz.min) / zlen);
+        return encodeMorton3(ix, iy, iz);
+    });
+
+    // order splats by morton code
+    indices.sort((a, b) => morton[a.globalIndex] - morton[b.globalIndex]);
+};
+
+const convertPlyCompressed = (convertData: ConvertEntry[]) => {
+    const chunkProps = [
+        'min_x', 'min_y', 'min_z',
+        'max_x', 'max_y', 'max_z',
+        'min_scale_x', 'min_scale_y',
+        'min_scale_z', 'max_scale_x',
+        'max_scale_y', 'max_scale_z'
+    ];
+
+    const vertexProps = [
+        'packed_position',
+        'packed_rotation',
+        'packed_scale',
+        'packed_color'
+    ];
+
+    // create a list of indices spanning all splats
+    const indices: CompressedIndex[] = convertData.reduce((indices, entry, entryIndex) => {
+        const splatData = entry.splatData;
+        const state = splatData.getProp('state') as Uint8Array;
+        for (let i = 0; i < splatData.numSplats; ++i) {
+            if ((state[i] & State.deleted) === 0) {
+                indices.push({
+                    entry,
+                    entryIndex,
+                    i,
+                    globali: indices.length
+                });
+            }
         }
-    }
+        return indices;
+    }, []);
 
     if (indices.length === 0) {
         console.error('nothing to export');
@@ -378,8 +426,6 @@ const convertPlyCompressed = (convertData: ConvertEntry[]) => {
     const numSplats = indices.length;
     const numChunks = Math.ceil(numSplats / 256);
 
-    const chunkProps = ['min_x', 'min_y', 'min_z', 'max_x', 'max_y', 'max_z', 'min_scale_x', 'min_scale_y', 'min_scale_z', 'max_scale_x', 'max_scale_y', 'max_scale_z'];
-    const vertexProps = ['packed_position', 'packed_rotation', 'packed_scale', 'packed_color'];
     const headerText = [
         [
             `ply`,
@@ -406,14 +452,36 @@ const convertPlyCompressed = (convertData: ConvertEntry[]) => {
     const chunkOffset = header.byteLength;
     const vertexOffset = chunkOffset + numChunks * 12 * 4;
 
-    const chunk = new Chunk();
-
     // sort splats into some kind of order
     sortSplats(indices);
 
+    // generate transforms for each splat model
+    const transforms = convertData.map((entry) => {
+        return {
+            modelMat: entry.modelMat.clone(),
+            quat: new Quat().setFromMat4(entry.modelMat),
+            scale: entry.modelMat.getScale()
+        };
+    });
+
+    const chunk = new Chunk();
+    const singleSplat = new SingleSplat();
+
     for (let i = 0; i < numChunks; ++i) {
-        chunk.set(splatData, indices.slice(i * 256, (i + 1) * 256));
-        chunk.transform(modelMat);
+        const num = Math.min(numSplats, (i + 1) * 256) - i * 256;
+        for (let j = 0; j < num; ++j) {
+            const index = indices[i * 256 + j];
+
+            // read splat
+            singleSplat.read(index);
+
+            // transform
+            const t = transforms[index.entryIndex];
+            singleSplat.transform(t.modelMat, t.quat, t.scale);
+
+            // set
+            chunk.set(j, singleSplat);
+        }
 
         const result = chunk.pack();
 
@@ -445,83 +513,4 @@ const convertPlyCompressed = (convertData: ConvertEntry[]) => {
 
     return result;
 };
-
-const convertSplat = (convertData: ConvertEntry[]) => {
-    // count the number of non-deleted splats
-    const x = splatData.getProp('x');
-    const y = splatData.getProp('y');
-    const z = splatData.getProp('z');
-    const opacity = splatData.getProp('opacity');
-    const rot_0 = splatData.getProp('rot_0');
-    const rot_1 = splatData.getProp('rot_1');
-    const rot_2 = splatData.getProp('rot_2');
-    const rot_3 = splatData.getProp('rot_3');
-    const f_dc_0 = splatData.getProp('f_dc_0');
-    const f_dc_1 = splatData.getProp('f_dc_1');
-    const f_dc_2 = splatData.getProp('f_dc_2');
-    const scale_0 = splatData.getProp('scale_0');
-    const scale_1 = splatData.getProp('scale_1');
-    const scale_2 = splatData.getProp('scale_2');
-
-    const state = splatData.getProp('state') as Uint8Array;
-
-    // count number of non-deleted splats
-    let numSplats = 0;
-    for (let i = 0; i < splatData.numSplats; ++i) {
-        numSplats += (state[i] & State.deleted) === State.deleted ? 0 : 1;
-    }
-
-    // position.xyz: float32, scale.xyz: float32, color.rgba: uint8, quaternion.ijkl: uint8
-    const result = new Uint8Array(numSplats * 32);
-    const dataView = new DataView(result.buffer);
-
-    // we must undo the transform we apply at load time to output data
-    const mat = new Mat4();
-    mat.setScale(-1, -1, 1);
-    mat.invert();
-    mat.mul2(mat, modelMat);
-
-    const quat = new Quat();
-    quat.setFromMat4(mat);
-
-    const v = new Vec3();
-    const q = new Quat();
-
-    const scale = new Vec3();
-    mat.getScale(scale);
-
-    const clamp = (x: number) => Math.max(0, Math.min(255, x));
-    let idx = 0;
-
-    for (let i = 0; i < splatData.numSplats; ++i) {
-        if ((state[i] & State.deleted) === State.deleted) continue;
-
-        const off = idx++ * 32;
-
-        v.set(x[i], y[i], z[i]);
-        mat.transformPoint(v, v);
-        dataView.setFloat32(off + 0, v.x, true);
-        dataView.setFloat32(off + 4, v.y, true);
-        dataView.setFloat32(off + 8, v.z, true);
-
-        dataView.setFloat32(off + 12, Math.exp(scale_0[i]) * scale.x, true);
-        dataView.setFloat32(off + 16, Math.exp(scale_1[i]) * scale.x, true);
-        dataView.setFloat32(off + 20, Math.exp(scale_2[i]) * scale.x, true);
-
-        const SH_C0 = 0.28209479177387814;
-        dataView.setUint8(off + 24, clamp((0.5 + SH_C0 * f_dc_0[i]) * 255));
-        dataView.setUint8(off + 25, clamp((0.5 + SH_C0 * f_dc_1[i]) * 255));
-        dataView.setUint8(off + 26, clamp((0.5 + SH_C0 * f_dc_2[i]) * 255));
-        dataView.setUint8(off + 27, clamp((1 / (1 + Math.exp(-opacity[i]))) * 255));
-
-        q.set(rot_1[i], rot_2[i], rot_3[i], rot_0[i]).mul2(quat, q).normalize();
-        dataView.setUint8(off + 28, clamp(q.w * 128 + 128));
-        dataView.setUint8(off + 29, clamp(q.x * 128 + 128));
-        dataView.setUint8(off + 30, clamp(q.y * 128 + 128));
-        dataView.setUint8(off + 31, clamp(q.z * 128 + 128));
-    }
-
-    return result;
-};
-
-export { convertPly, convertPlyCompressed, convertSplat };
+export { convertPly, convertPlyCompressed };

--- a/src/splat-convert.ts
+++ b/src/splat-convert.ts
@@ -513,4 +513,77 @@ const convertPlyCompressed = (convertData: ConvertEntry[]) => {
 
     return result;
 };
-export { convertPly, convertPlyCompressed };
+
+const convertSplat = (convertData: ConvertEntry[]) => {
+    const totalSplats = countTotalSplats(convertData);
+
+    // position.xyz: float32, scale.xyz: float32, color.rgba: uint8, quaternion.ijkl: uint8
+    const result = new Uint8Array(totalSplats * 32);
+    const dataView = new DataView(result.buffer);
+
+    let idx = 0;
+
+    for (let e = 0; e < convertData.length; ++e) {
+        const entry = convertData[e];
+        const splatData = entry.splatData;
+
+        // count the number of non-deleted splats
+        const x = splatData.getProp('x');
+        const y = splatData.getProp('y');
+        const z = splatData.getProp('z');
+        const opacity = splatData.getProp('opacity');
+        const rot_0 = splatData.getProp('rot_0');
+        const rot_1 = splatData.getProp('rot_1');
+        const rot_2 = splatData.getProp('rot_2');
+        const rot_3 = splatData.getProp('rot_3');
+        const f_dc_0 = splatData.getProp('f_dc_0');
+        const f_dc_1 = splatData.getProp('f_dc_1');
+        const f_dc_2 = splatData.getProp('f_dc_2');
+        const scale_0 = splatData.getProp('scale_0');
+        const scale_1 = splatData.getProp('scale_1');
+        const scale_2 = splatData.getProp('scale_2');
+
+        const state = splatData.getProp('state') as Uint8Array;
+
+        // we must undo the transform we apply at load time to output data
+        mat.setScale(-1, -1, 1);
+        mat.invert();
+        mat.mul2(mat, entry.modelMat);
+        quat.setFromMat4(mat);
+        mat.getScale(scale);
+
+        const clamp = (x: number) => Math.max(0, Math.min(255, x));
+
+        for (let i = 0; i < splatData.numSplats; ++i) {
+            if ((state[i] & State.deleted) === State.deleted) continue;
+
+            const off = idx++ * 32;
+
+            v.set(x[i], y[i], z[i]);
+            mat.transformPoint(v, v);
+            dataView.setFloat32(off + 0, v.x, true);
+            dataView.setFloat32(off + 4, v.y, true);
+            dataView.setFloat32(off + 8, v.z, true);
+
+            dataView.setFloat32(off + 12, Math.exp(scale_0[i]) * scale.x, true);
+            dataView.setFloat32(off + 16, Math.exp(scale_1[i]) * scale.x, true);
+            dataView.setFloat32(off + 20, Math.exp(scale_2[i]) * scale.x, true);
+
+            const SH_C0 = 0.28209479177387814;
+            dataView.setUint8(off + 24, clamp((0.5 + SH_C0 * f_dc_0[i]) * 255));
+            dataView.setUint8(off + 25, clamp((0.5 + SH_C0 * f_dc_1[i]) * 255));
+            dataView.setUint8(off + 26, clamp((0.5 + SH_C0 * f_dc_2[i]) * 255));
+            dataView.setUint8(off + 27, clamp((1 / (1 + Math.exp(-opacity[i]))) * 255));
+
+            q.set(rot_1[i], rot_2[i], rot_3[i], rot_0[i]).mul2(quat, q).normalize();
+            dataView.setUint8(off + 28, clamp(q.w * 128 + 128));
+            dataView.setUint8(off + 29, clamp(q.x * 128 + 128));
+            dataView.setUint8(off + 30, clamp(q.y * 128 + 128));
+            dataView.setUint8(off + 31, clamp(q.z * 128 + 128));
+        }
+    }
+
+    return result;
+};
+
+export { convertPly, convertPlyCompressed, convertSplat };

--- a/src/splat-debug.ts
+++ b/src/splat-debug.ts
@@ -1,5 +1,6 @@
 import {
     BLEND_NORMAL,
+    Entity,
     GSplatData,
     Material,
     Mesh,
@@ -10,7 +11,6 @@ import {
 } from 'playcanvas';
 import { State } from './edit-ops';
 import { Scene } from './scene';
-import { Splat } from './splat';
 
 const vs = /* glsl */ `
 attribute vec4 vertex_position;
@@ -55,7 +55,7 @@ class SplatDebug {
     meshInstance: MeshInstance;
     size = 2;
 
-    constructor(scene: Scene, splat: Splat, splatData: GSplatData) {
+    constructor(scene: Scene, root: Entity, splatData: GSplatData) {
         const device = scene.graphicsDevice;
 
         const shader = createShaderFromCode(device, vs, fs, `splatDebugShader`, {
@@ -85,9 +85,14 @@ class SplatDebug {
         mesh.update(PRIMITIVE_POINTS, true);
 
         this.splatData = splatData;
-        this.meshInstance = new MeshInstance(mesh, material, splat.root);
+        this.meshInstance = new MeshInstance(mesh, material, root);
 
         this.splatSize = this.size;
+    }
+
+    destroy() {
+        this.meshInstance.material.destroy();
+        this.meshInstance.destroy();
     }
 
     update() {

--- a/src/splat.ts
+++ b/src/splat.ts
@@ -181,6 +181,10 @@ class Splat extends Element {
         return this.root.getWorldTransform();
     }
 
+    get filename() {
+        return this.asset.file.filename;
+    }
+
     add() {
         // add the entity to the scene
         this.scene.contentRoot.addChild(this.entity);

--- a/src/splat.ts
+++ b/src/splat.ts
@@ -7,10 +7,12 @@ import {
     Entity,
     GSplatData,
     GSplatResource,
+    Quat,
     Texture,
     Vec3
 } from 'playcanvas';
 import { Element, ElementType } from "./element";
+import { SplatDebug } from "./splat-debug";
 import { Serializer } from "./serializer";
 import { State } from './edit-ops';
 
@@ -116,10 +118,15 @@ const vec = new Vec3();
 class Splat extends Element {
     asset: Asset;
     splatData: GSplatData;
+    splatDebug: SplatDebug;
     entity: Entity;
     root: Entity;
     changedCounter = 0;
     stateTexture: Texture;
+    localBoundStorage: BoundingBox;
+    worldBoundStorage: BoundingBox;
+    localBoundDirty = true;
+    worldBoundDirty = true;
 
     constructor(asset: Asset) {
         super(ElementType.splat);
@@ -134,6 +141,12 @@ class Splat extends Element {
             fragment: fragmentShader
         });
 
+        // added per-splat state channel
+        // bit 1: selected
+        // bit 2: deleted
+        // bit 3: hidden
+        this.splatData.addProp('state', new Uint8Array(this.splatData.numSplats));
+
         // create the state texture
         this.stateTexture = new Texture(splatResource.device, {
             name: 'splatState',
@@ -146,10 +159,16 @@ class Splat extends Element {
             addressU: ADDRESS_CLAMP_TO_EDGE,
             addressV: ADDRESS_CLAMP_TO_EDGE
         });
-        splatResource.device.scope.resolve('splatState').setValue(this.stateTexture);
+
+        const instance = this.root.gsplat.instance;
+
+        this.localBoundStorage = instance.splat.aabb;
+        this.worldBoundStorage = instance.meshInstance._aabb;
+
+        instance.material.setParameter('splatState', this.stateTexture);
 
         // when sort changes, re-render the scene
-        this.root.gsplat.instance.sorter.on('updated', () => {
+        instance.sorter.on('updated', () => {
             this.changedCounter++;
         });
 
@@ -163,18 +182,21 @@ class Splat extends Element {
         this.asset.unload();
     }
 
-    updateState(state: Uint8Array) {
+    updateState(recalcBound = false) {
+        const state = this.splatData.getProp('state') as Uint8Array;
         const data = this.stateTexture.lock();
         data.set(state);
         this.stateTexture.unlock();
-    }
 
-    get localBound() {
-        return this.root.gsplat.instance.splat.aabb;
-    }
+        this.splatDebug.update();
 
-    get worldBound() {
-        return this.root.gsplat.instance.meshInstance.aabb;
+        if (recalcBound) {
+            this.localBoundDirty = true;
+            this.worldBoundDirty = true;
+            this.scene.boundDirty = true;
+        }
+
+        this.scene.forceRender = true;
     }
 
     get worldTransform() {
@@ -185,17 +207,43 @@ class Splat extends Element {
         return this.asset.file.filename;
     }
 
+    getSplatWorldPosition(splatId: number, result: Vec3) {
+        if (splatId >= this.splatData.numSplats) {
+            return false;
+        }
+
+        result.set(
+            this.splatData.getProp('x')[splatId],
+            this.splatData.getProp('y')[splatId],
+            this.splatData.getProp('z')[splatId]
+        );
+
+        this.worldTransform.transformPoint(result, result);
+
+        return true;
+    }
+
     add() {
+        this.splatDebug = new SplatDebug(this.scene, this.root, this.splatData);
+
         // add the entity to the scene
         this.scene.contentRoot.addChild(this.entity);
 
-        const localBound = this.localBound;
+        const localBound = this.localBoundStorage;
         this.entity.setLocalPosition(localBound.center.x, localBound.center.y, localBound.center.z);
         this.root.setLocalPosition(-localBound.center.x, -localBound.center.y, -localBound.center.z);
+
+        this.localBoundDirty = true;
+        this.worldBoundDirty = true;
+        this.scene.boundDirty = true;
     }
 
     remove() {
+        this.splatDebug.destroy();
+        this.splatDebug = null;
+
         this.scene.contentRoot.removeChild(this.entity);
+        this.scene.boundDirty = true;
     }
 
     serialize(serializer: Serializer) {
@@ -203,39 +251,83 @@ class Splat extends Element {
         serializer.pack(this.changedCounter);
     }
 
-    calcBound(result: BoundingBox) {
-        result.copy(this.worldBound);
-        return true;
-    }
+    onPreRender() {
+        const events = this.scene.events;
+        const selected = events.invoke('selection') === this;
+        const cameraMode = events.invoke('camera.mode');
+        const splatSize = events.invoke('splatSize');
 
-    // recalculate the local space splat aabb and update engine/root transforms so it
-    // remains centered on the splat but doesn't move in world space.
-    recalcBound() {
-        // it's faster to calculate bound of splat centers
-        const state = this.splatData.getProp('state') as Uint8Array;
+        // configure rings rendering
+        const material = this.root.gsplat.instance.material;
+        material.setParameter('ringSize', (selected && cameraMode === 'rings' && splatSize > 0) ? 0.04 : 0);
 
-        const localBound = this.localBound;
-        if (!this.splatData.calcAabb(localBound, (i: number) => (state[i] & State.deleted) === 0)) {
-            localBound.center.set(0, 0, 0);
-            localBound.halfExtents.set(0.5, 0.5, 0.5);
+        // render splat centers
+        if (selected && cameraMode === 'centers' && splatSize > 0) {
+            this.splatDebug.splatSize = splatSize;
+            this.scene.app.drawMeshInstance(this.splatDebug.meshInstance);
         }
-
-        // calculate meshinstance aabb (transformed local bound)
-        const meshInstance = this.root.gsplat.instance.meshInstance;
-        meshInstance._aabb.setFromTransformedAabb(localBound, this.entity.getWorldTransform());
-
-        // calculate movement in local space
-        vec.add2(this.root.getLocalPosition(), localBound.center);
-        this.entity.getWorldTransform().transformVector(vec, vec);
-        vec.add(this.entity.getLocalPosition());
-
-        // update transforms so base entity node is oriented to the center of the mesh
-        this.entity.setLocalPosition(vec);
-        this.root.setLocalPosition(-localBound.center.x, -localBound.center.y, -localBound.center.z);
     }
 
     focalPoint() {
         return this.asset.resource?.getFocalPoint?.();
+    }
+
+    move(position?: Vec3, rotation?: Quat, scale?: Vec3) {
+        const entity = this.entity;
+        if (position) {
+            entity.setLocalPosition(position);
+        }
+        if (rotation) {
+            entity.setLocalRotation(rotation);
+        }
+        if (scale) {
+            entity.setLocalScale(scale);
+        }
+
+        this.worldBoundDirty = true;
+        this.scene.boundDirty = true;
+    }
+
+    // get local space bound
+    get localBound() {
+        if (this.localBoundDirty) {
+            const state = this.splatData.getProp('state') as Uint8Array;
+            const localBound = this.localBoundStorage;
+
+            if (!this.splatData.calcAabb(localBound, (i: number) => (state[i] & State.deleted) === 0)) {
+                localBound.center.set(0, 0, 0);
+                localBound.halfExtents.set(0.5, 0.5, 0.5);
+            }
+
+            this.localBoundDirty = false;
+        }
+
+        return this.localBoundStorage;
+    }
+
+    // get world space bound
+    get worldBound() {
+        const localBound = this.localBound;
+
+        if (this.worldBoundDirty) {
+            // calculate meshinstance aabb (transformed local bound)
+            const aabb = this.root.gsplat.instance.meshInstance._aabb;
+            aabb.setFromTransformedAabb(localBound, this.entity.getWorldTransform());
+
+            // calculate movement in local space
+            vec.add2(this.root.getLocalPosition(), localBound.center);
+            this.entity.getWorldTransform().transformVector(vec, vec);
+            vec.add(this.entity.getLocalPosition());
+
+            // update transforms so base entity node is oriented to the center of the mesh
+            this.entity.setLocalPosition(vec);
+            this.root.setLocalPosition(-localBound.center.x, -localBound.center.y, -localBound.center.z);
+
+            // flag scene bound as dirty
+            this.worldBoundDirty = false;
+        }
+
+        return this.worldBoundStorage;
     }
 }
 

--- a/src/style.scss
+++ b/src/style.scss
@@ -69,10 +69,18 @@ body {
     #keyboard-panel & { content: '\E136'};
 }
 
-#file-selector-container {
-    flex-shrink: 0;
-    flex-grow: 0;
-    margin: 5px;
+#file-selector {
+    display: none;
+}
+
+#file-menu {
+    position: absolute;
+}
+
+.file-menu-item span {
+    padding: 6px;
+    color: $text-secondary !important;
+    font-size: 14px;
 }
 
 .toolbar-button {
@@ -250,6 +258,66 @@ body {
     margin-right: auto;
     width: 400px;
     top: 50%;
+}
+
+//-- Message popup
+
+#message {
+    width: 100%;
+    height: 100%;
+    background-color: rgba(0, 0, 0, 0.5);
+    pointer-events: all;
+}
+
+#message-background {
+    display: flex;
+    flex-direction: column;
+    position: absolute;
+    left: 50%;
+    top: 50%;
+    width: 600px;
+    transform: translate(-50%, -50%);
+    background-color: $bcg-primary;
+    padding: 20px;
+    border-radius: 10px;
+    border: 1px solid $bcg-darker;
+    pointer-events: all;
+}
+
+#message-buttons {
+    display: flex;
+    flex-direction: row;
+    justify-content: center;
+}
+
+.message-button {
+    background-color: $bcg-darker;
+    color: white;
+    // border-radius: 10px;
+    height: 40px;
+    width: 120px
+}
+
+#message-text {
+    font-size: 18px;
+    color: $text-primary;
+    text-wrap: wrap;
+    text-align: center;
+    margin: 20px 0px;
+}
+
+#message-text.error::before {
+    content: '\E218';
+    font-family: 'pc-icon';
+    margin: 0px 10px;
+    color: $error;
+}
+
+#message-text.info::before {
+    content: '\E400';
+    font-family: 'pc-icon';
+    margin: 0px 10px;
+    color: $text-primary;
 }
 
 /* scrollbar styling */

--- a/src/style.scss
+++ b/src/style.scss
@@ -217,9 +217,17 @@ body {
     image-rendering: pixelated;
 }
 
+#tooltips-container {
+    position: fixed;
+    left: 0;
+    top: 0;
+    width: 100%;
+    height: 100%;
+    pointer-events: none;
+}
+
 #top-container {
     position: fixed;
-    z-index: 10000;
     left: 0;
     top: 0;
     width: 100%;
@@ -239,37 +247,16 @@ body {
     margin-right: 6px;
 }
 
-.error-popup {
-    position: absolute;
-    left: 0;
-    right: 0;
-    margin-left: auto;
-    margin-right: auto;
-    width: 400px;
-    top: 50%;
-    color: red;
-}
+//-- Popup
 
-.info-popup {
-    position: absolute;
-    left: 0;
-    right: 0;
-    margin-left: auto;
-    margin-right: auto;
-    width: 400px;
-    top: 50%;
-}
-
-//-- Message popup
-
-#message {
+#popup {
     width: 100%;
     height: 100%;
     background-color: rgba(0, 0, 0, 0.5);
     pointer-events: all;
 }
 
-#message-background {
+#popup-background {
     display: flex;
     flex-direction: column;
     position: absolute;
@@ -284,13 +271,13 @@ body {
     pointer-events: all;
 }
 
-#message-buttons {
+#popup-buttons {
     display: flex;
     flex-direction: row;
     justify-content: center;
 }
 
-.message-button {
+.popup-button {
     background-color: $bcg-darker;
     color: white;
     // border-radius: 10px;
@@ -298,7 +285,7 @@ body {
     width: 120px
 }
 
-#message-text {
+#popup-text {
     font-size: 18px;
     color: $text-primary;
     text-wrap: wrap;
@@ -306,14 +293,14 @@ body {
     margin: 20px 0px;
 }
 
-#message-text.error::before {
+#popup-text.error::before {
     content: '\E218';
     font-family: 'pc-icon';
     margin: 0px 10px;
     color: $error;
 }
 
-#message-text.info::before {
+#popup-text.info::before {
     content: '\E400';
     font-family: 'pc-icon';
     margin: 0px 10px;

--- a/src/style.scss
+++ b/src/style.scss
@@ -69,6 +69,29 @@ body {
     #keyboard-panel & { content: '\E136'};
 }
 
+#scene-panel-splat-list-container {
+    // padding: 10px;
+    overflow: scroll;
+
+    width: 100%;
+    height: 100px;
+    display: flex;
+    flex-direction: row;
+    flex-grow: 1;
+
+    background-color: $bcg-primary;
+}
+
+#scene-panel-splat-list {
+    width: 100%;
+    height: 100%;
+    padding: 4px;
+}
+
+#scene-panel-splat-list .pcui-treeview-item-contents.pcui-treeview-item-selected {
+    background-color: royalblue;
+}
+
 #file-selector {
     display: none;
 }

--- a/src/style.scss
+++ b/src/style.scss
@@ -316,6 +316,10 @@ body {
     margin: 20px 0px;
 }
 
+#popup-text-input {
+    margin-bottom: 24px;
+}
+
 #popup-text.error::before {
     content: '\E218';
     font-family: 'pc-icon';

--- a/src/style.scss
+++ b/src/style.scss
@@ -303,7 +303,6 @@ body {
 .popup-button {
     background-color: $bcg-darker;
     color: white;
-    // border-radius: 10px;
     height: 40px;
     width: 120px
 }

--- a/src/tools/transform-tool.ts
+++ b/src/tools/transform-tool.ts
@@ -1,10 +1,10 @@
-import { Entity, TransformGizmo } from 'playcanvas';
-import { ElementType } from '../element';
+import { TransformGizmo } from 'playcanvas';
+import { Element } from '../element';
 import { Scene } from '../scene';
 import { Splat } from '../splat';
 import { Events } from '../events';
 import { EditHistory, EditOp } from '../edit-history';
-import { EntityTransformOp } from '../edit-ops';
+import { EntityOp, EntityTransformOp } from '../edit-ops';
 
 // patch gizmo to be more opaque
 const patchGizmoMaterials = (gizmo: TransformGizmo) => {
@@ -17,12 +17,15 @@ const patchGizmoMaterials = (gizmo: TransformGizmo) => {
 class TransformTool {
     scene: Scene;
     gizmo: TransformGizmo;
-    entities: Entity[] = [];
-    ops: any[] = [];
+    elements: Element[] = [];
+    ops: EntityOp[] = [];
+    events: Events;
+    active = false;
 
     constructor(gizmo: TransformGizmo, events: Events, editHistory: EditHistory, scene: Scene) {
         this.scene = scene;
         this.gizmo = gizmo;
+        this.events = events;
 
         // patch gizmo materials (until we have API to do this)
         patchGizmoMaterials(this.gizmo);
@@ -35,9 +38,11 @@ class TransformTool {
         });
 
         this.gizmo.on('transform:start', () => {
-            this.ops = this.entities.map((entity) => {
+            this.ops = this.elements.map((element) => {
+                const entity = element.entity;
+
                 return {
-                    entity: entity,
+                    element: element,
                     old: {
                         position: entity.getLocalPosition().clone(),
                         rotation: entity.getLocalRotation().clone(),
@@ -53,13 +58,13 @@ class TransformTool {
         });
 
         this.gizmo.on('transform:move', () => {
-            scene.updateBound();
+            scene.boundDirty = true;
         });
 
         this.gizmo.on('transform:end', () => {
             // update new transforms
             this.ops.forEach((op) => {
-                const e = op.entity;
+                const e = op.element.entity;
                 op.new.position.copy(e.getLocalPosition());
                 op.new.rotation.copy(e.getLocalRotation());
                 op.new.scale.copy(e.getLocalScale());
@@ -67,7 +72,7 @@ class TransformTool {
 
             // filter out ops that didn't change
             this.ops = this.ops.filter((op) => {
-                const e = op.entity;
+                const e = op.element.entity;
                 return !op.old.position.equals(e.getLocalPosition()) ||
                        !op.old.rotation.equals(e.getLocalRotation()) ||
                        !op.old.scale.equals(e.getLocalScale());
@@ -80,8 +85,8 @@ class TransformTool {
         });
 
         events.on('scene.boundChanged', (editOp: EditOp) => {
-            if (this.entities) {
-                this.gizmo.attach(this.entities);
+            if (this.elements) {
+                this.gizmo.attach(this.elements.map((element) => element.entity));
             }
         });
 
@@ -89,16 +94,38 @@ class TransformTool {
             this.gizmo.coordSpace = coordSpace;
             scene.forceRender = true;
         });
+
+        events.on('selection.changed', (selection: Splat) => {
+            this.update();
+        });
+    }
+
+    update() {
+        if (!this.active) {
+            this.gizmo.detach();
+            this.elements = [];
+            return;
+        }
+
+        const selection = this.events.invoke('selection');
+        if (!selection) {
+            this.gizmo.detach();
+            this.elements = [];
+            return;
+        }
+
+        this.elements = [selection];
+        this.gizmo.attach(this.elements.map((element) => element.entity));
     }
 
     activate() {
-        this.entities = this.scene.getElementsByType(ElementType.splat).map((splat: Splat) => splat.entity);
-        this.gizmo.attach(this.entities);
+        this.active = true;
+        this.update();
     }
 
     deactivate() {
-        this.gizmo.detach();
-        this.entities = [];
+        this.active = false;
+        this.update();
     }
 }
 

--- a/src/tools/transform-tool.ts
+++ b/src/tools/transform-tool.ts
@@ -1,5 +1,4 @@
 import { TransformGizmo } from 'playcanvas';
-import { Element } from '../element';
 import { Scene } from '../scene';
 import { Splat } from '../splat';
 import { Events } from '../events';
@@ -17,7 +16,7 @@ const patchGizmoMaterials = (gizmo: TransformGizmo) => {
 class TransformTool {
     scene: Scene;
     gizmo: TransformGizmo;
-    elements: Element[] = [];
+    splats: Splat[] = [];
     ops: EntityOp[] = [];
     events: Events;
     active = false;
@@ -31,18 +30,18 @@ class TransformTool {
         patchGizmoMaterials(this.gizmo);
 
         this.gizmo.coordSpace = events.invoke('tool.coordSpace');
-        this.gizmo.size = 0.9;
+        this.gizmo.size = 0.8;
 
         this.gizmo.on('render:update', () => {
             scene.forceRender = true;
         });
 
         this.gizmo.on('transform:start', () => {
-            this.ops = this.elements.map((element) => {
-                const entity = element.entity;
+            this.ops = this.splats.map((splat) => {
+                const entity = splat.entity;
 
                 return {
-                    element: element,
+                    splat,
                     old: {
                         position: entity.getLocalPosition().clone(),
                         rotation: entity.getLocalRotation().clone(),
@@ -58,13 +57,16 @@ class TransformTool {
         });
 
         this.gizmo.on('transform:move', () => {
+            this.ops.forEach((op) => {
+                op.splat.worldBoundDirty = true;
+            });
             scene.boundDirty = true;
         });
 
         this.gizmo.on('transform:end', () => {
             // update new transforms
             this.ops.forEach((op) => {
-                const e = op.element.entity;
+                const e = op.splat.entity;
                 op.new.position.copy(e.getLocalPosition());
                 op.new.rotation.copy(e.getLocalRotation());
                 op.new.scale.copy(e.getLocalScale());
@@ -72,7 +74,7 @@ class TransformTool {
 
             // filter out ops that didn't change
             this.ops = this.ops.filter((op) => {
-                const e = op.element.entity;
+                const e = op.splat.entity;
                 return !op.old.position.equals(e.getLocalPosition()) ||
                        !op.old.rotation.equals(e.getLocalRotation()) ||
                        !op.old.scale.equals(e.getLocalScale());
@@ -85,8 +87,8 @@ class TransformTool {
         });
 
         events.on('scene.boundChanged', (editOp: EditOp) => {
-            if (this.elements) {
-                this.gizmo.attach(this.elements.map((element) => element.entity));
+            if (this.splats) {
+                this.gizmo.attach(this.splats.map((splat) => splat.entity));
             }
         });
 
@@ -103,19 +105,19 @@ class TransformTool {
     update() {
         if (!this.active) {
             this.gizmo.detach();
-            this.elements = [];
+            this.splats = [];
             return;
         }
 
-        const selection = this.events.invoke('selection');
+        const selection = this.events.invoke('selection') as Splat;
         if (!selection) {
             this.gizmo.detach();
-            this.elements = [];
+            this.splats = [];
             return;
         }
 
-        this.elements = [selection];
-        this.gizmo.attach(this.elements.map((element) => element.entity));
+        this.splats = [selection];
+        this.gizmo.attach(this.splats.map((splats) => splats.entity));
     }
 
     activate() {

--- a/src/ui/control-panel.ts
+++ b/src/ui/control-panel.ts
@@ -377,37 +377,6 @@ class ControlPanel extends Panel {
         events.on('edit.canUndo', (value: boolean) => { undoButton.enabled = value; });
         events.on('edit.canRedo', (value: boolean) => { redoButton.enabled = value; });
 
-        // export
-        const exportPanel = new Panel({
-            id: 'export-panel',
-            class: 'control-panel',
-            headerText: 'EXPORT TO'
-        });
-
-        const storageIcon = remoteStorageMode ? 'E222' : 'E245';
-
-        const exportPlyButton = new Button({
-            class: 'control-element',
-            text: 'Ply file',
-            icon: storageIcon
-        });
-
-        const exportCompressedPlyButton = new Button({
-            class: 'control-element',
-            text: 'Compressed Ply file',
-            icon: storageIcon
-        });
-
-        const exportSplatButton = new Button({
-            class: 'control-element',
-            text: 'Splat file',
-            icon: storageIcon
-        });
-
-        exportPanel.append(exportPlyButton);
-        exportPanel.append(exportCompressedPlyButton);
-        exportPanel.append(exportSplatButton);
-
         // options
         const optionsPanel = new Panel({
             id: 'options-panel',
@@ -439,7 +408,6 @@ class ControlPanel extends Panel {
         this.content.append(selectionPanel);
         this.content.append(showPanel);
         this.content.append(modifyPanel);
-        this.content.append(exportPanel);
         this.content.append(optionsPanel);
 
         rectSelectButton.on('click', () => {
@@ -602,18 +570,6 @@ class ControlPanel extends Panel {
 
         allDataToggle.on('change', (enabled: boolean) => {
             events.fire('allData', enabled);
-        });
-
-        exportPlyButton.on('click', () => {
-            events.fire('scene.exportPly');
-        });
-
-        exportCompressedPlyButton.on('click', () => {
-            events.fire('scene.exportCompressedPly');
-        });
-
-        exportSplatButton.on('click', () => {
-            events.fire('scene.exportSplat');
         });
 
         events.on('splat.count', (count: number) => {

--- a/src/ui/editor.ts
+++ b/src/ui/editor.ts
@@ -2,6 +2,7 @@ import { Container, InfoBox, Label } from 'pcui';
 import { ControlPanel } from './control-panel';
 import { Toolbar } from './toolbar';
 import { Events } from '../events';
+import { MessagePopup } from './message-popup';
 import logo from './playcanvas-logo.png';
 
 class EditorUI {
@@ -13,6 +14,7 @@ class EditorUI {
     filenameLabel: Label;
     errorPopup: InfoBox;
     infoPopup: InfoBox;
+    messagePopup: MessagePopup;
 
     constructor(events: Events, remoteStorageMode: boolean) {
         // favicon
@@ -59,11 +61,10 @@ class EditorUI {
         const controlPanel = new ControlPanel(events, remoteStorageMode);
 
         // file select
-        const fileSelect = new Container({
-            id: 'file-selector-container'
-        });
-
-        controlPanel.append(fileSelect);
+        // const fileSelect = new Container({
+        //     id: 'file-selector-container'
+        // });
+        // controlPanel.append(fileSelect);
 
         editorContainer.append(toolbar);
         editorContainer.append(controlPanel);
@@ -88,6 +89,9 @@ class EditorUI {
         topContainer.append(errorPopup);
         topContainer.append(infoPopup);
 
+        // message popup
+        this.messagePopup = new MessagePopup(topContainer);
+
         appContainer.append(editorContainer);
         appContainer.append(topContainer);
 
@@ -103,6 +107,10 @@ class EditorUI {
         document.body.appendChild(appContainer.dom);
 
         window.showError = (err: string) => this.showError(err);
+
+        events.function('showMessage', (options: { type: 'error' | 'info' | 'yesno', message: string }) => {
+            return this.messagePopup.show(options.type, options.message);
+        });
 
         // initialize canvas to correct size before creating graphics device etc
         const pixelRatio = window.devicePixelRatio;
@@ -126,6 +134,10 @@ class EditorUI {
         } else {
             this.infoPopup.hidden = true;
         }
+    }
+
+    showMessage(type: 'error' | 'info' | 'yesno', message: string) {
+        return this.messagePopup.show(type, message);
     }
 
     setFilename(filename: string) {

--- a/src/ui/editor.ts
+++ b/src/ui/editor.ts
@@ -2,19 +2,17 @@ import { Container, InfoBox, Label } from 'pcui';
 import { ControlPanel } from './control-panel';
 import { Toolbar } from './toolbar';
 import { Events } from '../events';
-import { MessagePopup } from './message-popup';
+import { Popup } from './popup';
 import logo from './playcanvas-logo.png';
 
 class EditorUI {
     appContainer: Container;
-    overlaysContainer: Container;
+    topContainer: Container;
     controlPanel: ControlPanel;
     canvasContainer: Container;
     canvas: HTMLCanvasElement;
     filenameLabel: Label;
-    errorPopup: InfoBox;
-    infoPopup: InfoBox;
-    messagePopup: MessagePopup;
+    popup: Popup;
 
     constructor(events: Events, remoteStorageMode: boolean) {
         // favicon
@@ -33,13 +31,27 @@ class EditorUI {
             id: 'editor-container'
         });
 
+        // tooltips container
+        const tooltipsContainer = new Container({
+            id: 'tooltips-container'
+        });
+
         // top container
         const topContainer = new Container({
             id: 'top-container'
         });
-        
+
+        const killit = (event: UIEvent) => {
+            event.preventDefault();
+            event.stopPropagation();
+            return false;
+        };
+
+        topContainer.dom.addEventListener('mousemove', (event: MouseEvent) => killit(event));
+        topContainer.on('click', (event: MouseEvent) => killit(event));
+
         // toolbar
-        const toolbar = new Toolbar(events, appContainer, topContainer);
+        const toolbar = new Toolbar(events, appContainer, tooltipsContainer);
 
         // canvas
         const canvas = document.createElement('canvas');
@@ -60,84 +72,42 @@ class EditorUI {
         // control panel
         const controlPanel = new ControlPanel(events, remoteStorageMode);
 
-        // file select
-        // const fileSelect = new Container({
-        //     id: 'file-selector-container'
-        // });
-        // controlPanel.append(fileSelect);
-
         editorContainer.append(toolbar);
         editorContainer.append(controlPanel);
         editorContainer.append(canvasContainer);
 
-        // error box 
-        const errorPopup = new InfoBox({
-            class: 'error-popup',
-            icon: 'E218',
-            title: 'Error',
-            hidden: true
-        });
-
-        // info box
-        const infoPopup = new InfoBox({
-            class: 'info-popup',
-            icon: 'E400',
-            title: 'Info',
-            hidden: true
-        });
-
-        topContainer.append(errorPopup);
-        topContainer.append(infoPopup);
-
         // message popup
-        this.messagePopup = new MessagePopup(topContainer);
+        this.popup = new Popup(topContainer);
 
         appContainer.append(editorContainer);
+        appContainer.append(tooltipsContainer);
         appContainer.append(topContainer);
 
         this.appContainer = appContainer;
-        this.overlaysContainer = topContainer;
+        this.topContainer = topContainer;
         this.controlPanel = controlPanel;
         this.canvasContainer = canvasContainer;
         this.canvas = canvas;
         this.filenameLabel = filenameLabel;
-        this.errorPopup = errorPopup;
-        this.infoPopup = infoPopup;
 
         document.body.appendChild(appContainer.dom);
 
-        window.showError = (err: string) => this.showError(err);
+        events.function('showPopup', (options: { type: 'error' | 'info' | 'yesno' | 'okcancel', message: string, value: string}) => {
+            return this.popup.show(options.type, options.message, options.value);
+        });
 
-        events.function('showMessage', (options: { type: 'error' | 'info' | 'yesno', message: string }) => {
-            return this.messagePopup.show(options.type, options.message);
+        events.function('error', (err: any) => {
+            return this.popup.show('error', err);
+        });
+
+        events.function('info', (info: string) => {
+            return this.popup.show('info', info);
         });
 
         // initialize canvas to correct size before creating graphics device etc
         const pixelRatio = window.devicePixelRatio;
         canvas.width = Math.ceil(canvasContainer.dom.offsetWidth * pixelRatio);
         canvas.height = Math.ceil(canvasContainer.dom.offsetHeight * pixelRatio);
-    }
-
-    showError(err: string) {
-        if (err) {
-            this.errorPopup.text = err;
-            this.errorPopup.hidden = false;
-        } else {
-            this.errorPopup.hidden = true;
-        }
-    }
-
-    showInfo(info: string) {
-        if (info) {
-            this.infoPopup.text = info;
-            this.infoPopup.hidden = false;
-        } else {
-            this.infoPopup.hidden = true;
-        }
-    }
-
-    showMessage(type: 'error' | 'info' | 'yesno', message: string) {
-        return this.messagePopup.show(type, message);
     }
 
     setFilename(filename: string) {

--- a/src/ui/popup.ts
+++ b/src/ui/popup.ts
@@ -1,0 +1,160 @@
+import { Button, Container, Label, TextInput } from 'pcui';
+
+class Popup {
+    show: (type: 'error' | 'info' | 'yesno' | 'okcancel', message: string, value?: string) => void;
+    hide: () => void;
+    destroy: () => void;
+
+    constructor(parent: Container) {
+
+        const text = new Label({
+            id: 'popup-text'
+        });
+
+        const inputValue = new TextInput({
+            id: 'popup-text-input'
+        });
+
+        const okButton = new Button({
+            class: 'popup-button',
+            text: 'OK'
+        });
+
+        const cancelButton = new Button({
+            class: 'popup-button',
+            text: 'Cancel'
+        });
+
+        const yesButton = new Button({
+            class: 'popup-button',
+            text: 'Yes'
+        });
+
+        const noButton = new Button({
+            class: 'popup-button',
+            text: 'No'
+        });
+
+        const buttons = new Container({
+            id: 'popup-buttons'
+        });
+
+        buttons.append(okButton);
+        buttons.append(cancelButton);
+        buttons.append(yesButton);
+        buttons.append(noButton);
+
+        const background = new Container({
+            id: 'popup-background'
+        });
+
+        background.append(text);
+        background.append(inputValue);
+        background.append(buttons);
+
+        const container = new Container({
+            id: 'popup',
+            hidden: true
+        });
+
+        container.append(background);
+
+        parent.append(container);
+
+        let okFn: () => void;
+        let cancelFn: () => void;
+        let yesFn: () => void;
+        let noFn: () => void;
+        let containerFn: () => void;
+
+        okButton.on('click', () => {
+            okFn();
+        });
+
+        cancelButton.on('click', () => {
+            cancelFn();
+        });
+
+        yesButton.on('click', () => {
+            yesFn();
+        });
+
+        noButton.on('click', () => {
+            noFn();
+        });
+
+        container.on('click', () => {
+            containerFn();
+        });
+
+        background.on('click', (event) => {
+            event.stopPropagation();
+        });
+
+        this.show = async (type: 'error' | 'info' | 'yesno' | 'okcancel', message: string, value?: string) => {
+            // set the message
+            text.text = message;
+
+            if (type === 'error') {
+                text.class.add('error');
+                text.class.remove('info');
+            } else if (type === 'info') {
+                text.class.remove('error');
+                text.class.add('info');
+            } else {
+                text.class.remove('error');
+                text.class.remove('info');
+            }
+
+            inputValue.hidden = value === undefined;
+            if (value !== undefined) {
+                inputValue.value = value;
+            }
+
+            // configure based on message type
+            okButton.hidden = type === 'yesno';
+            cancelButton.hidden = type !== 'okcancel';
+            yesButton.hidden = type !== 'yesno';
+            noButton.hidden = type !== 'yesno';
+            container.hidden = false;
+
+            return new Promise<{action: string, value?: string}>((resolve) => {
+                okFn = () => {
+                    this.hide();
+                    resolve({
+                        action: 'ok',
+                        value: value !== undefined && inputValue.value
+                    });
+                };
+                cancelFn = () => {
+                    this.hide();
+                    resolve({ action: 'cancel' });
+                };
+                yesFn = () => {
+                    this.hide();
+                    resolve({ action: 'yes' });
+                };
+                noFn = () => {
+                    this.hide();
+                    resolve({ action: 'no' });
+                };
+                containerFn = () => {
+                    if (type === 'info') {
+                        cancelFn();
+                    }
+                };
+            });
+        };
+
+        this.hide = () => {
+            container.hidden = true;
+        };
+
+        this.destroy = () => {
+            this.hide();
+            container.destroy();
+        };
+    }
+}
+
+export { Popup };

--- a/src/ui/popup.ts
+++ b/src/ui/popup.ts
@@ -106,10 +106,6 @@ class Popup {
                 text.class.remove('info');
             }
 
-            inputValue.hidden = value === undefined;
-            if (value !== undefined) {
-                inputValue.value = value;
-            }
 
             // configure based on message type
             okButton.hidden = type === 'yesno';
@@ -117,6 +113,12 @@ class Popup {
             yesButton.hidden = type !== 'yesno';
             noButton.hidden = type !== 'yesno';
             container.hidden = false;
+
+            inputValue.hidden = value === undefined;
+            if (value !== undefined) {
+                inputValue.value = value;
+                inputValue.focus();
+            }
 
             return new Promise<{action: string, value?: string}>((resolve) => {
                 okFn = () => {

--- a/src/ui/shortcuts-popup.ts
+++ b/src/ui/shortcuts-popup.ts
@@ -21,6 +21,7 @@ const shortcutList = [
     { key: 'H', action: 'Hide Selected Splats' },
     { key: 'U', action: 'Unhide All Splats' },
     { header: 'OTHER' },
+    { key: 'Tab', action: 'Select Next Splat' },
     { key: 'Ctrl + Z', action: 'Undo' },
     { key: 'Ctrl + Shift + Z', action: 'Redo' },
     { key: 'Space', action: 'Toggle Debug Splat Display' },

--- a/src/ui/toolbar.ts
+++ b/src/ui/toolbar.ts
@@ -5,7 +5,7 @@ import { Events } from '../events';
 import logo from './playcanvas-logo.png';
 
 class Toolbar extends Container {
-    constructor(events: Events, appContainer: Container, topContainer: Container, args = {}) {
+    constructor(events: Events, appContainer: Container, tooltipsContainer: Container, args = {}) {
         args = Object.assign(args, {
             id: 'toolbar-container'
         });
@@ -63,12 +63,12 @@ class Toolbar extends Container {
                     class: 'file-menu-item',
                     text: 'Compressed Ply',
                     icon: 'E245',
-                    onSelect: () => events.fire('scene.exportCompressedPly')
+                    onSelect: () => events.invoke('scene.export', 'compressed-ply')
                 }, {
                     class: 'file-menu-item',
                     text: 'Splat file',
                     icon: 'E245',
-                    onSelect: () => events.fire('scene.exportSplat')
+                    onSelect: () => events.invoke('scene.export', 'splat')
                 }]
             }]
         });
@@ -207,7 +207,7 @@ class Toolbar extends Container {
 
         const addTooltip = (target: Element, text: string) => {
             const tooltip = new Tooltip({ target, text });
-            topContainer.append(tooltip);
+            tooltipsContainer.append(tooltip);
             return tooltip;
         };
 

--- a/src/ui/toolbar.ts
+++ b/src/ui/toolbar.ts
@@ -64,6 +64,11 @@ class Toolbar extends Container {
                     text: 'Compressed Ply',
                     icon: 'E245',
                     onSelect: () => events.invoke('scene.export', 'compressed-ply')
+                }, {
+                    class: 'file-menu-item',
+                    text: 'Splat file',
+                    icon: 'E245',
+                    onSelect: () => events.invoke('scene.export', 'splat')
                 }]
             }]
         });

--- a/src/ui/toolbar.ts
+++ b/src/ui/toolbar.ts
@@ -1,4 +1,4 @@
-import { Button, Container, Element } from 'pcui';
+import { Button, Container, Element, Menu } from 'pcui';
 import { ShortcutsPopup } from './shortcuts-popup';
 import { Tooltip } from './tooltip';
 import { Events } from '../events';
@@ -22,6 +22,70 @@ class Toolbar extends Container {
         appLogo.classList.add('toolbar-button');
         appLogo.id = 'app-logo';
         appLogo.src = logo.src;
+
+        // file
+        const fileButton = new Button({
+            id: 'file-menu-button',
+            class: 'toolbar-button',
+            icon: 'E220'
+        });
+
+        const fileMenu = new Menu({
+            id: 'file-menu',
+            items: [{
+                class: 'file-menu-item',
+                text: 'New',
+                icon: 'E208',
+                onSelect: () => events.fire('scene.new')
+            }, {
+                class: 'file-menu-item',
+                text: 'Open...',
+                icon: 'E276',
+                onSelect: () => events.fire('scene.open')
+            }, {
+                class: 'file-menu-item',
+                text: 'Save',
+                icon: 'E276',
+                onSelect: () => events.fire('scene.save'),
+                onIsEnabled: () => events.invoke('scene.canSave')
+            }, {
+                class: 'file-menu-item',
+                text: 'Save As...',
+                icon: 'E276',
+                onSelect: () => events.fire('scene.saveAs'),
+                onIsEnabled: () => events.invoke('scene.canSave')
+            }, {
+                class: 'file-menu-item',
+                text: 'Export',
+                icon: 'E226',
+                onIsEnabled: () => events.invoke('scene.canSave'),
+                items: [{
+                    class: 'file-menu-item',
+                    text: 'Compressed Ply',
+                    icon: 'E245',
+                    onSelect: () => events.fire('scene.exportCompressedPly')
+                }, {
+                    class: 'file-menu-item',
+                    text: 'Splat file',
+                    icon: 'E245',
+                    onSelect: () => events.fire('scene.exportSplat')
+                }]
+            }]
+        });
+
+        fileButton.on('click', () => {
+            const r = fileButton.dom.getBoundingClientRect();
+            fileMenu.position(r.right, r.top);
+            fileMenu.hidden = false;
+        });
+
+        window.addEventListener('click', (e: Event) => {
+            if (!fileMenu.hidden &&
+                !fileMenu.dom.contains(e.target as Node) &&
+                e.target !== fileButton.dom) {
+                fileMenu.hidden = true;
+            }
+        });
 
         // move
         const moveTool = new Button({
@@ -99,6 +163,8 @@ class Toolbar extends Container {
         });
 
         toolbarToolsContainer.dom.appendChild(appLogo);
+        toolbarToolsContainer.append(fileButton);
+        toolbarToolsContainer.append(fileMenu);
         toolbarToolsContainer.append(moveTool);
         toolbarToolsContainer.append(rotateTool);
         toolbarToolsContainer.append(scaleTool);

--- a/src/ui/toolbar.ts
+++ b/src/ui/toolbar.ts
@@ -40,18 +40,18 @@ class Toolbar extends Container {
             }, {
                 class: 'file-menu-item',
                 text: 'Open...',
-                icon: 'E276',
+                icon: 'E226',
                 onSelect: () => events.fire('scene.open')
             }, {
                 class: 'file-menu-item',
                 text: 'Save',
-                icon: 'E276',
+                icon: 'E216',
                 onSelect: () => events.fire('scene.save'),
                 onIsEnabled: () => events.invoke('scene.canSave')
             }, {
                 class: 'file-menu-item',
                 text: 'Save As...',
-                icon: 'E276',
+                icon: 'E216',
                 onSelect: () => events.fire('scene.saveAs'),
                 onIsEnabled: () => events.invoke('scene.canSave')
             }, {

--- a/src/ui/toolbar.ts
+++ b/src/ui/toolbar.ts
@@ -64,11 +64,6 @@ class Toolbar extends Container {
                     text: 'Compressed Ply',
                     icon: 'E245',
                     onSelect: () => events.invoke('scene.export', 'compressed-ply')
-                }, {
-                    class: 'file-menu-item',
-                    text: 'Splat file',
-                    icon: 'E245',
-                    onSelect: () => events.invoke('scene.export', 'splat')
                 }]
             }]
         });
@@ -192,7 +187,7 @@ class Toolbar extends Container {
             icon: 'E259' 
         });
         github.on('click', () => {
-            window.open('https://github.com/playcanvas/super-splat', '_blank').focus();
+            window.open('https://github.com/playcanvas/supersplat', '_blank').focus();
         });
 
         // toolbar help toolbar

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,7 +13,10 @@
         "paths": {
             "playcanvas": ["node_modules/playcanvas/build/playcanvas"],
             "pcui": ["node_modules/@playcanvas/pcui"]
-        }
+        },
+        "types": [
+            "@types/wicg-file-system-access"
+        ]
     },
     "include": ["./src/**/*.ts"],
     "exclude": ["node_modules", "**/*.js", "dist"]


### PR DESCRIPTION
This PR:
* adds initial support for loading and editing multiple splats
* place file handling under file menu popup (see screenshot below)
* use File System Api for loading and saving files when available 
    * grandad Safari still uses the old file download path
* update to playcanvas [engine v1.71.5](https://github.com/playcanvas/engine/releases/tag/v1.71.5)
* bump package minor version

<img width="1593" alt="Screenshot 2024-06-06 at 15 30 54" src="https://github.com/playcanvas/supersplat/assets/11276292/8960b97a-05e2-473b-8664-66e364acbeb8">
