### PR TITLE
Support spherical harmonics

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "supersplat",
-    "version": "1.1.0",
+    "version": "1.2.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "supersplat",
-            "version": "1.1.0",
+            "version": "1.2.0",
             "license": "MIT",
             "devDependencies": {
                 "@playcanvas/eslint-config": "^1.7.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "supersplat",
-    "version": "1.1.0",
+    "version": "1.2.0",
     "author": "PlayCanvas<support@playcanvas.com>",
     "homepage": "https://playcanvas.com/supersplat/editor",
     "description": "3D Gaussian Splat Editor",

--- a/src/camera.ts
+++ b/src/camera.ts
@@ -476,7 +476,7 @@ class Camera extends Element {
 
         const device = this.scene.graphicsDevice as WebglGraphicsDevice;
         const events = this.scene.events;
-        const alpha = events.invoke('camera.debug') && events.invoke('camera.mode') === 'rings' ? 0.0 : 0.2;
+        const alpha = events.invoke('camera.mode') === 'rings' ? 0.0 : 0.2;
 
         // hide non-selected elements
         const splats = this.scene.getElementsByType(ElementType.splat);

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -88,6 +88,10 @@ const registerEditorEvents = (events: Events, editHistory: EditHistory, scene: S
         scene.forceRender = true;
     });
 
+    events.on('view.bands', (bands: number) => {
+        scene.forceRender = true;
+    });
+
     const setGridVisible = (visible: boolean) => {
         if (visible !== scene.grid.visible) {
             scene.grid.visible = visible;
@@ -519,6 +523,25 @@ const registerEditorEvents = (events: Events, editHistory: EditHistory, scene: S
 
     events.on('camera.setSplatSize', (value: number) => {
         setSplatSize(value);
+    });
+
+    // view spherical harmonic bands
+
+    let viewBands = 0;
+
+    const setViewBands = (value: number) => {
+        if (value !== viewBands) {
+            viewBands = value;
+            events.fire('view.bands', viewBands);
+        }
+    };
+
+    events.function('view.bands', () => {
+        return viewBands;
+    });
+
+    events.on('view.setBands', (value: number) => {
+        setViewBands(value);
     });
 }
 

--- a/src/sh-utils.ts
+++ b/src/sh-utils.ts
@@ -1,0 +1,191 @@
+import { Mat3 } from 'playcanvas';
+
+const kSqrt03_02  = Math.sqrt( 3.0 /  2.0);
+const kSqrt01_03  = Math.sqrt( 1.0 /  3.0);
+const kSqrt02_03  = Math.sqrt( 2.0 /  3.0);
+const kSqrt04_03  = Math.sqrt( 4.0 /  3.0);
+const kSqrt01_04  = Math.sqrt( 1.0 /  4.0);
+const kSqrt03_04  = Math.sqrt( 3.0 /  4.0);
+const kSqrt01_05  = Math.sqrt( 1.0 /  5.0);
+const kSqrt03_05  = Math.sqrt( 3.0 /  5.0);
+const kSqrt06_05  = Math.sqrt( 6.0 /  5.0);
+const kSqrt08_05  = Math.sqrt( 8.0 /  5.0);
+const kSqrt09_05  = Math.sqrt( 9.0 /  5.0);
+const kSqrt01_06  = Math.sqrt( 1.0 /  6.0);
+const kSqrt05_06  = Math.sqrt( 5.0 /  6.0);
+const kSqrt03_08  = Math.sqrt( 3.0 /  8.0);
+const kSqrt05_08  = Math.sqrt( 5.0 /  8.0);
+const kSqrt09_08  = Math.sqrt( 9.0 /  8.0);
+const kSqrt05_09  = Math.sqrt( 5.0 /  9.0);
+const kSqrt08_09  = Math.sqrt( 8.0 /  9.0);
+const kSqrt01_10  = Math.sqrt( 1.0 / 10.0);
+const kSqrt03_10  = Math.sqrt( 3.0 / 10.0);
+const kSqrt01_12  = Math.sqrt( 1.0 / 12.0);
+const kSqrt04_15  = Math.sqrt( 4.0 / 15.0);
+const kSqrt01_16  = Math.sqrt( 1.0 / 16.0);
+const kSqrt15_16  = Math.sqrt(15.0 / 16.0);
+const kSqrt01_18  = Math.sqrt( 1.0 / 18.0);
+const kSqrt01_60  = Math.sqrt( 1.0 / 60.0);
+
+const dp = (start: number, n: number, a: number[] | Float32Array, b: number[] | Float32Array) => {
+    let sum = 0;
+    for (let i = 0; i < n; i++) {
+        sum += a[start + i] * b[i];
+    }
+    return sum;
+}
+
+const coeffsIn = new Float32Array(16);
+
+class SHRotation {
+    rotate: (coeffs: Float32Array, coeffsIn: Float32Array) => void;
+
+    constructor(mat: Mat3) {
+        const rot = mat.data;
+
+        // band 1
+        const sh1 = [
+            [ rot[4], rot[7], rot[1] ],
+            [ rot[5], rot[8], rot[2] ],
+            [ rot[3], rot[6], rot[0] ]
+        ];
+
+        // band 2
+        const sh2 = [[
+            kSqrt01_04 * ((sh1[2][2] * sh1[0][0] + sh1[2][0] * sh1[0][2]) + (sh1[0][2] * sh1[2][0] + sh1[0][0] * sh1[2][2])),
+                          (sh1[2][1] * sh1[0][0] + sh1[0][1] * sh1[2][0]),
+            kSqrt03_04 *  (sh1[2][1] * sh1[0][1] + sh1[0][1] * sh1[2][1]),
+                          (sh1[2][1] * sh1[0][2] + sh1[0][1] * sh1[2][2]),
+            kSqrt01_04 * ((sh1[2][2] * sh1[0][2] - sh1[2][0] * sh1[0][0]) + (sh1[0][2] * sh1[2][2] - sh1[0][0] * sh1[2][0]))
+        ], [
+            kSqrt01_04 * ((sh1[1][2] * sh1[0][0] + sh1[1][0] * sh1[0][2]) + (sh1[0][2] * sh1[1][0] + sh1[0][0] * sh1[1][2])),
+                           sh1[1][1] * sh1[0][0] + sh1[0][1] * sh1[1][0],
+            kSqrt03_04 *  (sh1[1][1] * sh1[0][1] + sh1[0][1] * sh1[1][1]),
+                           sh1[1][1] * sh1[0][2] + sh1[0][1] * sh1[1][2],
+            kSqrt01_04 * ((sh1[1][2] * sh1[0][2] - sh1[1][0] * sh1[0][0]) + (sh1[0][2] * sh1[1][2] - sh1[0][0] * sh1[1][0])),
+        ], [
+            kSqrt01_03 * (sh1[1][2] * sh1[1][0] + sh1[1][0] * sh1[1][2]) - kSqrt01_12 * ((sh1[2][2] * sh1[2][0] + sh1[2][0] * sh1[2][2]) + (sh1[0][2] * sh1[0][0] + sh1[0][0] * sh1[0][2])),
+            kSqrt04_03 *  sh1[1][1] * sh1[1][0] - kSqrt01_03 * (sh1[2][1] * sh1[2][0] + sh1[0][1] * sh1[0][0]),
+                          sh1[1][1] * sh1[1][1] - kSqrt01_04 * (sh1[2][1] * sh1[2][1] + sh1[0][1] * sh1[0][1]),
+            kSqrt04_03 *  sh1[1][1] * sh1[1][2] - kSqrt01_03 * (sh1[2][1] * sh1[2][2] + sh1[0][1] * sh1[0][2]),
+            kSqrt01_03 * (sh1[1][2] * sh1[1][2] - sh1[1][0] * sh1[1][0]) - kSqrt01_12 * ((sh1[2][2] * sh1[2][2] - sh1[2][0] * sh1[2][0]) + (sh1[0][2] * sh1[0][2] - sh1[0][0] * sh1[0][0])),
+        ], [
+            kSqrt01_04 * ((sh1[1][2] * sh1[2][0] + sh1[1][0] * sh1[2][2]) + (sh1[2][2] * sh1[1][0] + sh1[2][0] * sh1[1][2])),
+                           sh1[1][1] * sh1[2][0] + sh1[2][1] * sh1[1][0],
+            kSqrt03_04 *  (sh1[1][1] * sh1[2][1] + sh1[2][1] * sh1[1][1]),
+                           sh1[1][1] * sh1[2][2] + sh1[2][1] * sh1[1][2],
+            kSqrt01_04 * ((sh1[1][2] * sh1[2][2] - sh1[1][0] * sh1[2][0]) + (sh1[2][2] * sh1[1][2] - sh1[2][0] * sh1[1][0])),
+        ], [
+            kSqrt01_04 * ((sh1[2][2] * sh1[2][0] + sh1[2][0] * sh1[2][2]) - (sh1[0][2] * sh1[0][0] + sh1[0][0] * sh1[0][2])),
+                          (sh1[2][1] * sh1[2][0] - sh1[0][1] * sh1[0][0]),
+            kSqrt03_04 *  (sh1[2][1] * sh1[2][1] - sh1[0][1] * sh1[0][1]),
+                          (sh1[2][1] * sh1[2][2] - sh1[0][1] * sh1[0][2]),
+            kSqrt01_04 * ((sh1[2][2] * sh1[2][2] - sh1[2][0] * sh1[2][0]) - (sh1[0][2] * sh1[0][2] - sh1[0][0] * sh1[0][0])),
+        ]];
+
+        // band 3
+        const sh3 = [[
+            kSqrt01_04 * ((sh1[2][2] * sh2[0][0] + sh1[2][0] * sh2[0][4]) + (sh1[0][2] * sh2[4][0] + sh1[0][0] * sh2[4][4])),
+            kSqrt03_02 *  (sh1[2][1] * sh2[0][0] + sh1[0][1] * sh2[4][0]),
+            kSqrt15_16 *  (sh1[2][1] * sh2[0][1] + sh1[0][1] * sh2[4][1]),
+            kSqrt05_06 *  (sh1[2][1] * sh2[0][2] + sh1[0][1] * sh2[4][2]),
+            kSqrt15_16 *  (sh1[2][1] * sh2[0][3] + sh1[0][1] * sh2[4][3]),
+            kSqrt03_02 *  (sh1[2][1] * sh2[0][4] + sh1[0][1] * sh2[4][4]),
+            kSqrt01_04 * ((sh1[2][2] * sh2[0][4] - sh1[2][0] * sh2[0][0]) + (sh1[0][2] * sh2[4][4] - sh1[0][0] * sh2[4][0])),
+        ], [
+            kSqrt01_06 * (sh1[1][2] * sh2[0][0] + sh1[1][0] * sh2[0][4]) + kSqrt01_06 * ((sh1[2][2] * sh2[1][0] + sh1[2][0] * sh2[1][4]) + (sh1[0][2] * sh2[3][0] + sh1[0][0] * sh2[3][4])),
+                          sh1[1][1] * sh2[0][0]                          +               (sh1[2][1] * sh2[1][0] + sh1[0][1] * sh2[3][0]),
+            kSqrt05_08 *  sh1[1][1] * sh2[0][1]                          + kSqrt05_08 *  (sh1[2][1] * sh2[1][1] + sh1[0][1] * sh2[3][1]),
+            kSqrt05_09 *  sh1[1][1] * sh2[0][2]                          + kSqrt05_09 *  (sh1[2][1] * sh2[1][2] + sh1[0][1] * sh2[3][2]),
+            kSqrt05_08 *  sh1[1][1] * sh2[0][3]                          + kSqrt05_08 *  (sh1[2][1] * sh2[1][3] + sh1[0][1] * sh2[3][3]),
+                          sh1[1][1] * sh2[0][4]                          +               (sh1[2][1] * sh2[1][4] + sh1[0][1] * sh2[3][4]),
+            kSqrt01_06 * (sh1[1][2] * sh2[0][4] - sh1[1][0] * sh2[0][0]) + kSqrt01_06 * ((sh1[2][2] * sh2[1][4] - sh1[2][0] * sh2[1][0]) + (sh1[0][2] * sh2[3][4] - sh1[0][0] * sh2[3][0])),
+        ], [
+            kSqrt04_15 * (sh1[1][2] * sh2[1][0] + sh1[1][0] * sh2[1][4]) + kSqrt01_05 * (sh1[0][2] * sh2[2][0] + sh1[0][0] * sh2[2][4]) - kSqrt01_60 * ((sh1[2][2] * sh2[0][0] + sh1[2][0] * sh2[0][4]) - (sh1[0][2] * sh2[4][0] + sh1[0][0] * sh2[4][4])),
+            kSqrt08_05 *  sh1[1][1] * sh2[1][0]                          + kSqrt06_05 *  sh1[0][1] * sh2[2][0] - kSqrt01_10 * (sh1[2][1] * sh2[0][0] - sh1[0][1] * sh2[4][0]),
+                          sh1[1][1] * sh2[1][1]                          + kSqrt03_04 *  sh1[0][1] * sh2[2][1] - kSqrt01_16 * (sh1[2][1] * sh2[0][1] - sh1[0][1] * sh2[4][1]),
+            kSqrt08_09 *  sh1[1][1] * sh2[1][2]                          + kSqrt02_03 *  sh1[0][1] * sh2[2][2] - kSqrt01_18 * (sh1[2][1] * sh2[0][2] - sh1[0][1] * sh2[4][2]),
+                          sh1[1][1] * sh2[1][3]                          + kSqrt03_04 *  sh1[0][1] * sh2[2][3] - kSqrt01_16 * (sh1[2][1] * sh2[0][3] - sh1[0][1] * sh2[4][3]),
+            kSqrt08_05 *  sh1[1][1] * sh2[1][4]                          + kSqrt06_05 *  sh1[0][1] * sh2[2][4] - kSqrt01_10 * (sh1[2][1] * sh2[0][4] - sh1[0][1] * sh2[4][4]),
+            kSqrt04_15 * (sh1[1][2] * sh2[1][4] - sh1[1][0] * sh2[1][0]) + kSqrt01_05 * (sh1[0][2] * sh2[2][4] - sh1[0][0] * sh2[2][0]) - kSqrt01_60 * ((sh1[2][2] * sh2[0][4] - sh1[2][0] * sh2[0][0]) - (sh1[0][2] * sh2[4][4] - sh1[0][0] * sh2[4][0])),
+        ], [
+            kSqrt03_10 * (sh1[1][2] * sh2[2][0] + sh1[1][0] * sh2[2][4]) - kSqrt01_10 * ((sh1[2][2] * sh2[3][0] + sh1[2][0] * sh2[3][4]) + (sh1[0][2] * sh2[1][0] + sh1[0][0] * sh2[1][4])),
+            kSqrt09_05 *  sh1[1][1] * sh2[2][0]                          - kSqrt03_05 *  (sh1[2][1] * sh2[3][0] + sh1[0][1] * sh2[1][0]),
+            kSqrt09_08 *  sh1[1][1] * sh2[2][1]                          - kSqrt03_08 *  (sh1[2][1] * sh2[3][1] + sh1[0][1] * sh2[1][1]),
+                          sh1[1][1] * sh2[2][2]                          - kSqrt01_03 *  (sh1[2][1] * sh2[3][2] + sh1[0][1] * sh2[1][2]),
+            kSqrt09_08 *  sh1[1][1] * sh2[2][3]                          - kSqrt03_08 *  (sh1[2][1] * sh2[3][3] + sh1[0][1] * sh2[1][3]),
+            kSqrt09_05 *  sh1[1][1] * sh2[2][4]                          - kSqrt03_05 *  (sh1[2][1] * sh2[3][4] + sh1[0][1] * sh2[1][4]),
+            kSqrt03_10 * (sh1[1][2] * sh2[2][4] - sh1[1][0] * sh2[2][0]) - kSqrt01_10 * ((sh1[2][2] * sh2[3][4] - sh1[2][0] * sh2[3][0]) + (sh1[0][2] * sh2[1][4] - sh1[0][0] * sh2[1][0])),
+        ], [
+            kSqrt04_15 * (sh1[1][2] * sh2[3][0] + sh1[1][0] * sh2[3][4]) + kSqrt01_05 * (sh1[2][2] * sh2[2][0] + sh1[2][0] * sh2[2][4]) - kSqrt01_60 * ((sh1[2][2] * sh2[4][0] + sh1[2][0] * sh2[4][4]) + (sh1[0][2] * sh2[0][0] + sh1[0][0] * sh2[0][4])),
+            kSqrt08_05 *  sh1[1][1] * sh2[3][0]                          + kSqrt06_05 *  sh1[2][1] * sh2[2][0] - kSqrt01_10 * (sh1[2][1] * sh2[4][0] + sh1[0][1] * sh2[0][0]),
+                          sh1[1][1] * sh2[3][1]                          + kSqrt03_04 *  sh1[2][1] * sh2[2][1] - kSqrt01_16 * (sh1[2][1] * sh2[4][1] + sh1[0][1] * sh2[0][1]),
+            kSqrt08_09 *  sh1[1][1] * sh2[3][2]                          + kSqrt02_03 *  sh1[2][1] * sh2[2][2] - kSqrt01_18 * (sh1[2][1] * sh2[4][2] + sh1[0][1] * sh2[0][2]),
+                          sh1[1][1] * sh2[3][3]                          + kSqrt03_04 *  sh1[2][1] * sh2[2][3] - kSqrt01_16 * (sh1[2][1] * sh2[4][3] + sh1[0][1] * sh2[0][3]),
+            kSqrt08_05 *  sh1[1][1] * sh2[3][4]                          + kSqrt06_05 *  sh1[2][1] * sh2[2][4] - kSqrt01_10 * (sh1[2][1] * sh2[4][4] + sh1[0][1] * sh2[0][4]),
+            kSqrt04_15 * (sh1[1][2] * sh2[3][4] - sh1[1][0] * sh2[3][0]) + kSqrt01_05 * (sh1[2][2] * sh2[2][4] - sh1[2][0] * sh2[2][0]) - kSqrt01_60 * ((sh1[2][2] * sh2[4][4] - sh1[2][0] * sh2[4][0]) + (sh1[0][2] * sh2[0][4] - sh1[0][0] * sh2[0][0])),
+        ], [
+            kSqrt01_06 * (sh1[1][2] * sh2[4][0] + sh1[1][0] * sh2[4][4]) + kSqrt01_06 * ((sh1[2][2] * sh2[3][0] + sh1[2][0] * sh2[3][4]) - (sh1[0][2] * sh2[1][0] + sh1[0][0] * sh2[1][4])),
+                          sh1[1][1] * sh2[4][0]                          +               (sh1[2][1] * sh2[3][0] - sh1[0][1] * sh2[1][0]),
+            kSqrt05_08 *  sh1[1][1] * sh2[4][1]                          + kSqrt05_08 *  (sh1[2][1] * sh2[3][1] - sh1[0][1] * sh2[1][1]),
+            kSqrt05_09 *  sh1[1][1] * sh2[4][2]                          + kSqrt05_09 *  (sh1[2][1] * sh2[3][2] - sh1[0][1] * sh2[1][2]),
+            kSqrt05_08 *  sh1[1][1] * sh2[4][3]                          + kSqrt05_08 *  (sh1[2][1] * sh2[3][3] - sh1[0][1] * sh2[1][3]),
+                          sh1[1][1] * sh2[4][4]                          +               (sh1[2][1] * sh2[3][4] - sh1[0][1] * sh2[1][4]),
+            kSqrt01_06 * (sh1[1][2] * sh2[4][4] - sh1[1][0] * sh2[4][0]) + kSqrt01_06 * ((sh1[2][2] * sh2[3][4] - sh1[2][0] * sh2[3][0]) - (sh1[0][2] * sh2[1][4] - sh1[0][0] * sh2[1][0])),
+        ], [
+            kSqrt01_04 * ((sh1[2][2] * sh2[4][0] + sh1[2][0] * sh2[4][4]) - (sh1[0][2] * sh2[0][0] + sh1[0][0] * sh2[0][4])),
+            kSqrt03_02 *  (sh1[2][1] * sh2[4][0] - sh1[0][1] * sh2[0][0]),
+            kSqrt15_16 *  (sh1[2][1] * sh2[4][1] - sh1[0][1] * sh2[0][1]),
+            kSqrt05_06 *  (sh1[2][1] * sh2[4][2] - sh1[0][1] * sh2[0][2]),
+            kSqrt15_16 *  (sh1[2][1] * sh2[4][3] - sh1[0][1] * sh2[0][3]),
+            kSqrt03_02 *  (sh1[2][1] * sh2[4][4] - sh1[0][1] * sh2[0][4]),
+            kSqrt01_04 * ((sh1[2][2] * sh2[4][4] - sh1[2][0] * sh2[4][0]) - (sh1[0][2] * sh2[0][4] - sh1[0][0] * sh2[0][0])),
+        ]];
+
+        // rotate spherical harmonic coefficients, up to band 3
+        this.rotate = (coeffs: Float32Array, src?: Float32Array) => {
+            if (!src || src == coeffs) {
+                coeffsIn.set(coeffs);
+                src = coeffsIn;
+            }
+
+            let idx = 0;
+
+            // band 0
+            coeffs[idx] = src[idx];
+            if (coeffs.length < 4) {
+                return;
+            }
+            idx++;
+
+            // band 1
+            coeffs[1] = dp(idx, 3, src, sh1[0]);
+            coeffs[2] = dp(idx, 3, src, sh1[1]);
+            coeffs[3] = dp(idx, 3, src, sh1[2]);
+            if (coeffs.length < 9)
+                return;
+            idx += 3;
+
+            // band 2
+            coeffs[4] = dp(idx, 5, src, sh2[0]);
+            coeffs[5] = dp(idx, 5, src, sh2[1]);
+            coeffs[6] = dp(idx, 5, src, sh2[2]);
+            coeffs[7] = dp(idx, 5, src, sh2[3]);
+            coeffs[8] = dp(idx, 5, src, sh2[4]);
+            if (coeffs.length < 16)
+                return;
+            idx += 5;
+
+            // band 3
+            coeffs[9]  = dp(idx, 7, src, sh3[0]);
+            coeffs[10] = dp(idx, 7, src, sh3[1]);
+            coeffs[11] = dp(idx, 7, src, sh3[2]);
+            coeffs[12] = dp(idx, 7, src, sh3[3]);
+            coeffs[13] = dp(idx, 7, src, sh3[4]);
+            coeffs[14] = dp(idx, 7, src, sh3[5]);
+            coeffs[15] = dp(idx, 7, src, sh3[6]);
+        };
+    }
+}
+
+export { SHRotation };

--- a/src/sh-utils.ts
+++ b/src/sh-utils.ts
@@ -27,7 +27,7 @@ const kSqrt15_16  = Math.sqrt(15.0 / 16.0);
 const kSqrt01_18  = Math.sqrt( 1.0 / 18.0);
 const kSqrt01_60  = Math.sqrt( 1.0 / 60.0);
 
-const dp = (start: number, n: number, a: number[] | Float32Array, b: number[] | Float32Array) => {
+const dp = (n: number, start: number, a: number[] | Float32Array, b: number[] | Float32Array) => {
     let sum = 0;
     for (let i = 0; i < n; i++) {
         sum += a[start + i] * b[i];
@@ -38,16 +38,16 @@ const dp = (start: number, n: number, a: number[] | Float32Array, b: number[] | 
 const coeffsIn = new Float32Array(16);
 
 class SHRotation {
-    rotate: (coeffs: Float32Array | number[], coeffsIn: Float32Array | number[]) => void;
+    rotate: (result: Float32Array | number[], src?: Float32Array | number[]) => void;
 
     constructor(mat: Mat3) {
         const rot = mat.data;
 
         // band 1
         const sh1 = [
-            [ rot[4], rot[7], rot[1] ],
-            [ rot[5], rot[8], rot[2] ],
-            [ rot[3], rot[6], rot[0] ]
+            [ rot[4],-rot[7], rot[1] ],
+            [-rot[5], rot[8],-rot[2] ],
+            [ rot[3],-rot[6], rot[0] ]
         ];
 
         // band 2
@@ -143,47 +143,42 @@ class SHRotation {
         ]];
 
         // rotate spherical harmonic coefficients, up to band 3
-        this.rotate = (coeffs: Float32Array, src?: Float32Array) => {
-            if (!src || src == coeffs) {
-                coeffsIn.set(coeffs);
+        this.rotate = (result: Float32Array | number[], src?: Float32Array | number[]) => {
+            if (!src || src == result) {
+                coeffsIn.set(result);
                 src = coeffsIn;
             }
 
-            let idx = 0;
-
             // band 0
-            coeffs[idx] = src[idx];
-            if (coeffs.length < 4) {
-                return;
-            }
-            idx++;
+            result[0] = src[0];
 
             // band 1
-            coeffs[1] = dp(idx, 3, src, sh1[0]);
-            coeffs[2] = dp(idx, 3, src, sh1[1]);
-            coeffs[3] = dp(idx, 3, src, sh1[2]);
-            if (coeffs.length < 9)
+            if (result.length < 4) {
                 return;
-            idx += 3;
+            }
+            result[1] = dp(3, 1, src, sh1[0]);
+            result[2] = dp(3, 1, src, sh1[1]);
+            result[3] = dp(3, 1, src, sh1[2]);
 
             // band 2
-            coeffs[4] = dp(idx, 5, src, sh2[0]);
-            coeffs[5] = dp(idx, 5, src, sh2[1]);
-            coeffs[6] = dp(idx, 5, src, sh2[2]);
-            coeffs[7] = dp(idx, 5, src, sh2[3]);
-            coeffs[8] = dp(idx, 5, src, sh2[4]);
-            if (coeffs.length < 16)
+            if (result.length < 9)
                 return;
-            idx += 5;
+            result[4] = dp(5, 4, src, sh2[0]);
+            result[5] = dp(5, 4, src, sh2[1]);
+            result[6] = dp(5, 4, src, sh2[2]);
+            result[7] = dp(5, 4, src, sh2[3]);
+            result[8] = dp(5, 4, src, sh2[4]);
 
             // band 3
-            coeffs[9]  = dp(idx, 7, src, sh3[0]);
-            coeffs[10] = dp(idx, 7, src, sh3[1]);
-            coeffs[11] = dp(idx, 7, src, sh3[2]);
-            coeffs[12] = dp(idx, 7, src, sh3[3]);
-            coeffs[13] = dp(idx, 7, src, sh3[4]);
-            coeffs[14] = dp(idx, 7, src, sh3[5]);
-            coeffs[15] = dp(idx, 7, src, sh3[6]);
+            if (result.length < 16)
+                return;
+            result[9]  = dp(7, 9, src, sh3[0]);
+            result[10] = dp(7, 9, src, sh3[1]);
+            result[11] = dp(7, 9, src, sh3[2]);
+            result[12] = dp(7, 9, src, sh3[3]);
+            result[13] = dp(7, 9, src, sh3[4]);
+            result[14] = dp(7, 9, src, sh3[5]);
+            result[15] = dp(7, 9, src, sh3[6]);
         };
     }
 }

--- a/src/sh-utils.ts
+++ b/src/sh-utils.ts
@@ -42,7 +42,7 @@ const coeffsIn = new Float32Array(16);
 // This implementation calculates the rotation factors during construction which can then
 // be used to rotate multiple spherical harmonics cheaply.
 class SHRotation {
-    rotate: (result: Float32Array | number[], src?: Float32Array | number[]) => void;
+    apply: (result: Float32Array | number[], src?: Float32Array | number[]) => void;
 
     constructor(mat: Mat3) {
         const rot = mat.data;
@@ -147,7 +147,7 @@ class SHRotation {
         ]];
 
         // rotate spherical harmonic coefficients, up to band 3
-        this.rotate = (result: Float32Array | number[], src?: Float32Array | number[]) => {
+        this.apply = (result: Float32Array | number[], src?: Float32Array | number[]) => {
             if (!src || src == result) {
                 coeffsIn.set(result);
                 src = coeffsIn;

--- a/src/sh-utils.ts
+++ b/src/sh-utils.ts
@@ -37,6 +37,9 @@ const dp = (n: number, start: number, a: number[] | Float32Array, b: number[] | 
 
 const coeffsIn = new Float32Array(16);
 
+// Rotate spherical harmonics up to band 3
+// Calculates the rotation factors once which can then be applied to multiple spherical
+// harmonics.
 class SHRotation {
     rotate: (result: Float32Array | number[], src?: Float32Array | number[]) => void;
 

--- a/src/sh-utils.ts
+++ b/src/sh-utils.ts
@@ -38,7 +38,7 @@ const dp = (start: number, n: number, a: number[] | Float32Array, b: number[] | 
 const coeffsIn = new Float32Array(16);
 
 class SHRotation {
-    rotate: (coeffs: Float32Array, coeffsIn: Float32Array) => void;
+    rotate: (coeffs: Float32Array | number[], coeffsIn: Float32Array | number[]) => void;
 
     constructor(mat: Mat3) {
         const rot = mat.data;

--- a/src/sh-utils.ts
+++ b/src/sh-utils.ts
@@ -37,9 +37,10 @@ const dp = (n: number, start: number, a: number[] | Float32Array, b: number[] | 
 
 const coeffsIn = new Float32Array(16);
 
-// Rotate spherical harmonics up to band 3
-// Calculates the rotation factors once which can then be applied to multiple spherical
-// harmonics.
+// Rotate spherical harmonics up to band 3 based on https://github.com/andrewwillmott/sh-lib
+//
+// This implementation calculates the rotation factors during construction which can then
+// be used to rotate multiple spherical harmonics cheaply.
 class SHRotation {
     rotate: (result: Float32Array | number[], src?: Float32Array | number[]) => void;
 

--- a/src/splat-convert.ts
+++ b/src/splat-convert.ts
@@ -1,10 +1,12 @@
 import {
     GSplatData,
+    Mat3,
     Mat4,
     Quat,
     Vec3
 } from 'playcanvas';
 import { State } from './edit-ops';
+import { SHRotation } from './sh-utils';
 
 interface ConvertEntry {
     splatData: GSplatData;
@@ -42,6 +44,7 @@ const getCommonPropNames = (convertData: ConvertEntry[]) => {
 };
 
 const mat = new Mat4();
+const mat3 = new Mat3();
 const quat = new Quat();
 const scale = new Vec3();
 const v = new Vec3();
@@ -58,6 +61,12 @@ const convertPly = (convertData: ConvertEntry[]) => {
     const hasPosition = ['x', 'y', 'z'].every(v => propNames.includes(v));
     const hasRotation = ['rot_0', 'rot_1', 'rot_2', 'rot_3'].every(v => propNames.includes(v));
     const hasScale = ['scale_0', 'scale_1', 'scale_2'].every(v => propNames.includes(v));
+    const hasSH = (() => {
+        for (let i = 0; i < 45; ++i) {
+            if (!propNames.includes(`f_rest_${i}`)) return false;
+        }
+        return true;
+    })();
 
     const headerText = [
         `ply`,
@@ -95,6 +104,24 @@ const convertPly = (convertData: ConvertEntry[]) => {
         quat.setFromMat4(mat);
         mat.getScale(scale);
 
+        let shRot;
+        let shData;
+        let shCoeffs: number[];
+        if (hasSH) {
+            mat3.setFromQuat(quat);
+
+            // initialize sh rotation helper
+            shRot = new SHRotation(mat3);
+
+            // get sh coefficients
+            shData = [];
+            for (let i = 0; i < 45; ++i) {
+                shData.push(splatData.getProp(`f_rest_${i}`));
+            }
+
+            shCoeffs = [0];
+        }
+
         for (let i = 0; i < splatData.numSplats; ++i) {
             if ((state[i] & State.deleted) === State.deleted) continue;
 
@@ -121,7 +148,19 @@ const convertPly = (convertData: ConvertEntry[]) => {
                 splat.scale_2 = Math.log(Math.exp(splat.scale_2) * scale.z);
             }
 
-            // TODO: transform spherical harmonics
+            if (hasSH) {
+                for (let c = 0; c < 3; ++c) {
+                    for (let d = 0; d < 15; ++d) {
+                        shCoeffs[d + 1] = shData[c * 15 + d][i];
+                    }
+
+                    shRot.rotate(shCoeffs, shCoeffs);
+
+                    for (let d = 0; d < 15; ++d) {
+                        splat[`f_rest_${c * 15 + d}`] = shCoeffs[d + 1];
+                    }
+                }
+            }
 
             // write
             for (let j = 0; j < propNames.length; ++j) {

--- a/src/splat-convert.ts
+++ b/src/splat-convert.ts
@@ -154,7 +154,7 @@ const convertPly = (convertData: ConvertEntry[]) => {
                         shCoeffs[d + 1] = shData[c * 15 + d][i];
                     }
 
-                    shRot.rotate(shCoeffs, shCoeffs);
+                    shRot.apply(shCoeffs, shCoeffs);
 
                     for (let d = 0; d < 15; ++d) {
                         splat[`f_rest_${c * 15 + d}`] = shCoeffs[d + 1];

--- a/src/splat.ts
+++ b/src/splat.ts
@@ -368,7 +368,7 @@ class Splat extends Element {
                         sh[d + 1] = src[c * 15 + d][i];
                     }
 
-                    rot.rotate(sh, sh);
+                    rot.apply(sh, sh);
 
                     for (let d = 0; d < 15; ++d) {
                         src[c * 15 + d][i] = sh[d + 1];

--- a/src/ui/view-panel.ts
+++ b/src/ui/view-panel.ts
@@ -36,18 +36,39 @@ class ViewPanel extends Container {
         header.append(icon);
         header.append(label);
 
-        // centers size
-
-        const splatSizeRow = new Container({
+        // sh bands
+        const shBandsRow = new Container({
             class: 'view-panel-row'
         });
 
-        const splatSizeLabel = new Label({
+        const shBandsLabel = new Label({
+            text: 'SH Bands',
+            class: 'view-panel-row-label'
+        });
+
+        const shBandsSlider = new SliderInput({
+            class: 'view-panel-row-slider',
+            min: 0,
+            max: 3,
+            precision: 0,
+            value: 0
+        });
+
+        shBandsRow.append(shBandsLabel);
+        shBandsRow.append(shBandsSlider);
+
+        // centers size
+
+        const centersSizeRow = new Container({
+            class: 'view-panel-row'
+        });
+
+        const centersSizeLabel = new Label({
             text: 'Centers Size',
             class: 'view-panel-row-label'
         });
 
-        const splatSizeSlider = new SliderInput({
+        const centersSizeSlider = new SliderInput({
             class: 'view-panel-row-slider',
             min: 0,
             max: 10,
@@ -55,8 +76,8 @@ class ViewPanel extends Container {
             value: 2
         });
 
-        splatSizeRow.append(splatSizeLabel);
-        splatSizeRow.append(splatSizeSlider);
+        centersSizeRow.append(centersSizeLabel);
+        centersSizeRow.append(centersSizeSlider);
 
         // show grid
 
@@ -79,7 +100,8 @@ class ViewPanel extends Container {
         showGridRow.append(showGridToggle);
 
         this.append(header);
-        this.append(splatSizeRow);
+        this.append(shBandsRow);
+        this.append(centersSizeRow);
         this.append(showGridRow);
 
         // handle panel visibility
@@ -103,13 +125,23 @@ class ViewPanel extends Container {
             setVisible(this.hidden);
         });
 
+        // sh bands
+
+        events.on('view.bands', (bands: number) => {
+            shBandsSlider.value = bands;
+        });
+
+        shBandsSlider.on('change', (value: number) => {
+            events.fire('view.setBands', value);
+        });
+
         // splat size
 
         events.on('camera.splatSize', (value: number) => {
-            splatSizeSlider.value = value;
+            centersSizeSlider.value = value;
         });
 
-        splatSizeSlider.on('change', (value: number) => {
+        centersSizeSlider.on('change', (value: number) => {
             events.fire('camera.setSplatSize', value);
             events.fire('camera.setDebug', true);
             events.fire('camera.setMode', 'centers');


### PR DESCRIPTION
Fixes: #159

This PR:
* adds option to render with spherical harmonics
    * available under view panel
* rotates spherical harmonics correctly on export
* bump package to version v1.2.0

Without spherical harmonics:
<img width="1571" alt="Screenshot 2024-08-16 at 16 49 33" src="https://github.com/user-attachments/assets/9ab3a53e-7ddb-4b4c-8a33-743817f7599e">

With spherical harmonics:
<img width="1571" alt="Screenshot 2024-08-16 at 16 49 36" src="https://github.com/user-attachments/assets/50da7189-b0f7-4a23-8d4e-4843cdb030c3">
