### PR TITLE
Do not reset camera clearColor in viewer AR mode

### DIFF
--- a/src/templates/index.js
+++ b/src/templates/index.js
@@ -279,44 +279,6 @@ document.addEventListener('DOMContentLoaded', async () => {
         });
     }
 
-    // On entering/exiting AR, we need to set the camera clear color to transparent black
-    let cameraEntity, skyType = null;
-    const clearColor = new Color();
-
-    app.xr.on('start', () => {
-        if (app.xr.type === 'immersive-ar') {
-            cameraEntity = app.xr.camera;
-            clearColor.copy(cameraEntity.camera.clearColor);
-            cameraEntity.camera.clearColor = new Color(0, 0, 0, 0);
-
-            const sky = document.querySelector('pc-sky');
-            if (sky && sky.type !== 'none') {
-                skyType = sky.type;
-                sky.type = 'none';
-            }
-
-            app.autoRender = true;
-        }
-    });
-
-    app.xr.on('end', () => {
-        if (app.xr.type === 'immersive-ar') {
-            cameraEntity.camera.clearColor = clearColor;
-
-            const sky = document.querySelector('pc-sky');
-            if (sky) {
-                if (skyType) {
-                    sky.type = skyType;
-                    skyType = null;
-                } else {
-                    sky.removeAttribute('type');
-                }
-            }
-
-            app.autoRender = false;
-        }
-    });
-
     // Get button and info panel elements
     const dom = ['arMode', 'vrMode', 'enterFullscreen', 'exitFullscreen', 'info', 'infoPanel', 'buttonContainer'].reduce((acc, id) => {
         acc[id] = document.getElementById(id);


### PR DESCRIPTION
Currently the viewer does a strange thing in AR mode - it sets the camera clear color to fully transparent, which has the effect of showing you your physical environment in AR mode wherever there is transparency in your scene. This simply deletes this behavior. I don't have an intuition for why it exists previously but feel free to ignore this PR if it's essential for something. In testing it in my viewer app it seems to work fine (Pixel 7 Chrome AR mode).