### PR TITLE
Changed Discord link to permalink invite to channel

### DIFF
--- a/src/ui/menu.ts
+++ b/src/ui/menu.ts
@@ -222,7 +222,7 @@ class Menu extends Container {
         }, {
             text: localize('help.discord'),
             icon: 'E233',
-            onSelect: () => window.open('https://discord.com/channels/408617316415307776/1275850227663769686', '_blank').focus()
+            onSelect: () => window.open('https://discord.gg/T3pnhRTTAY', '_blank').focus()
         }, {
             text: localize('help.forum'),
             icon: 'E432',


### PR DESCRIPTION
The Discord link has been changed to a permalink invite to the server but land direct into the gaussian splatting channel.

When clicked, whether you have joined the server, you will see:

<img width="552" alt="image" src="https://github.com/user-attachments/assets/efa93aa7-d175-4485-8a53-9a7a12521450">
