### PR TITLE
Expose bg color, grid, bound URL params

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "supersplat",
-    "version": "1.2.2",
+    "version": "1.2.3",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "supersplat",
-            "version": "1.2.2",
+            "version": "1.2.3",
             "license": "MIT",
             "devDependencies": {
                 "@playcanvas/eslint-config": "^1.7.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "supersplat",
-    "version": "1.2.2",
+    "version": "1.2.3",
     "author": "PlayCanvas<support@playcanvas.com>",
     "homepage": "https://playcanvas.com/supersplat/editor",
     "description": "3D Gaussian Splat Editor",

--- a/src/camera.ts
+++ b/src/camera.ts
@@ -198,8 +198,7 @@ class Camera extends Element {
         const controls = config.controls;
 
         // configure background
-        const clr = config.backgroundColor;
-        this.entity.camera.clearColor.set(clr.r, clr.g, clr.b, clr.a);
+        this.entity.camera.clearColor.set(0, 0, 0, 0);
 
         this.minElev = (controls.minPolarAngle * 180) / Math.PI - 90;
         this.maxElev = (controls.maxPolarAngle * 180) / Math.PI - 90;

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -117,6 +117,8 @@ const registerEditorEvents = (events: Events, editHistory: EditHistory, scene: S
         setGridVisible(!scene.grid.visible);
     });
 
+    setGridVisible(scene.config.show.grid);
+
     // camera.fov
 
     const setCameraFov = (fov: number) => {
@@ -136,7 +138,7 @@ const registerEditorEvents = (events: Events, editHistory: EditHistory, scene: S
 
     // camera.bound
 
-    let bound = true;
+    let bound = scene.config.show.bound;
 
     const setBoundVisible = (visible: boolean) => {
         if (visible !== bound) {
@@ -156,6 +158,8 @@ const registerEditorEvents = (events: Events, editHistory: EditHistory, scene: S
     events.on('camera.toggleBound', () => {
         setBoundVisible(!events.invoke('camera.bound'));
     });
+
+    // camera.focus
 
     events.on('camera.focus', () => {
         const splat = selectedSplats()[0];
@@ -573,7 +577,7 @@ const registerEditorEvents = (events: Events, editHistory: EditHistory, scene: S
 
     // view spherical harmonic bands
 
-    let viewBands = 3;
+    let viewBands = scene.config.show.shBands;
 
     const setViewBands = (value: number) => {
         if (value !== viewBands) {
@@ -593,6 +597,7 @@ const registerEditorEvents = (events: Events, editHistory: EditHistory, scene: S
     // hack: fire events to initialize UI
     events.fire('camera.fov', scene.camera.fov);
     events.fire('camera.debug', cameraDebug);
+    events.fire('view.bands', viewBands);
 }
 
 export { registerEditorEvents };

--- a/src/main.ts
+++ b/src/main.ts
@@ -136,7 +136,7 @@ const main = async () => {
     );
 
     // configure body background color
-    const clr = sceneConfig.bcgClr;
+    const clr = sceneConfig.bgClr;
     const cnv = (v: number) => `${Math.max(0, Math.min(255, (v * 255))).toFixed(0)}`
     document.body.style.backgroundColor = `rgba(${cnv(clr.r)},${cnv(clr.g)},${cnv(clr.b)},${clr.a.toFixed(2)})`;
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -135,6 +135,11 @@ const main = async () => {
         graphicsDevice
     );
 
+    // configure body background color
+    const clr = sceneConfig.bcgClr;
+    const cnv = (v: number) => `${Math.max(0, Math.min(255, (v * 255))).toFixed(0)}`
+    document.body.style.backgroundColor = `rgba(${cnv(clr.r)},${cnv(clr.g)},${cnv(clr.b)},${clr.a.toFixed(2)})`;
+
     // tool manager
     const toolManager = new ToolManager(events);
     toolManager.register('rectSelection', new RectSelection(events, editorUI.toolsContainer.dom));

--- a/src/scene-config.ts
+++ b/src/scene-config.ts
@@ -18,7 +18,7 @@ const sceneConfig = {
         intensity: 1.0,
         rotation: 0.0
     },
-    bcgClr: DEFAULT,
+    bgClr: DEFAULT,
     camera: {
         pixelScale: 1,
         multisample: false,

--- a/src/scene-config.ts
+++ b/src/scene-config.ts
@@ -1,14 +1,15 @@
 
-const contentsPromise: Promise<ArrayBuffer> = null;
+type Color = { r: number, g: number, b: number, a: number };
+
+const DEFAULT: Color = { r: 0.4, g: 0.4, b: 0.4, a: 1 };
 
 // default config
 const sceneConfig = {
     model: {
         url: '',
         filename: '',
-        contents: contentsPromise,
-        position: {x: 0, y: 0, z: 0},
-        rotation: {x: 0, y: 0, z: 0},
+        position: { x: 0, y: 0, z: 0 },
+        rotation: { x: 0, y: 0, z: 0 },
         scale: 1.0,
         hideLeftShoe: true
     },
@@ -17,7 +18,7 @@ const sceneConfig = {
         intensity: 1.0,
         rotation: 0.0
     },
-    backgroundColor: {r: 0, g: 0, b: 0, a: 0},
+    bcgClr: DEFAULT,
     camera: {
         pixelScale: 1,
         multisample: false,
@@ -26,6 +27,11 @@ const sceneConfig = {
         toneMapping: 'linear',
         debug_render: '',
         debug: true
+    },
+    show: {
+        grid: true,
+        bound: true,
+        shBands: 3
     },
     shadow: {
         intensity: 0.25,
@@ -91,35 +97,46 @@ class Params {
         return typeof value === 'string' ? parseFloat(value) : value;
     }
 
-    getVec3(path: string) {
+    getVec(path: string) {
         const value = this.get(path);
-        if (typeof value === 'string') {
-            const values = value.split(',').map((v: string) => parseFloat(v));
-            return values.length === 1
-                ? {x: values[0], y: values[0], z: values[0]}
-                : {x: values[0], y: values[1], z: values[2]};
-        } else if (typeof value === 'number') {
-            return {x: value, y: value, z: value};
+        return typeof value === 'string' ? value.split(',') : undefined;
+    }
+
+    getVec3(path: string) {
+        const value = this.getVec(path);
+        if (value) {
+            const numbers = value.map(v => parseFloat(v));
+            if (value.length === 1) {
+                return { x: numbers[0], y: numbers[0], z: numbers[0] };
+            } else if (value.length === 3) {
+                return { x: numbers[0], y: numbers[1], z: numbers[2] };
+            }
         }
         return undefined;
     }
 
     getColor(path: string) {
-        const value = this.get(path);
-        const makeColor = (vals: number[]) => {
-            return vals.length === 4 ? {r: vals[0], g: vals[1], b: vals[2], a: vals[3]} : undefined;
-        };
-        return typeof value === 'string' ? makeColor(value.split(',').map(v => parseFloat(v))) : undefined;
-    }
-
-    getVec(path: string) {
-        const value = this.get(path);
-        return typeof value === 'string' ? value.split(',') : undefined;
+        const value = this.getVec(path);
+        if (value) {
+            const numbers = value.map(v => parseFloat(v));
+            if (value.length === 1) {
+                return { r: numbers[0], g: numbers[0], b: numbers[0], a: 1 };
+            } else if (value.length === 3) {
+                return { r: numbers[0], g: numbers[1], b: numbers[2], a: 1 };
+            } else if (value.length === 4) {
+                return { r: numbers[0], g: numbers[1], b: numbers[2], a: numbers[3] };
+            }
+        }
+        return undefined;
     }
 }
 
 const getSceneConfig = (overrides: any[]) => {
     const params = new Params(overrides);
+
+    const cmp = (a: any[], b: any[]) => {
+        return a.length === b.length && a.every((v, i) => v === b[i]);
+    };
 
     // recurse the object and replace concrete leaf values with overrides
     const rec = (obj: any, path: string) => {
@@ -135,6 +152,16 @@ const getSceneConfig = (overrides: any[]) => {
                     break;
                 case 'string':
                     obj[child] = params.get(childPath) ?? childValue;
+                    break;
+                case 'object':
+                    const keys = Object.keys(childValue).sort();
+                    if (cmp(keys, ['a', 'b', 'g', 'r'])) {
+                        obj[child] = params.getColor(childPath) ?? childValue;
+                    } else if (cmp(keys, ['x', 'y', 'z'])) {
+                        obj[child] = params.getVec3(childPath) ?? childValue;
+                    } else {
+                        rec(childValue, childPath);
+                    }
                     break;
                 default:
                     rec(childValue, childPath);

--- a/src/scene-config.ts
+++ b/src/scene-config.ts
@@ -153,7 +153,7 @@ const getSceneConfig = (overrides: any[]) => {
                 case 'string':
                     obj[child] = params.get(childPath) ?? childValue;
                     break;
-                case 'object':
+                case 'object': {
                     const keys = Object.keys(childValue).sort();
                     if (cmp(keys, ['a', 'b', 'g', 'r'])) {
                         obj[child] = params.getColor(childPath) ?? childValue;
@@ -163,6 +163,7 @@ const getSceneConfig = (overrides: any[]) => {
                         rec(childValue, childPath);
                     }
                     break;
+                }
                 default:
                     rec(childValue, childPath);
                     break;

--- a/src/ui/style.scss
+++ b/src/ui/style.scss
@@ -143,7 +143,6 @@ body {
 
 #canvas-container {
     width: 100%;
-    background-color: #666666;
     display: flex;
     border: 0;
     padding: 0;


### PR DESCRIPTION
<img width="1159" alt="Screenshot 2024-08-30 at 11 43 55" src="https://github.com/user-attachments/assets/b391b7aa-5f89-475e-9188-175a1995f45d">

This PR:
- updates the handling of URL param config overrides to correctly handle vec3 and color types
- applies the background color config value correctly
- adds new config options to control grid and bound visibility and number of sh bands
- bumps package to v1.2.3

For example, with the following URL, grid and bound is initially hidden with a reddish background:
``` url
https://playcanvas.com/supersplat/editor?show.grid=false&show.bound=false&bgClr=0.5,0.2,0.2
```