### PR TITLE
Shortcut update for select none

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -77,7 +77,7 @@ const initShortcuts = (events: Events) => {
     shortcuts.register(['L', 'l'], { event: 'tool.lassoSelection', sticky: true });
     shortcuts.register(['B', 'b'], { event: 'tool.brushSelection', sticky: true });
     shortcuts.register(['A', 'a'], { event: 'select.all', ctrl: true });
-    shortcuts.register(['A', 'a'], { event: 'select.none', ctrl: true, shift: true });
+    shortcuts.register(['A', 'a'], { event: 'select.none', shift: true });
     shortcuts.register(['I', 'i'], { event: 'select.invert', ctrl: true });
     shortcuts.register(['H', 'h'], { event: 'select.hide' });
     shortcuts.register(['U', 'u'], { event: 'select.unhide' });

--- a/src/ui/menu.ts
+++ b/src/ui/menu.ts
@@ -184,7 +184,7 @@ class Menu extends Container {
         }, {
             text: localize('select.none'),
             icon: createSvg(selectNone),
-            extra: 'Ctrl + Shift + A',
+            extra: 'Shift + A',
             onSelect: () => events.fire('select.none')
         }, {
             text: localize('select.invert'),

--- a/src/ui/shortcuts-popup.ts
+++ b/src/ui/shortcuts-popup.ts
@@ -14,7 +14,7 @@ const shortcutList = [
     { key: 'Esc', action: 'deactivate-tool' },
     { header: 'selection' },
     { key: 'Ctrl + A', action: 'select-all' },
-    { key: 'Ctrl + Shift + A', action: 'deselect-all' },
+    { key: 'Shift + A', action: 'deselect-all' },
     { key: 'Ctrl + I', action: 'invert-selection' },
     { key: 'Shift', action: 'add-to-selection' },
     { key: 'Ctrl', action: 'remove-from-selection' },


### PR DESCRIPTION
Revert back to `shift + a` for select none since `shift + ctrl + a` clashes with browser shortcut on Windows.