### PR TITLE
Camera cleanup

### DIFF
--- a/src/camera.ts
+++ b/src/camera.ts
@@ -226,14 +226,7 @@ class Camera extends Element {
         const { width, height } = this.scene.targetSize;
         this.picker = new Picker(this.scene.app, width, height);
 
-        // handle the scene's bound changing. the camera must be configured to render
-        // the entire extents as well as possible.
-        // also update the existing camera distance to maintain the current view
-        this.scene.events.on('scene.boundChanged', (bound: BoundingBox) => {
-            const prevDistance = this.distanceTween.value.distance * this.sceneRadius;
-            this.sceneRadius = bound.halfExtents.length();
-            this.setDistance(prevDistance / this.sceneRadius, 0);
-        });
+        this.scene.events.on('scene.boundChanged', this.onBoundChanged, this);
     }
 
     remove() {
@@ -246,6 +239,17 @@ class Camera extends Element {
         // destroy doesn't exist on picker?
         // this.picker.destroy();
         this.picker = null;
+
+        this.scene.events.off('scene.boundChanged', this.onBoundChanged, this);
+    }
+
+    // handle the scene's bound changing. the camera must be configured to render
+    // the entire extents as well as possible.
+    // also update the existing camera distance to maintain the current view
+    onBoundChanged(bound: BoundingBox) {
+        const prevDistance = this.distanceTween.value.distance * this.sceneRadius;
+        this.sceneRadius = bound.halfExtents.length();
+        this.setDistance(prevDistance / this.sceneRadius, 0);
     }
 
     serialize(serializer: Serializer) {

--- a/src/controllers.ts
+++ b/src/controllers.ts
@@ -24,7 +24,7 @@ class PointerController {
             // For panning to work at any zoom level, we use screen point to world projection
             // to work out how far we need to pan the pivotEntity in world space
             const c = camera.entity.camera;
-            const distance = camera.focusDistance * camera.distanceTween.value.distance;
+            const distance = camera.sceneRadius * camera.distanceTween.value.distance;
 
             c.screenToWorld(x, y, distance, fromWorldPoint);
             c.screenToWorld(x - dx, y - dy, distance, toWorldPoint);
@@ -179,7 +179,7 @@ class PointerController {
             const z = keys.ArrowDown - keys.ArrowUp;
 
             if (x || z) {
-                const factor = deltaTime * camera.distance * camera.focusDistance * 20;
+                const factor = deltaTime * camera.distance * camera.sceneRadius * 20;
                 const worldTransform = camera.entity.getWorldTransform();
                 const xAxis = worldTransform.getX().mulScalar(x * factor);
                 const zAxis = worldTransform.getZ().mulScalar(z * factor);

--- a/src/controllers.ts
+++ b/src/controllers.ts
@@ -24,7 +24,7 @@ class PointerController {
             // For panning to work at any zoom level, we use screen point to world projection
             // to work out how far we need to pan the pivotEntity in world space
             const c = camera.entity.camera;
-            const distance = camera.sceneRadius * camera.distanceTween.value.distance;
+            const distance = camera.distanceTween.value.distance * camera.sceneRadius / camera.fovFactor;
 
             c.screenToWorld(x, y, distance, fromWorldPoint);
             c.screenToWorld(x - dx, y - dy, distance, toWorldPoint);

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -163,7 +163,7 @@ const registerEditorEvents = (events: Events, editHistory: EditHistory, scene: S
 
             scene.camera.focus({
                 focalPoint: vec,
-                distance: aabb.halfExtents.length() * vec2.x / scene.bound.halfExtents.length()
+                radius: aabb.halfExtents.length() * vec2.x
             });
         }
     });

--- a/src/scene-config.ts
+++ b/src/scene-config.ts
@@ -22,7 +22,6 @@ const sceneConfig = {
         pixelScale: 1,
         multisample: false,
         fov: 50,
-        dollyZoom: true,
         exposure: 1.0,
         toneMapping: 'linear',
         debug_render: ''
@@ -32,9 +31,6 @@ const sceneConfig = {
         fade: true
     },
     controls: {
-        enableRotate: true, // enableOrbit
-        enablePan: true,
-        enableZoom: true,
         dampingFactor: 0.2,
         minPolarAngle: 0,
         maxPolarAngle: Math.PI,
@@ -43,15 +39,8 @@ const sceneConfig = {
         initialAzim: -45,
         initialElev: -10,
         initialZoom: 1.0,
-        autoRotate: false,
-        autoRotateSpeed: -2.0,
-        autoRotateInitialDelay: 0.0,
-        autoRotateDelay: 5.0,
         orbitSensitivity: 0.3,
         zoomSensitivity: 0.4
-    },
-    animation: {
-        autoPlay: false
     },
     debug: {
         showBound: false

--- a/src/scene.ts
+++ b/src/scene.ts
@@ -287,7 +287,7 @@ class Scene {
             });
 
             this.boundDirty = false;
-            this.events.fire('scene.boundChanged');
+            this.events.fire('scene.boundChanged', this.boundStorage);
         }
 
         return this.boundStorage;

--- a/src/splat.ts
+++ b/src/splat.ts
@@ -155,14 +155,6 @@ void main(void)
         return;
     }
 
-    // get splat state, discard if it's deleted (this should not happen as we filter out
-    // deleted splats from sorting and rendering anyway)
-    vertexState = uint(texelFetch(splatState, splatUV, 0).r * 255.0);
-    if ((vertexState & 4u) == 4u) {
-        gl_Position = discardVec;
-        return;
-    }
-
     // read splat data
     readData();
 
@@ -175,6 +167,7 @@ void main(void)
     gl_Position = pos;
 
     texCoord = vertex_position.xy;
+    vertexState = uint(texelFetch(splatState, splatUV, 0).r * 255.0);
 
     vec4 worldPos = matrix_model * vec4(center, 1.0);
     vec3 worldDir = worldPos.xyz / worldPos.w - view_position;

--- a/src/splat.ts
+++ b/src/splat.ts
@@ -155,7 +155,15 @@ void main(void)
         return;
     }
 
-    // read data
+    // get splat state, discard if it's deleted (this should not happen as we filter out
+    // deleted splats from sorting and rendering anyway)
+    vertexState = uint(texelFetch(splatState, splatUV, 0).r * 255.0);
+    if ((vertexState & 4u) == 4u) {
+        gl_Position = discardVec;
+        return;
+    }
+
+    // read splat data
     readData();
 
     vec4 pos;
@@ -168,17 +176,15 @@ void main(void)
 
     texCoord = vertex_position.xy;
 
-    #ifndef DITHER_NONE
-        id = float(splatId);
-    #endif
-
-    vertexState = uint(texelFetch(splatState, splatUV, 0).r * 255.0);
-
     vec4 worldPos = matrix_model * vec4(center, 1.0);
     vec3 worldDir = worldPos.xyz / worldPos.w - view_position;
     vec3 modelDir = normalize(worldDir * mat3(matrix_model));
 
     color = evalColor(modelDir);
+
+    #ifndef DITHER_NONE
+        id = float(splatId);
+    #endif
 
     #ifdef PICK_PASS
         vertexId = splatId;
@@ -200,11 +206,6 @@ float PI = 3.14159;
 
 void main(void)
 {
-    if ((vertexState & 4u) == 4u) {
-        // deleted
-        discard;
-    }
-
     float A = dot(texCoord, texCoord);
     if (A > 4.0) {
         discard;
@@ -228,7 +229,7 @@ void main(void)
         float alpha;
 
         if ((vertexState & 2u) == 2u) {
-            // hidden
+            // frozen/hidden
             c = vec3(0.0, 0.0, 0.0);
             alpha = B * 0.05;
         } else {
@@ -240,14 +241,16 @@ void main(void)
                 c = color.xyz;
             }
 
-            alpha = B;
-
             if (ringSize > 0.0) {
+                // rings mode
                 if (A < 4.0 - ringSize * 4.0) {
                     alpha = max(0.05, B);
                 } else {
                     alpha = 0.6;
                 }
+            } else {
+                // centers mode
+                alpha = B;
             }
         }
 


### PR DESCRIPTION
This PR updates the camera implementation in preparation for #176 

The following changes are made:
- remove legacy config and camera implementation for options we no longer need or use (enable flags/auto rotate)
- handle camera correctly under varying fov (i.e. maintain correct zoom min, max, distance)
- small shader speedup