### PR TITLE
Fix input

### DIFF
--- a/src/ui/editor.ts
+++ b/src/ui/editor.ts
@@ -185,7 +185,7 @@ class EditorUI {
             if (event.target === canvas || toolsContainer.dom.contains(event.target as Node)) {
                 document.body.focus();
             }
-        });
+        }, true);
     }
 }
 


### PR DESCRIPTION
Register event on capture phase so we more consistently set the input focus when clicking on the editor.