### PR TITLE
Duplicate fix

### DIFF
--- a/src/splat-serialize.ts
+++ b/src/splat-serialize.ts
@@ -365,7 +365,7 @@ const serializePly = async (options: SerializeOptions, write: WriteFunc) => {
 
         for (let i = 0; i < splatData.numSplats; ++i) {
             if ((state[i] & State.deleted) === State.deleted) continue;
-            if (options.selected && (state[i] & State.selected) === 0) continue;
+            if (options.selected && (state[i] !== State.selected)) continue;
 
             singleSplat.read(splat, i);
 


### PR DESCRIPTION
This PR fixes an issue duplicating/separating splats when part of the model is frozen.

See https://discord.com/channels/408617316415307776/1275850227663769686/1318674627496775700 for more.

