### PR TITLE
Polygon tool tweaks

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -70,10 +70,9 @@ const initShortcuts = (events: Events) => {
     shortcuts.register(['G', 'g'], { event: 'grid.toggleVisible' });
     shortcuts.register(['C', 'c'], { event: 'tool.toggleCoordSpace' });
     shortcuts.register(['F', 'f'], { event: 'camera.focus' });
-    shortcuts.register(['O', 'o'], { event: 'tool.polygonSelection', sticky: true });
-    shortcuts.register(['B', 'b'], { event: 'tool.brushSelection', sticky: true });
     shortcuts.register(['R', 'r'], { event: 'tool.rectSelection', sticky: true });
-    shortcuts.register(['P', 'p'], { event: 'tool.rectSelection', sticky: true });
+    shortcuts.register(['P', 'p'], { event: 'tool.polygonSelection', sticky: true });
+    shortcuts.register(['B', 'b'], { event: 'tool.brushSelection', sticky: true });
     shortcuts.register(['A', 'a'], { event: 'select.all' });
     shortcuts.register(['A', 'a'], { event: 'select.none', shift: true });
     shortcuts.register(['I', 'i'], { event: 'select.invert' });
@@ -174,15 +173,28 @@ const main = async () => {
 
     setBgClr(new Color(sceneConfig.bgClr.r, sceneConfig.bgClr.g, sceneConfig.bgClr.b, 1));
 
+    // create the mask selection canvas
+    const maskCanvas = document.createElement('canvas');
+    const maskContext = maskCanvas.getContext('2d');
+    maskCanvas.setAttribute('id', 'mask-canvas');
+    maskContext.globalCompositeOperation = 'copy';
+
+    const mask = {
+        canvas: maskCanvas,
+        context: maskContext
+    };
+
     // tool manager
     const toolManager = new ToolManager(events);
     toolManager.register('rectSelection', new RectSelection(events, editorUI.toolsContainer.dom));
-    toolManager.register('brushSelection', new BrushSelection(events, editorUI.toolsContainer.dom));
-    toolManager.register('polygonSelection', new PolygonSelection(events, editorUI.toolsContainer.dom));
+    toolManager.register('brushSelection', new BrushSelection(events, editorUI.toolsContainer.dom, mask));
+    toolManager.register('polygonSelection', new PolygonSelection(events, editorUI.toolsContainer.dom, mask));
     toolManager.register('sphereSelection', new SphereSelection(events, scene, editorUI.canvasContainer));
     toolManager.register('move', new MoveTool(events, scene));
     toolManager.register('rotate', new RotateTool(events, scene));
     toolManager.register('scale', new ScaleTool(events, scene));
+
+    editorUI.toolsContainer.dom.appendChild(maskCanvas);
 
     window.scene = scene;
 

--- a/src/tools/brush-selection.ts
+++ b/src/tools/brush-selection.ts
@@ -4,7 +4,7 @@ class BrushSelection {
     activate: () => void;
     deactivate: () => void;
 
-    constructor(events: Events, parent: HTMLElement) {
+    constructor(events: Events, parent: HTMLElement, mask: { canvas: HTMLCanvasElement, context: CanvasRenderingContext2D }) {
         let radius = 40;
 
         // create svg
@@ -20,12 +20,7 @@ class BrushSelection {
         circle.setAttribute('stroke-width', '1');
         circle.setAttribute('stroke-dasharray', '5, 5');
 
-        // create canvas
-        const selectCanvas = document.createElement('canvas');
-        selectCanvas.id = 'brush-select-canvas';
-
-        const context = selectCanvas.getContext('2d');
-        context.globalCompositeOperation = 'copy';
+        const { canvas, context } = mask;
 
         const prev = { x: 0, y: 0 };
         let dragId: number | undefined;
@@ -60,16 +55,16 @@ class BrushSelection {
                 parent.setPointerCapture(dragId);
 
                 // initialize canvas
-                if (selectCanvas.width !== parent.clientWidth || selectCanvas.height !== parent.clientHeight) {
-                    selectCanvas.width = parent.clientWidth;
-                    selectCanvas.height = parent.clientHeight;
+                if (canvas.width !== parent.clientWidth || canvas.height !== parent.clientHeight) {
+                    canvas.width = parent.clientWidth;
+                    canvas.height = parent.clientHeight;
                 }
 
                 // clear canvas
-                context.clearRect(0, 0, selectCanvas.width, selectCanvas.height);
+                context.clearRect(0, 0, canvas.width, canvas.height);
 
                 // display it
-                selectCanvas.style.display = 'inline';
+                canvas.style.display = 'inline';
 
                 prev.x = e.offsetX;
                 prev.y = e.offsetY;
@@ -90,7 +85,7 @@ class BrushSelection {
         const dragEnd = () => {
             parent.releasePointerCapture(dragId);
             dragId = undefined;
-            selectCanvas.style.display = 'none';
+            canvas.style.display = 'none';
         };
 
         const pointerup = (e: PointerEvent) => {
@@ -103,7 +98,7 @@ class BrushSelection {
                 events.fire(
                     'select.byMask',
                     e.shiftKey ? 'add' : (e.ctrlKey ? 'remove' : 'set'),
-                    selectCanvas,
+                    canvas,
                     context
                 );
             }
@@ -141,7 +136,6 @@ class BrushSelection {
 
         svg.appendChild(circle);
         parent.appendChild(svg);
-        parent.appendChild(selectCanvas);
     }
 }
 

--- a/src/ui/localization.ts
+++ b/src/ui/localization.ts
@@ -152,8 +152,8 @@ const localizeInit = () => {
                         // Bottom toolbar
                         "tooltip.undo": "Rückgängig ( Strg + Z )",
                         "tooltip.redo": "Wiederholen ( Strg + Shift + Z )",
-                        "tooltip.picker": "Einzelselektion ( P )",
-                        "tooltip.polygon": "Polygonselektion ( O )",
+                        "tooltip.picker": "Einzelselektion ( R )",
+                        "tooltip.polygon": "Polygonselektion ( P )",
                         "tooltip.brush": "Pinselselektion ( B )",
                         "tooltip.sphere": "Kugelselektion",
                         "tooltip.translate": "Verschieben ( 1 )",
@@ -303,8 +303,8 @@ const localizeInit = () => {
                         // Bottom toolbar
                         "tooltip.undo": "Undo ( Ctrl + Z )",
                         "tooltip.redo": "Redo ( Ctrl + Shift + Z )",
-                        "tooltip.picker": "Picker Select ( P )",
-                        "tooltip.polygon": "Polygon Select ( O )",
+                        "tooltip.picker": "Picker Select ( R )",
+                        "tooltip.polygon": "Polygon Select ( P )",
                         "tooltip.brush": "Brush Select ( B )",
                         "tooltip.sphere": "Sphere Select",
                         "tooltip.translate": "Translate ( 1 )",
@@ -454,7 +454,8 @@ const localizeInit = () => {
                         // bottom toolbar
                         "tooltip.undo": "Annuler ( Ctrl + Z )",
                         "tooltip.redo": "Rétablir ( Ctrl + Shift + Z )",
-                        "tooltip.picker": "Sélection avec pipette ( P )",
+                        "tooltip.picker": "Sélection avec pipette ( R )",
+                        "tooltip.polygon": "Sélection avec polygone ( P )",
                         "tooltip.brush": "Sélection avec pinceau ( B )",
                         "tooltip.sphere": "Sélection avec sphère",
                         "tooltip.translate": "Translation ( 1 )",
@@ -604,7 +605,8 @@ const localizeInit = () => {
                         // Bottom toolbar
                         "tooltip.undo": "元に戻す ( Ctrl + Z )",
                         "tooltip.redo": "やり直し ( Ctrl + Shift + Z )",
-                        "tooltip.picker": "ピッカー選択 ( P )",
+                        "tooltip.picker": "ピッカー選択 ( R )",
+                        "tooltip.polygon": "ポリゴン選択 ( P )",
                         "tooltip.brush": "ブラシ選択 ( B )",
                         "tooltip.sphere": "球で選択",
                         "tooltip.translate": "移動 ( 1 )",
@@ -754,7 +756,8 @@ const localizeInit = () => {
                         // Bottom toolbar
                         "tooltip.undo": "실행 취소 ( Ctrl + Z )",
                         "tooltip.redo": "다시 실행 ( Ctrl + Shift + Z )",
-                        "tooltip.picker": "피커 선택 ( P )",
+                        "tooltip.picker": "피커 선택 ( R )",
+                        "tooltip.polygon": "다각형 선택 ( P )",
                         "tooltip.brush": "브러시 선택 ( B )",
                         "tooltip.sphere": "구 선택",
                         "tooltip.translate": "이동 ( 1 )",
@@ -904,7 +907,8 @@ const localizeInit = () => {
                         // Bottom toolbar
                         "tooltip.undo": "撤销 ( Ctrl + Z )",
                         "tooltip.redo": "重做 ( Ctrl + Shift + Z )",
-                        "tooltip.picker": "选择器 ( P )",
+                        "tooltip.picker": "选择器 ( R )",
+                        "tooltip.polygon": "多边形选择 ( P )",
                         "tooltip.brush": "画笔 ( B )",
                         "tooltip.sphere": "球选择",
                         "tooltip.translate": "移动 ( 1 )",

--- a/src/ui/scss/style.scss
+++ b/src/ui/scss/style.scss
@@ -129,7 +129,7 @@ body {
     pointer-events: none;
 }
 
-#brush-select-canvas {
+#mask-canvas {
     display: none;
     position: absolute;
     opacity: 0.4;


### PR DESCRIPTION
Followup PR to #261:
- brush and polygon tool use same html canvas for generating mask
- use 'p' for polygon tool keyboard shortcut ('r' used for picker/rect tool)
- small tweaks on polygon tool:
    - use 8px distance to close polygon
    - small double click change
- added localisation for remaining languages