### PR TITLE
Latest engine

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "supersplat",
-    "version": "0.25.0",
+    "version": "0.25.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "supersplat",
-            "version": "0.25.0",
+            "version": "0.25.1",
             "license": "MIT",
             "devDependencies": {
                 "@playcanvas/eslint-config": "^1.7.1",
@@ -26,7 +26,7 @@
                 "cross-env": "^7.0.3",
                 "eslint": "^8.56.0",
                 "jest": "^29.7.0",
-                "playcanvas": "^1.73.0",
+                "playcanvas": "^1.73.1",
                 "rollup": "^4.18.0",
                 "rollup-plugin-sass": "^1.13.0",
                 "rollup-plugin-visualizer": "^5.12.0",
@@ -6299,9 +6299,9 @@
             }
         },
         "node_modules/playcanvas": {
-            "version": "1.73.0",
-            "resolved": "https://registry.npmjs.org/playcanvas/-/playcanvas-1.73.0.tgz",
-            "integrity": "sha512-XYGu9IRHJyg38bwMwSgEMDXqfmXuZPLGBBv6P1udj9V7JzFL0kmT+2VEtejg+oecYNyvCEtie0LkG4bsrJSXrA==",
+            "version": "1.73.1",
+            "resolved": "https://registry.npmjs.org/playcanvas/-/playcanvas-1.73.1.tgz",
+            "integrity": "sha512-/1FZLtsbEkVR36ZNlonbVowDJHSnKy68adg0nsvf9CVS2y+5CR29S4mr8bnU1PmwYb+yvVY3wvNEkrgwadiLQg==",
             "dev": true,
             "dependencies": {
                 "@types/webxr": "^0.5.16",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "supersplat",
-    "version": "0.25.0",
+    "version": "0.25.1",
     "author": "PlayCanvas<support@playcanvas.com>",
     "homepage": "https://playcanvas.com/supersplat/editor",
     "description": "3D Gaussian Splat Editor",
@@ -68,7 +68,7 @@
         "cross-env": "^7.0.3",
         "eslint": "^8.56.0",
         "jest": "^29.7.0",
-        "playcanvas": "^1.73.0",
+        "playcanvas": "^1.73.1",
         "rollup": "^4.18.0",
         "rollup-plugin-sass": "^1.13.0",
         "rollup-plugin-visualizer": "^5.12.0",


### PR DESCRIPTION
This PR:
* update to latest engine [v1.73.1](https://github.com/playcanvas/engine/releases/tag/v1.73.1), which includes a bugfix for splats going missing after delete
* bump package version