### PR TITLE
Show selection on the active splat only

### DIFF
--- a/src/outline.ts
+++ b/src/outline.ts
@@ -14,6 +14,7 @@ import {
 
 import { Element, ElementType } from './element';
 import { vertexShader, fragmentShader } from './shaders/outline-shader';
+import { Splat } from './splat';
 
 class Outline extends Element {
     entity: Entity;
@@ -33,9 +34,20 @@ class Outline extends Element {
 
     add() {
         const device = this.scene.app.graphicsDevice;
+        const layerId = this.scene.overlayLayer.id;
+
+        // add selected splat to outline layer
+        this.scene.events.on('selection.changed', (splat: Splat, prev: Splat) => {
+            if (prev) {
+                prev.entity.gsplat.layers = prev.entity.gsplat.layers.filter(id => id !== layerId);
+            }
+            if (splat) {
+                splat.entity.gsplat.layers = splat.entity.gsplat.layers.concat([layerId]);
+            }
+        });
 
         // render overlay layer only
-        this.entity.camera.layers = [this.scene.overlayLayer.id];
+        this.entity.camera.layers = [layerId];
         this.scene.camera.entity.addChild(this.entity);
 
         this.shader = createShaderFromCode(device, vertexShader, fragmentShader, 'apply-outline', {

--- a/src/splat.ts
+++ b/src/splat.ts
@@ -286,8 +286,6 @@ class Splat extends Element {
     }
 
     add() {
-        this.entity.gsplat.layers = this.entity.gsplat.layers.concat([this.scene.overlayLayer.id]);
-
         // add the entity to the scene
         this.scene.contentRoot.addChild(this.entity);
 
@@ -323,7 +321,7 @@ class Splat extends Element {
         material.setParameter('mode', cameraMode === 'rings' ? 1 : 0);
         material.setParameter('ringSize', (selected && cameraOverlay && cameraMode === 'rings') ? 0.04 : 0);
 
-        const selectionAlpha = events.invoke('view.outlineSelection') ? 0 : this.selectionAlpha;
+        const selectionAlpha = selected && !events.invoke('view.outlineSelection') ? this.selectionAlpha : 0;
 
         // configure colors
         const selectedClr = events.invoke('selectedClr');


### PR DESCRIPTION
This PR:
- changes the display to show selected gaussians on the active splat only (instead of rendering yellow/outline on all splats)
- slight cleanup of selection logic
