### PR TITLE
Histogram panel update

### DIFF
--- a/src/ui/histogram.ts
+++ b/src/ui/histogram.ts
@@ -48,6 +48,7 @@ class HistogramData {
             const v = valueFunc(i);
             if (v !== undefined) {
                 const n = min === max ? 0 : (v - min) / (max - min);
+                if (isNaN(n)) continue;
                 const bin = Math.min(bins.length - 1, Math.floor(n * bins.length));
                 if (selectedFunc(i)) {
                     bins[bin].selected++;


### PR DESCRIPTION
This PR:
- updates the SPLAT DATA panel to make available all the data loaded from the PLY
- though the 45 spherical harmonic coefficients since leaving them in would clutter the dropdown for little benefit
- small fix for NaN bucket calc