### PR TITLE
Fix blending

### DIFF
--- a/src/shaders/splat-shader.ts
+++ b/src/shaders/splat-shader.ts
@@ -160,7 +160,7 @@ void main(void) {
                 }
             }
 
-            gl_FragColor = vec4(color.xyz, alpha);
+            gl_FragColor = vec4(color.xyz * alpha, alpha);
         #endif
     #endif
 }

--- a/src/splat.ts
+++ b/src/splat.ts
@@ -1,9 +1,13 @@
 import {
     ADDRESS_CLAMP_TO_EDGE,
+    BLENDEQUATION_ADD,
+    BLENDMODE_ONE,
+    BLENDMODE_ONE_MINUS_SRC_ALPHA,
     FILTER_NEAREST,
     PIXELFORMAT_R8,
     PIXELFORMAT_R16U,
     Asset,
+    BlendState,
     BoundingBox,
     Color,
     Entity,
@@ -154,10 +158,14 @@ class Splat extends Element {
         // create the transform palette
         this.transformPalette = new TransformPalette(splatResource.device);
 
+        // blend mode for splats
+        const blendState = new BlendState(true, BLENDEQUATION_ADD, BLENDMODE_ONE, BLENDMODE_ONE_MINUS_SRC_ALPHA);
+
         this.rebuildMaterial = (bands: number) => {
             instance.createMaterial(materialOptions);
             const { material } = instance;
             material.chunks = { gsplatCenterVS: gsplatCenter };
+            material.blendState = blendState;
             material.setDefine('SH_BANDS', `${Math.min(bands, instance.splat.shBands)}`);
             material.setParameter('splatState', this.stateTexture);
             material.setParameter('splatTransform', this.transformTexture);


### PR DESCRIPTION
Perform color blending in shader to accomodate HDR values instead of relying on GPU blend operation (which clamps before blending).

Resulting before and after:
<img width="1000" alt="Screenshot 2025-02-25 at 14 54 48" src="https://github.com/user-attachments/assets/50743ae3-930f-4bbd-a527-a384ebac6056" />
<img width="1000" alt="Screenshot 2025-02-25 at 14 54 51" src="https://github.com/user-attachments/assets/911f1db7-93f1-4e61-a28f-880637c873a6" />
