### PR TITLE
Handle NaN data better in histogram

### DIFF
--- a/src/ui/histogram.ts
+++ b/src/ui/histogram.ts
@@ -24,7 +24,7 @@ class HistogramData {
         let min, max, i;
         for (i = 0; i < count; i++) {
             const v = valueFunc(i);
-            if (v !== undefined) {
+            if (v !== undefined && !isNaN(v)) {
                 min = max = v;
                 break;
             }


### PR DESCRIPTION
This issue as noticed in #360.

The histogram will display no data when encountering NaNs. This PR changes the histogram logic to ignore NaNs and continue plotting non-NaN values.

We should probably display the number of NaN elements encountered on the histogram and also allow users to select these gaussians.