### PR TITLE
Typesafe Colmap and Nerfstudio camara-pose loading

### DIFF
--- a/src/json-types.ts
+++ b/src/json-types.ts
@@ -38,6 +38,17 @@ type NerfstudioCameraIntrinsics = {
 }
 
 type NerfstudioPose = NerfstudioCameraIntrinsics & {    
+    /**
+     * [+X0, +Y0, +Z0, X]
+     * 
+     * [+X1, +Y1, +Z1, Y]
+     * 
+     * [+X2, +Y2, +Z2, Z]
+     * 
+     * [0.0, 0.0, 0.0, 1]
+     * 
+     * https://docs.nerf.studio/quickstart/data_conventions.html
+     */
     transform_matrix: [
         [number, number, number, number],
         [number, number, number, number],

--- a/src/json-types.ts
+++ b/src/json-types.ts
@@ -1,0 +1,50 @@
+
+
+type ColmapJson = ColmapPose[];
+
+type ColmapPose = {
+    id?: number,
+    img_name?: string,
+    width?: number,
+    height?: number,
+    position: [number, number, number],
+    rotation: [[number, number, number], [number, number, number], [number, number, number]]
+    fx?: number,
+    fy?: number
+};
+
+
+type NerfstudioJson = NerfstudioCameraIntrinsics & { 
+    frames: NerfstudioPose[]
+};
+
+type NerfstudioCameraIntrinsics = {
+    camera_model?: string,
+    h?: number,
+    w?: number,
+    file_path?: string,
+    fl_x?: number,
+    fl_y?: number,
+    cx?: number,
+    cy?: number,
+    k1?: number,
+    k2?: number,
+    k3?: number,
+    k4?: number,
+    p1?: number,
+    p2?: number
+}
+
+type NerfstudioPose = NerfstudioCameraIntrinsics & {    
+    transform_matrix: [
+        [number, number, number, number],
+        [number, number, number, number],
+        [number, number, number, number],
+        [number, number, number, number]
+    ]
+};
+
+export {
+    ColmapJson, ColmapPose,
+    NerfstudioJson, NerfstudioPose, NerfstudioCameraIntrinsics
+};

--- a/src/json-types.ts
+++ b/src/json-types.ts
@@ -23,6 +23,8 @@ type NerfstudioCameraIntrinsics = {
     h?: number,
     w?: number,
     file_path?: string,
+    depth_file_path?: string,
+    mask_path?: string,
     fl_x?: number,
     fl_y?: number,
     cx?: number,


### PR DESCRIPTION
I am currently looking into pose-loading and want to continue by support loading nerfstudio-data poses. However, for that the first step is to know what kind of json I am looking at. 
So I improved the type-safetyness of loading colmap poses. Each pose now is casted to an interface that provides named access to other (currently unused properties). Before that, every entry is checked to be well-formed. Arrays with 2 or 4 elements when 3 were required are rejected. The entire pose then will not be loaded (but all others are). 
Counting the number of poses is done after filtering invalid ones (this was a tiny issue in the old code)

I expanded this to also loading nerfstudio data.
Here is an example of nerfstudio-data:
[transforms.json.zip](https://github.com/user-attachments/files/17723606/transforms.json.zip)
[bike2.ply.zip](https://github.com/user-attachments/files/17723607/bike2.ply.zip)

The data-format is explained here: https://docs.nerf.studio/quickstart/data_conventions.html