### PR TITLE
Export fix

### DIFF
--- a/src/file-handler.ts
+++ b/src/file-handler.ts
@@ -6,7 +6,7 @@ import { Events } from './events';
 import { Scene } from './scene';
 import { Writer, DownloadWriter, FileStreamWriter } from './serialize/writer';
 import { Splat } from './splat';
-import { serializePly, serializePlyCompressed, serializeSplat, serializeViewer, ViewerExportSettings } from './splat-serialize';
+import { serializePly, serializePlyCompressed, SerializeSettings, serializeSplat, serializeViewer, ViewerExportSettings } from './splat-serialize';
 import { localize } from './ui/localization';
 
 // ts compiler and vscode find this type, but eslint does not
@@ -384,7 +384,7 @@ const initFileHandler = (scene: Scene, events: Events, dropTarget: HTMLElement, 
         const splats = getSplats();
         const events = splats[0].scene.events;
 
-        const serializeSettings = {
+        const serializeSettings: SerializeSettings = {
             maxSHBands: events.invoke('view.bands')
         };
 
@@ -393,6 +393,8 @@ const initFileHandler = (scene: Scene, events: Events, dropTarget: HTMLElement, 
                 await serializePly(splats, serializeSettings, writer);
                 break;
             case 'compressed-ply':
+                serializeSettings.minOpacity = 1 / 255;
+                serializeSettings.removeInvalid = true;
                 await serializePlyCompressed(splats, serializeSettings, writer);
                 break;
             case 'splat':

--- a/src/ui/publish-settings-dialog.ts
+++ b/src/ui/publish-settings-dialog.ts
@@ -308,7 +308,8 @@ class PublishSettingsDialog extends Container {
 
                     const serializeSettings = {
                         maxSHBands: bandsSlider.value,
-                        minOpacity: 1 / 255                 // remove completely semitransparent splats
+                        minOpacity: 1 / 255,                    // remove completely semitransparent splats
+                        removeInvalid: true                     // remove gaussians with any NaN data
                     };
 
                     resolve({


### PR DESCRIPTION
This PR updates the compressed export (and publish) to, by default:
- remove gaussians with alpha < 1 / 255 
- remove gaussians with NaNs or infinites in any of their properties

This is done because we are seeing scenes published which contain a large numbers of invalid gaussian data (in some cases nearly half the scene). These gaussians don't render, but take storage and download space and slow down rendering, significantly in some cases.