### PR TITLE
Add gizmo origin toggle

### DIFF
--- a/src/entity-transform-handler.ts
+++ b/src/entity-transform-handler.ts
@@ -7,7 +7,6 @@ import { Splat } from './splat';
 import { Transform } from './transform';
 import { TransformHandler } from './transform-handler';
 
-const vec = new Vec3();
 const mat = new Mat4();
 const quat = new Quat();
 const transform = new Transform();
@@ -40,6 +39,12 @@ class EntityTransformHandler implements TransformHandler {
             }
         });
 
+        events.on('pivot.origin', (mode: 'center' | 'boundCenter') => {
+            if (this.splat) {
+                this.placePivot();
+            }
+        });
+
         events.on('camera.focalPointPicked', (details: { splat: Splat, position: Vec3 }) => {
             if (this.splat) {
                 const pivot = events.invoke('pivot') as Pivot;
@@ -52,9 +57,8 @@ class EntityTransformHandler implements TransformHandler {
 
     placePivot() {
         // place initial pivot point
-        const { entity } = this.splat;
-        entity.getLocalTransform().transformPoint(this.splat.localBound.center, vec);
-        transform.set(vec, entity.getLocalRotation(), entity.getLocalScale());
+        const origin = this.events.invoke('pivot.origin');
+        this.splat.getPivot(origin === 'center' ? 'center' : 'boundCenter', false, transform);
         this.events.fire('pivot.place', transform);
     }
 

--- a/src/pivot.ts
+++ b/src/pivot.ts
@@ -56,11 +56,35 @@ class Pivot {
     }
 }
 
+type PivotOrigin = 'center' | 'boundCenter';
+
 const registerPivotEvents = (events: Events) => {
     const pivot = new Pivot(events);
 
     events.function('pivot', () => {
         return pivot;
+    });
+
+    // pivot mode
+    let origin: PivotOrigin = 'center';
+
+    const setOrigin = (o: PivotOrigin) => {
+        if (o !== origin) {
+            origin = o;
+            events.fire('pivot.origin', origin);
+        }
+    };
+
+    events.function('pivot.origin', () => {
+        return origin;
+    });
+
+    events.on('pivot.setOrigin', (o: PivotOrigin) => {
+        setOrigin(o === 'center' ? 'center' : 'boundCenter');
+    });
+
+    events.on('pivot.toggleOrigin', () => {
+        setOrigin(origin === 'center' ? 'boundCenter' : 'center');
     });
 };
 

--- a/src/publish.ts
+++ b/src/publish.ts
@@ -64,7 +64,15 @@ const publish = async (data: Uint8Array, publishSettings: PublishSettings) => {
     });
 
     if (!publishResponse.ok) {
-        throw new Error('failed to publish');
+        let msg;
+        try {
+            const err = await publishResponse.json();
+            msg = err.error ?? msg;
+        } catch (e) {
+            msg = "Failed to publish";
+        }
+
+        throw new Error(msg);
     }
 
     return await publishResponse.json();

--- a/src/splat.ts
+++ b/src/splat.ts
@@ -21,6 +21,7 @@ import { Serializer } from './serializer';
 import { vertexShader, fragmentShader, gsplatCenter } from './shaders/splat-shader';
 import { State } from './splat-state';
 import { TransformPalette } from './transform-palette';
+import { Transform } from './transform';
 
 const vec = new Vec3();
 const veca = new Vec3();
@@ -498,6 +499,19 @@ class Splat extends Element {
 
     get transparency() {
         return this._transparency;
+    }
+
+    getPivot(mode: 'center' | 'boundCenter', selection: boolean, result: Transform) {
+        const { entity } = this;
+        switch (mode) {
+            case 'center':
+                result.set(entity.getLocalPosition(), entity.getLocalRotation(), entity.getLocalScale());
+                break;
+            case 'boundCenter':
+                entity.getLocalTransform().transformPoint((selection ? this.selectionBound : this.localBound).center, vec);
+                result.set(vec, entity.getLocalRotation(), entity.getLocalScale());
+                break;
+        }
     }
 }
 

--- a/src/splats-transform-handler.ts
+++ b/src/splats-transform-handler.ts
@@ -10,7 +10,6 @@ import { TransformHandler } from './transform-handler';
 
 const mat = new Mat4();
 const mat2 = new Mat4();
-const vec = new Vec3();
 const transform = new Transform();
 
 class SplatsTransformHandler implements TransformHandler {
@@ -50,6 +49,12 @@ class SplatsTransformHandler implements TransformHandler {
             }
         });
 
+        events.on('pivot.origin', (mode: 'center' | 'boundCenter') => {
+            if (this.splat) {
+                this.placePivot();
+            }
+        });
+
         events.on('camera.focalPointPicked', (details: { splat: Splat, position: Vec3 }) => {
             if (this.splat) {
                 const pivot = events.invoke('pivot') as Pivot;
@@ -62,12 +67,8 @@ class SplatsTransformHandler implements TransformHandler {
     }
 
     placePivot() {
-        const { splat } = this;
-        const { entity } = splat;
-
-        // place the pivot at the center of the selected splats
-        entity.getLocalTransform().transformPoint(splat.selectionBound.center, vec);
-        transform.set(vec, entity.getLocalRotation(), entity.getLocalScale());
+        const origin = this.events.invoke('pivot.origin');
+        this.splat.getPivot(origin === 'center' ? 'center' : 'boundCenter', false, transform);
         this.events.fire('pivot.place', transform);
     }
 

--- a/src/ui/bottom-toolbar.ts
+++ b/src/ui/bottom-toolbar.ts
@@ -96,6 +96,12 @@ class BottomToolbar extends Container {
             icon: 'E118'
         });
 
+        const origin = new Button({
+            id: 'bottom-toolbar-origin',
+            class: 'bottom-toolbar-toggle',
+            icon: 'E189'
+        });
+
         undo.dom.appendChild(createSvg(undoSvg));
         redo.dom.appendChild(createSvg(redoSvg));
         picker.dom.appendChild(createSvg(pickerSvg));
@@ -120,6 +126,7 @@ class BottomToolbar extends Container {
         this.append(rotate);
         this.append(scale);
         this.append(coordSpace);
+        this.append(origin);
 
         undo.dom.addEventListener('click', () => events.fire('edit.undo'));
         redo.dom.addEventListener('click', () => events.fire('edit.redo'));
@@ -132,6 +139,7 @@ class BottomToolbar extends Container {
         rotate.dom.addEventListener('click', () => events.fire('tool.rotate'));
         scale.dom.addEventListener('click', () => events.fire('tool.scale'));
         coordSpace.dom.addEventListener('click', () => events.fire('tool.toggleCoordSpace'));
+        origin.dom.addEventListener('click', () => events.fire('pivot.toggleOrigin'));
 
         events.on('edit.canUndo', (value: boolean) => {
             undo.enabled = value;
@@ -155,6 +163,10 @@ class BottomToolbar extends Container {
             coordSpace.dom.classList[space === 'local' ? 'add' : 'remove']('active');
         });
 
+        events.on('pivot.origin', (o: 'center' | 'boundCenter') => {
+            origin.dom.classList[o === 'boundCenter' ? 'add' : 'remove']('active');
+        });
+
         // register tooltips
         tooltips.register(undo, localize('tooltip.undo'));
         tooltips.register(redo, localize('tooltip.redo'));
@@ -168,7 +180,7 @@ class BottomToolbar extends Container {
         tooltips.register(rotate, localize('tooltip.rotate'));
         tooltips.register(scale, localize('tooltip.scale'));
         tooltips.register(coordSpace, localize('tooltip.local-space'));
-
+        tooltips.register(origin, localize('tooltip.bound-center'));
     }
 }
 

--- a/src/ui/localization.ts
+++ b/src/ui/localization.ts
@@ -169,6 +169,7 @@ const localizeInit = () => {
                     'tooltip.rotate': 'Drehen ( 2 )',
                     'tooltip.scale': 'Skalieren ( 3 )',
                     'tooltip.local-space': 'Gizmo in local-space',
+                    'tooltip.bound-center': 'Mittelpunkt verwenden',
 
                     // Viewer Export
                     'export.type': 'Export Typ',
@@ -350,7 +351,8 @@ const localizeInit = () => {
                     'tooltip.translate': 'Translate ( 1 )',
                     'tooltip.rotate': 'Rotate ( 2 )',
                     'tooltip.scale': 'Scale ( 3 )',
-                    'tooltip.local-space': 'Local Space Gizmo',
+                    'tooltip.local-space': 'Use Local Orientation',
+                    'tooltip.bound-center': 'Use Bound Center',
 
                     // Viewer Export
                     'export.header': 'VIEWER EXPORT',
@@ -538,6 +540,7 @@ const localizeInit = () => {
                     'tooltip.rotate': 'Rotation ( 2 )',
                     'tooltip.scale': 'Échelle ( 3 )',
                     'tooltip.local-space': 'Espace local gizmo',
+                    'tooltip.bound-center': 'Utiliser le centre de la limite',
 
                     // Viewer Export
                     'export.type': 'Type d\'export',
@@ -711,6 +714,7 @@ const localizeInit = () => {
                     'tooltip.rotate': '回転 ( 2 )',
                     'tooltip.scale': 'スケール ( 3 )',
                     'tooltip.local-space': 'ローカル座標へ切り替え',
+                    'tooltip.bound-center': 'バウンディングボックスの中心を使用',
 
                     // Viewer Export
                     'export.type': 'エクスポートタイプ',
@@ -884,6 +888,7 @@ const localizeInit = () => {
                     'tooltip.rotate': '회전 ( 2 )',
                     'tooltip.scale': '크기 조정 ( 3 )',
                     'tooltip.local-space': '로컬 공간',
+                    'tooltip.bound-center': '바운드 중심 사용',
 
                     // Viewer Export
                     'export.type': '내보내기 유형',
@@ -1057,6 +1062,7 @@ const localizeInit = () => {
                     'tooltip.rotate': '旋转 ( 2 )',
                     'tooltip.scale': '缩放 ( 3 )',
                     'tooltip.local-space': '局部坐标系',
+                    'tooltip.bound-center': '使用边界中心',   
 
                     // Viewer Export
                     'export.type': '导出类型',


### PR DESCRIPTION
This PR augments the gizmo controls with a toggle to set where the pivot is placed when selecting an object:
- when disabled (the default), the pivot is placed at the splats origin.
- when enabled, the pivot is placed at the center of the splat's bounding box.

<img width="254" alt="Screenshot 2025-01-14 at 16 08 30" src="https://github.com/user-attachments/assets/6773158d-c4b6-4636-8a0e-be626256fecd" />
