### PR TITLE
Rings mode picker update

### DIFF
--- a/src/camera.ts
+++ b/src/camera.ts
@@ -486,7 +486,7 @@ class Camera extends Element {
         for (let i = 0; i < splats.length; ++i) {
             const splat = splats[i] as Splat;
 
-            this.pickPrep(splat);
+            this.pickPrep(splat, 'set');
             const pickId = this.pick(sx, sy);
 
             if (pickId !== -1) {
@@ -533,7 +533,7 @@ class Camera extends Element {
     // pick mode
 
     // render picker contents
-    pickPrep(splat: Splat) {
+    pickPrep(splat: Splat, op: 'add'|'remove'|'set') {
         const { width, height } = this.scene.targetSize;
         const worldLayer = this.scene.app.scene.layers.getLayerByName('World');
 
@@ -548,6 +548,7 @@ class Camera extends Element {
         });
 
         device.scope.resolve('pickerAlpha').setValue(alpha);
+        device.scope.resolve('pickMode').setValue(['add', 'remove', 'set'].indexOf(op));
         this.picker.resize(width, height);
         this.picker.prepare(this.entity.camera, this.scene.app.scene, [worldLayer]);
 

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -243,7 +243,7 @@ const registerEditorEvents = (events: Events, editHistory: EditHistory, scene: S
             } else if (mode === 'rings') {
                 const { width, height } = scene.targetSize;
 
-                scene.camera.pickPrep(splat);
+                scene.camera.pickPrep(splat, op);
                 const pick = scene.camera.pickRect(
                     Math.floor(rect.start.x * width),
                     Math.floor(rect.start.y * height),
@@ -307,7 +307,7 @@ const registerEditorEvents = (events: Events, editHistory: EditHistory, scene: S
                 const pw = px1 - px0 + 1;
                 const ph = py1 - py0 + 1;
 
-                scene.camera.pickPrep(splat);
+                scene.camera.pickPrep(splat, op);
                 const pick = scene.camera.pickRect(px0, py0, pw, ph);
 
                 const selected = new Set<number>();
@@ -360,7 +360,7 @@ const registerEditorEvents = (events: Events, editHistory: EditHistory, scene: S
 
                 events.fire('edit.add', new SelectOp(splat, op, filter));
             } else if (mode === 'rings') {
-                scene.camera.pickPrep(splat);
+                scene.camera.pickPrep(splat, op);
 
                 const pickId = scene.camera.pickRect(
                     Math.floor(point.x * width),


### PR DESCRIPTION
When picking gaussians in rings mode, only the top layer of gaussians were ever considered for adding/removing/setting the selection.

This has meant it is not possible to select anything other than the top layer of gaussians. Also, it has not been possible to deselect gaussians that are embedded within the scene, since the top layer of gaussians block picking.

This PR updates the picking logic to be much more useful and behave more consistently:
- when adding to the selection (shift), only consider unselected gaussians
    - this means it's now possible to add gaussians to the current selection layer at a time
- when removing from the current selection (ctrl), only consider the currently selected gaussians
    - so unselecting "blocked" gaussians is now possible
- when setting the selection, do as before

For example, this was not possible before:

https://github.com/user-attachments/assets/91df1a59-921f-4233-bd81-46bfe7ef6900

