### PR TITLE
[FIX] Limit accepted file types for Open and Import

### DIFF
--- a/src/doc.ts
+++ b/src/doc.ts
@@ -12,7 +12,7 @@ type FilePickerAcceptType = unknown;
 const SuperFileType: FilePickerAcceptType[] = [{
     description: 'SuperSplat document',
     accept: {
-        'application/octet-stream': ['.ssproj']
+        'application/x-supersplat': ['.ssproj']
     }
 }];
 

--- a/src/file-handler.ts
+++ b/src/file-handler.ts
@@ -42,7 +42,7 @@ const filePickerTypes: { [key: string]: FilePickerAcceptType } = {
     'splat': {
         description: 'Gaussian Splat File',
         accept: {
-            'application/octet-stream': ['.splat']
+            'application/x-gaussian-splat': ['.splat']
         }
     },
     'htmlViewer': {


### PR DESCRIPTION
`File > Open`:

Before:

![image](https://github.com/user-attachments/assets/4fabd349-8d3c-4954-9585-6bb77289c315)

After:

![image](https://github.com/user-attachments/assets/3a511303-f737-4240-be9e-0079600ecd06)

`File > Import`:

Before:

![image](https://github.com/user-attachments/assets/dfa9ec49-c4d7-44bb-9669-6d28cc2cc65d)

After:

![image](https://github.com/user-attachments/assets/e305fa2c-f5fc-469f-82b5-bdef37b1cd16)
