### PR TITLE
Support video generation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32,6 +32,7 @@
                 "i18next-browser-languagedetector": "^8.0.4",
                 "jest": "^29.7.0",
                 "jszip": "^3.10.1",
+                "mp4-muxer": "^5.2.0",
                 "playcanvas": "^2.5.1",
                 "postcss": "^8.5.3",
                 "rollup": "^4.34.8",
@@ -2112,6 +2113,12 @@
             "dependencies": {
                 "@babel/types": "^7.20.7"
             }
+        },
+        "node_modules/@types/dom-webcodecs": {
+            "version": "0.1.14",
+            "resolved": "https://registry.npmjs.org/@types/dom-webcodecs/-/dom-webcodecs-0.1.14.tgz",
+            "integrity": "sha512-ba9aF0qARLLQpLihONIRbj8VvAdUxO+5jIxlscVcDAQTcJmq5qVr781+ino5qbQUJUmO21cLP2eLeXYWzao5Vg==",
+            "dev": true
         },
         "node_modules/@types/estree": {
             "version": "1.0.6",
@@ -6469,6 +6476,22 @@
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
             }
+        },
+        "node_modules/mp4-muxer": {
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/mp4-muxer/-/mp4-muxer-5.2.0.tgz",
+            "integrity": "sha512-07Ju20lmrtY1VosOgFPNSuAOud4B4TJX5oD9Yq3BWX8eWkJl3ncOEkv7yO/ANBjwQb0eFlQF+DvWBPGxZaqoHg==",
+            "dev": true,
+            "dependencies": {
+                "@types/dom-webcodecs": "^0.1.6",
+                "@types/wicg-file-system-access": "^2020.9.5"
+            }
+        },
+        "node_modules/mp4-muxer/node_modules/@types/wicg-file-system-access": {
+            "version": "2020.9.8",
+            "resolved": "https://registry.npmjs.org/@types/wicg-file-system-access/-/wicg-file-system-access-2020.9.8.tgz",
+            "integrity": "sha512-ggMz8nOygG7d/stpH40WVaNvBwuyYLnrg5Mbyf6bmsj/8+gb6Ei4ZZ9/4PNpcPNTT8th9Q8sM8wYmWGjMWLX/A==",
+            "dev": true
         },
         "node_modules/ms": {
             "version": "2.1.3",

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
         "i18next-browser-languagedetector": "^8.0.4",
         "jest": "^29.7.0",
         "jszip": "^3.10.1",
+        "mp4-muxer": "^5.2.0",
         "playcanvas": "^2.5.1",
         "postcss": "^8.5.3",
         "rollup": "^4.34.8",

--- a/src/camera-poses.ts
+++ b/src/camera-poses.ts
@@ -32,7 +32,7 @@ const registerCameraPosesEvents = (events: Events) => {
             const duration = events.invoke('timeline.frames');
 
             // interpolate camera positions and camera target positions
-            const spline = CubicSpline.fromPointsLooping(duration, times, points);
+            const spline = CubicSpline.fromPointsLooping(duration, times, points, -1);
             const result: number[] = [];
             const pose = { position: new Vec3(), target: new Vec3() };
 

--- a/src/camera.ts
+++ b/src/camera.ts
@@ -71,6 +71,11 @@ class Camera extends Element {
 
     workRenderTarget: RenderTarget;
 
+    // overridden target size
+    targetSize: { width: number, height: number } = null;
+
+    suppressFinalBlit = false;
+
     updateCameraUniforms: () => void;
 
     constructor() {
@@ -355,7 +360,7 @@ class Camera extends Element {
     // handle the viewer canvas resizing
     rebuildRenderTargets() {
         const device = this.scene.graphicsDevice;
-        const { width, height } = this.scene.targetSize;
+        const { width, height } = this.targetSize ?? this.scene.targetSize;
 
         const rt = this.entity.camera.renderTarget;
         if (rt && rt.width === width && rt.height === height) {
@@ -472,7 +477,9 @@ class Camera extends Element {
         }
 
         // copy render target
-        device.copyRenderTarget(renderTarget, null, true, false);
+        if (!this.suppressFinalBlit) {
+            device.copyRenderTarget(renderTarget, null, true, false);
+        }
     }
 
     focus(options?: { focalPoint: Vec3, radius: number, speed: number }) {
@@ -641,6 +648,18 @@ class Camera extends Element {
         this.setDistance(settings.distance, 0);
         this.fov = settings.fov;
         this.tonemapping = settings.tonemapping;
+    }
+
+    // offscreen render mode
+
+    startOffscreenMode(width: number, height: number) {
+        this.targetSize = { width, height };
+        this.suppressFinalBlit = true;
+    }
+
+    endOffscreenMode() {
+        this.targetSize = null;
+        this.suppressFinalBlit = false;
     }
 }
 

--- a/src/camera.ts
+++ b/src/camera.ts
@@ -76,6 +76,8 @@ class Camera extends Element {
 
     suppressFinalBlit = false;
 
+    renderOverlays = true;
+
     updateCameraUniforms: () => void;
 
     constructor() {
@@ -652,12 +654,9 @@ class Camera extends Element {
 
     // offscreen render mode
 
-    startOffscreenMode(width: number, height: number, renderDebug: boolean) {
+    startOffscreenMode(width: number, height: number) {
         this.targetSize = { width, height };
         this.suppressFinalBlit = true;
-        if (!renderDebug) {
-            // disable debug overlays etc
-        }
     }
 
     endOffscreenMode() {

--- a/src/camera.ts
+++ b/src/camera.ts
@@ -652,9 +652,12 @@ class Camera extends Element {
 
     // offscreen render mode
 
-    startOffscreenMode(width: number, height: number) {
+    startOffscreenMode(width: number, height: number, renderDebug: boolean) {
         this.targetSize = { width, height };
         this.suppressFinalBlit = true;
+        if (!renderDebug) {
+            // disable debug overlays etc
+        }
     }
 
     endOffscreenMode() {

--- a/src/file-handler.ts
+++ b/src/file-handler.ts
@@ -140,7 +140,9 @@ const initFileHandler = (scene: Scene, events: Events, dropTarget: HTMLElement, 
             }
 
             const lowerFilename = (filename || url).toLowerCase();
-            if (lowerFilename.endsWith('.json')) {
+            if (lowerFilename.endsWith('.ssproj')) {
+                await events.invoke('doc.dropped', new File([await (await fetch(url)).blob()], filename));
+            } else if (lowerFilename.endsWith('.json')) {
                 await loadCameraPoses(url, filename, events);
             } else if (lowerFilename.endsWith('.ply') || lowerFilename.endsWith('.splat')) {
                 const model = await scene.assetLoader.loadModel({ url, filename, animationFrame });

--- a/src/infinite-grid.ts
+++ b/src/infinite-grid.ts
@@ -47,7 +47,7 @@ class InfiniteGrid extends Element {
         );
 
         this.scene.camera.entity.camera.on('preRenderLayer', (layer: Layer, transparent: boolean) => {
-            if (this.visible && layer === this.scene.debugLayer && !transparent) {
+            if (this.visible && layer === this.scene.debugLayer && !transparent && this.scene.camera.renderOverlays) {
                 device.setBlendState(blendState);
                 device.setCullMode(CULLFACE_NONE);
                 device.setDepthState(DepthState.WRITEDEPTH);

--- a/src/main.ts
+++ b/src/main.ts
@@ -8,6 +8,7 @@ import { Events } from './events';
 import { initFileHandler } from './file-handler';
 import { registerPlySequenceEvents } from './ply-sequence';
 import { registerPublishEvents } from './publish';
+import { registerRenderEvents } from './render';
 import { Scene } from './scene';
 import { getSceneConfig } from './scene-config';
 import { registerSelectionEvents } from './selection';
@@ -249,6 +250,7 @@ const main = async () => {
     registerPlySequenceEvents(events);
     registerPublishEvents(events);
     registerDocEvents(scene, events);
+    registerRenderEvents(scene, events);
     initShortcuts(events);
     initFileHandler(scene, events, editorUI.appContainer.dom, remoteStorageDetails);
 

--- a/src/publish.ts
+++ b/src/publish.ts
@@ -92,24 +92,17 @@ const publish = async (data: Uint8Array, publishSettings: PublishSettings, user:
 };
 
 const registerPublishEvents = (events: Events) => {
-    events.function('scene.publish', async () => {
+
+    events.function('publish.enabled', async () => {
+        return !!(await getUser());
+    });
+
+    events.function('scene.publish', async (publishSettings: PublishSettings) => {
         const user = await getUser();
 
-        if (!user) {
-            // use must be logged in to publish
-            await events.invoke('showPopup', {
-                type: 'error',
-                header: localize('popup.error'),
-                message: localize('publish.please-log-in')
-            });
+        if (!user || !publishSettings) {
+            return false;
         } else {
-            // get publish options
-            const publishSettings: PublishSettings = await events.invoke('show.publishSettingsDialog');
-
-            if (!publishSettings) {
-                return;
-            }
-
             try {
                 events.fire('startSpinner');
 

--- a/src/render.ts
+++ b/src/render.ts
@@ -92,7 +92,7 @@ const registerRenderEvents = (scene: Scene, events: Events) => {
                 video: {
                     codec: 'avc',
                     width,
-                    height,
+                    height
                 },
                 fastStart: 'in-memory',
                 firstTimestampBehavior: 'offset'

--- a/src/render.ts
+++ b/src/render.ts
@@ -1,12 +1,12 @@
+import { Muxer, ArrayBufferTarget } from 'mp4-muxer';
 import { path } from 'playcanvas';
 
 import { ElementType } from './element';
 import { Events } from './events';
-import { localize } from './ui/localization';
-import { Muxer, ArrayBufferTarget } from 'mp4-muxer';
 import { PngCompressor } from './png-compressor';
 import { Scene } from './scene';
 import { Splat } from './splat';
+import { localize } from './ui/localization';
 
 type VideoSettings = {
     startFrame: number;
@@ -95,7 +95,7 @@ const registerRenderEvents = (scene: Scene, events: Events) => {
                     // render is upside-down. use transform to flip it
                     rotation: [
                         1, 0, 0,
-                        0,-1, 0,
+                        0, -1, 0,
                         0, height, 1
                     ]
                 },
@@ -131,7 +131,7 @@ const registerRenderEvents = (scene: Scene, events: Events) => {
             const data = new Uint8Array(width * height * 4);
 
             // get the list of visible splats
-            const splats = (scene.getElementsByType(ElementType.splat) as Splat[]).filter((splat) => splat.visible);
+            const splats = (scene.getElementsByType(ElementType.splat) as Splat[]).filter(splat => splat.visible);
 
             // prepare the frame for rendering
             const prepareFrame = async (frame: number) => {
@@ -166,7 +166,7 @@ const registerRenderEvents = (scene: Scene, events: Events) => {
 
                 // construct the video frame
                 const videoFrame = new VideoFrame(data, {
-                    format: "RGBA",
+                    format: 'RGBA',
                     codedWidth: width,
                     codedHeight: height,
                     timestamp: 1e6 * frame / frameRate,

--- a/src/render.ts
+++ b/src/render.ts
@@ -1,0 +1,187 @@
+import { path } from 'playcanvas';
+
+import { Events } from './events';
+import { Muxer, ArrayBufferTarget } from 'mp4-muxer';
+import { PngCompressor } from './png-compressor';
+import { Scene } from './scene';
+import { Splat } from './splat';
+
+type VideoSettings = {
+    startFrame: number;
+    endFrame: number;
+    frameRate: number;
+    width: number;
+    height: number;
+};
+
+const replaceExtension = (filename: string, extension: string) => {
+    const removeExtension = (filename: string) => {
+        return filename.substring(0, filename.length - path.getExtension(filename).length);
+    };
+    return `${removeExtension(filename)}${extension}`;
+};
+
+const downloadFile = (arrayBuffer: ArrayBuffer, filename: string) => {
+    const blob = new Blob([arrayBuffer], { type: 'octet/stream' });
+    const url = window.URL.createObjectURL(blob);
+    const el = document.createElement('a');
+    el.download = filename;
+    el.href = url;
+    el.click();
+    window.URL.revokeObjectURL(url);
+};
+
+const registerRenderEvents = (scene: Scene, events: Events) => {
+    let compressor: PngCompressor;
+
+    events.function('render.screenshot', async () => {
+        events.fire('startSpinner');
+
+        try {
+            const renderTarget = scene.camera.entity.camera.renderTarget;
+            const texture = renderTarget.colorBuffer;
+            const data = new Uint8Array(texture.width * texture.height * 4);
+
+            await texture.read(0, 0, texture.width, texture.height, { renderTarget, data });
+
+            // construct the png compressor
+            if (!compressor) {
+                compressor = new PngCompressor();
+            }
+
+            // @ts-ignore
+            const pixels = new Uint8ClampedArray(data.buffer);
+
+            // the render buffer contains premultiplied alpha. so apply background color.
+            const { r, g, b } = events.invoke('bgClr');
+            for (let i = 0; i < pixels.length; i += 4) {
+                const a = 255 - pixels[i + 3];
+                pixels[i + 0] += r * a;
+                pixels[i + 1] += g * a;
+                pixels[i + 2] += b * a;
+                pixels[i + 3] = 255;
+            }
+
+            const arrayBuffer = await compressor.compress(
+                new Uint32Array(pixels.buffer),
+                texture.width,
+                texture.height
+            );
+
+            // construct filename
+            const selected = events.invoke('selection') as Splat;
+            const filename = replaceExtension(selected?.filename ?? 'SuperSplat', '.png');
+
+            // download
+            downloadFile(arrayBuffer, filename);
+        } finally {
+            events.fire('stopSpinner');
+        }
+    });
+
+    events.function('render.video', async (videoSettings: VideoSettings) => {
+        events.fire('startSpinner');
+        try {
+            const { startFrame, endFrame, frameRate, width, height } = videoSettings;
+
+            const muxer = new Muxer({
+                target: new ArrayBufferTarget(),
+                video: {
+                    codec: 'avc',
+                    width,
+                    height,
+                },
+                fastStart: 'in-memory',
+                firstTimestampBehavior: 'offset'
+            });
+
+            const encoder = new VideoEncoder({
+                output: (chunk, meta) => {
+                    muxer.addVideoChunk(chunk, meta);
+                },
+                error: (error) => console.log(error)
+            });
+
+            encoder.configure({
+                codec: 'avc1.420028', // H.264 codec
+                width,
+                height,
+                bitrate: 1e8
+            });
+
+            // start rendering to offscreen buffer only
+            scene.camera.startOffscreenMode(width, height);
+            scene.camera.entity.camera.clearColor.copy(events.invoke('bgClr'));
+            scene.lockedRenderMode = true;
+
+            // cpu-side buffer to read pixels into
+            const data = new Uint8Array(width * height * 4);
+
+            let currentFrame = -1;
+            let frameCaptured: (value: boolean) => void = null;
+
+            const captureFrame = scene.events.on('postrender', async () => {
+                const { renderTarget } = scene.camera.entity.camera;
+                const { colorBuffer } = renderTarget;
+
+                const currentF = currentFrame;
+                const capturedF = frameCaptured;
+                currentFrame = -1;
+                frameCaptured = null;
+
+                if (!capturedF) {
+                    return;
+                }
+
+                // read the texture data
+                await colorBuffer.read(0, 0, width, height, { renderTarget, data });
+
+                // construct the next video frame
+                const frame = new VideoFrame(data, {
+                    format: "RGBA",
+                    codedWidth: width,
+                    codedHeight: height,
+                    timestamp: 1e6 * currentF / frameRate,
+                    duration: 1 / frameRate
+                });
+                encoder.encode(frame);
+                frame.close();
+
+                capturedF(true);
+            });
+
+            for (let frame = startFrame; frame <= endFrame; frame++) {
+                currentFrame = frame;
+
+                // move the timeline which should invoke render
+                events.fire('timeline.setFrame', frame);
+                scene.lockedRender = true;
+
+                await new Promise<boolean>((resolve, reject) => {
+                    frameCaptured = resolve;
+                });
+            }
+
+            captureFrame.off();
+
+            // Flush and finalize muxer
+            await encoder.flush();
+            muxer.finalize();
+
+            // Download
+            const selected = events.invoke('selection') as Splat;
+            downloadFile(muxer.target.buffer, replaceExtension(selected?.filename ?? 'SuperSplat', '.mp4'));
+
+            // Free resources
+            encoder.close();
+        } finally {
+            scene.camera.endOffscreenMode();
+            scene.camera.entity.camera.clearColor.set(0, 0, 0, 0);
+            scene.lockedRenderMode = false;
+
+            events.fire('stopSpinner');
+        }
+    });
+};
+
+export { registerRenderEvents };

--- a/src/render.ts
+++ b/src/render.ts
@@ -122,7 +122,8 @@ const registerRenderEvents = (scene: Scene, events: Events) => {
             });
 
             // start rendering to offscreen buffer only
-            scene.camera.startOffscreenMode(width, height, showDebug);
+            scene.camera.startOffscreenMode(width, height);
+            scene.camera.renderOverlays = showDebug;
             if (!transparentBg) {
                 scene.camera.entity.camera.clearColor.copy(events.invoke('bgClr'));
             }
@@ -196,6 +197,7 @@ const registerRenderEvents = (scene: Scene, events: Events) => {
             });
         } finally {
             scene.camera.endOffscreenMode();
+            scene.camera.renderOverlays = true;
             scene.camera.entity.camera.clearColor.set(0, 0, 0, 0);
             scene.lockedRenderMode = false;
             scene.forceRender = true;       // camera likely moved, finish with normal render

--- a/src/render.ts
+++ b/src/render.ts
@@ -142,10 +142,15 @@ const registerRenderEvents = (scene: Scene, events: Events) => {
                     // create a promise for each splat that will resolve upon sorting complete
                     return new Promise<void>((resolve) => {
                         const { instance } = splat.entity.gsplat;
+
+                        // listen for the sorter to complete
                         const handle = instance.sorter.on('updated', () => {
                             handle.off();
                             resolve();
                         });
+
+                        // manually invoke sort because internally the engine sorts after render the
+                        // scene call is made.
                         instance.sort(scene.camera.entity);
 
                         // in cases where the camera does not move between frames the sorter won't run

--- a/src/scene.ts
+++ b/src/scene.ts
@@ -41,6 +41,9 @@ class Scene {
     boundDirty = true;
     forceRender = false;
 
+    lockedRenderMode = false;
+    lockedRender = false;
+
     canvasResize: {width: number; height: number} | null = null;
     targetSize = {
         width: 0,
@@ -315,7 +318,10 @@ class Scene {
         const all = new Set([...result.added, ...result.removed, ...result.moved, ...result.changed]);
 
         // compare with previously serialized
-        if (!this.app.renderNextFrame) {
+        if (this.lockedRenderMode) {
+            this.app.renderNextFrame = this.lockedRender;
+            this.lockedRender = false;
+        } else if (!this.app.renderNextFrame) {
             this.app.renderNextFrame = this.forceRender || all.size > 0;
         }
         this.forceRender = false;
@@ -377,6 +383,8 @@ class Scene {
 
     private onPostRender() {
         this.forEachElement(e => e.onPostRender());
+
+        this.events.fire('postrender');
     }
 }
 

--- a/src/splat-overlay.ts
+++ b/src/splat-overlay.ts
@@ -105,6 +105,7 @@ class SplatOverlay extends Element {
         const splatSize = events.invoke('camera.splatSize');
 
         if (this.meshInstance.node &&
+            this.scene.camera.renderOverlays &&
             splatSize > 0 &&
             events.invoke('camera.overlay') &&
             events.invoke('camera.mode') === 'centers') {

--- a/src/splat.ts
+++ b/src/splat.ts
@@ -343,7 +343,7 @@ class Splat extends Element {
 
     onPreRender() {
         const events = this.scene.events;
-        const selected = events.invoke('selection') === this;
+        const selected = this.scene.camera.renderOverlays && events.invoke('selection') === this;
         const cameraMode = events.invoke('camera.mode');
         const cameraOverlay = events.invoke('camera.overlay');
 

--- a/src/splat.ts
+++ b/src/splat.ts
@@ -393,6 +393,13 @@ class Splat extends Element {
         }
 
         this.entity.enabled = this.visible;
+
+        // Temp hack: override the splat viewport size because we're rendering to an offscreen
+        // render target and the engine currently always takes the backbuffer size.
+        // this workaround can be removed once https://github.com/playcanvas/engine/pull/7425 is
+        // available
+        const rt = this.scene.camera.entity.camera.renderTarget;
+        this.entity.gsplat.instance.meshInstance.setParameter('viewport', [rt.width, rt.height]);
     }
 
     focalPoint() {

--- a/src/sw.ts
+++ b/src/sw.ts
@@ -10,6 +10,8 @@ const cacheUrls = [
     './index.html',
     './index.css',
     './index.js',
+    './index.js.map',
+    './jszip.js',
     './manifest.json',
     './static/icons/logo-192.png',
     './static/icons/logo-512.png',

--- a/src/ui/editor.ts
+++ b/src/ui/editor.ts
@@ -17,9 +17,9 @@ import { ShortcutsPopup } from './shortcuts-popup';
 import { Spinner } from './spinner';
 import { TimelinePanel } from './timeline-panel';
 import { Tooltips } from './tooltips';
+import { VideoSettingsDialog } from './video-settings-dialog';
 import { ViewCube } from './view-cube';
 import { ViewPanel } from './view-panel';
-import { VideoSettingsDialog } from './video-settings-dialog';
 import { ViewerExportPopup } from './viewer-export-popup';
 import { version } from '../../package.json';
 

--- a/src/ui/editor.ts
+++ b/src/ui/editor.ts
@@ -197,12 +197,33 @@ class EditorUI {
             return viewerExportPopup.show(filename);
         });
 
-        events.function('show.publishSettingsDialog', () => {
-            return publishSettingsDialog.show();
+        events.function('show.publishSettingsDialog', async () => {
+            // show popup if user isn't logged in
+            const canPublish = await events.invoke('publish.enabled');
+            if (!canPublish) {
+                await events.invoke('showPopup', {
+                    type: 'error',
+                    header: localize('popup.error'),
+                    message: localize('publish.please-log-in')
+                });
+                return false;
+            }
+
+            // get user publish settings
+            const publishSettings = await publishSettingsDialog.show();
+
+            // do publish
+            if (publishSettings) {
+                await events.invoke('scene.publish', publishSettings);
+            }
         });
 
-        events.function('show.videoSettingsDialog', () => {
-            return videoSettingsDialog.show();
+        events.function('show.videoSettingsDialog', async () => {
+            const videoSettings = await videoSettingsDialog.show();
+
+            if (videoSettings) {
+                await events.invoke('render.video', videoSettings);
+            }
         });
 
         events.function('show.about', () => {

--- a/src/ui/editor.ts
+++ b/src/ui/editor.ts
@@ -19,6 +19,7 @@ import { TimelinePanel } from './timeline-panel';
 import { Tooltips } from './tooltips';
 import { ViewCube } from './view-cube';
 import { ViewPanel } from './view-panel';
+import { VideoSettingsDialog } from './video-settings-dialog';
 import { ViewerExportPopup } from './viewer-export-popup';
 import { version } from '../../package.json';
 
@@ -162,12 +163,16 @@ class EditorUI {
         // export popup
         const viewerExportPopup = new ViewerExportPopup(events);
 
-        // publish options
+        // publish settings
         const publishSettingsDialog = new PublishSettingsDialog(events);
+
+        // video settings
+        const videoSettingsDialog = new VideoSettingsDialog(events);
 
         topContainer.append(popup);
         topContainer.append(viewerExportPopup);
         topContainer.append(publishSettingsDialog);
+        topContainer.append(videoSettingsDialog);
 
         appContainer.append(editorContainer);
         appContainer.append(topContainer);
@@ -194,6 +199,10 @@ class EditorUI {
 
         events.function('show.publishSettingsDialog', () => {
             return publishSettingsDialog.show();
+        });
+
+        events.function('show.videoSettingsDialog', () => {
+            return videoSettingsDialog.show();
         });
 
         events.function('show.about', () => {

--- a/src/ui/localization.ts
+++ b/src/ui/localization.ts
@@ -411,6 +411,8 @@ const localizeInit = () => {
                     // Video Settings Dialog
                     'video.header': 'VIDEO SETTINGS',
                     'video.resolution': 'Resolution',
+                    'video.bitrate': 'Bitrate',
+                    'video.portrait': 'Portrait Mode',
                     'video.transparentBg': 'Transparent Background',
                     'video.showDebug': 'Show Debug Overlays',
 

--- a/src/ui/localization.ts
+++ b/src/ui/localization.ts
@@ -21,7 +21,6 @@ const localizeInit = () => {
                     'file.load-all-data': 'PLY-Daten vollständig laden',
                     'file.save': 'Speichern',
                     'file.save-as': 'Speichern als...',
-                    'file.save-screenshot': 'Screenshot speichern',
                     'file.publish': 'Veröffentlichen...',
                     'file.export': 'Exportieren',
                     'file.export.compressed-ply': 'Komprimiertes PLY',
@@ -198,7 +197,6 @@ const localizeInit = () => {
                     'file.load-all-data': 'Load all PLY data',
                     'file.save': 'Save',
                     'file.save-as': 'Save As...',
-                    'file.save-screenshot': 'Save Screenshot',
                     'file.publish': 'Publish...',
                     'file.export': 'Export',
                     'file.export.ply': 'PLY (.ply)',
@@ -207,8 +205,8 @@ const localizeInit = () => {
                     'file.export.viewer': 'Viewer App...',
 
                     'render': 'Render',
-                    'render.screenshot': 'Screenshot',
-                    'render.video': 'Video',
+                    'render.image': 'Image',
+                    'render.video': 'Video...',
 
                     // Selection menu
                     'select': 'Select',
@@ -410,6 +408,12 @@ const localizeInit = () => {
                     'publish.message': 'Use the link below to access your scene.',
                     'publish.please-log-in': 'Publishing to PlayCanvas requires a user account. Please log in and try again.',
 
+                    // Video Settings Dialog
+                    'video.header': 'VIDEO SETTINGS',
+                    'video.resolution': 'Resolution',
+                    'video.transparentBg': 'Transparent Background',
+                    'video.showDebug': 'Show Debug Overlays',
+
                     // Timeline
                     'timeline.prev-key': 'Jump to previous keyframe',
                     'timeline.play': 'Play/Stop',
@@ -430,7 +434,6 @@ const localizeInit = () => {
                     'file.load-all-data': 'Charger toutes les données ply',
                     'file.save': 'Enregistrer',
                     'file.save-as': 'Enregistrer sous...',
-                    'file.save-screenshot': 'Enregistrer une capture d\'écran',
                     'file.publish': 'Publier...',
                     'file.export': 'Exporter',
                     'file.export.compressed-ply': 'Ply compressé',
@@ -607,7 +610,6 @@ const localizeInit = () => {
                     'file.load-all-data': '全てのPLYデータを読み込む',
                     'file.save': '保存',
                     'file.save-as': '名前を付けて保存',
-                    'file.save-screenshot': 'スクリーンショットを保存',
                     'file.publish': '公開...',
                     'file.export': 'エクスポート',
                     'file.export.compressed-ply': 'Compressed PLY (.ply)',
@@ -784,7 +786,6 @@ const localizeInit = () => {
                     'file.load-all-data': '모든 PLY 데이터 불러오기',
                     'file.save': '저장',
                     'file.save-as': '다른 이름으로 저장...',
-                    'file.save-screenshot': '스크린샷 저장',
                     'file.publish': '게시...',
                     'file.export': '내보내기',
                     'file.export.compressed-ply': '압축된 PLY',
@@ -961,7 +962,6 @@ const localizeInit = () => {
                     'file.load-all-data': '加载所有 PLY 数据',
                     'file.save': '保存',
                     'file.save-as': '另存为...',
-                    'file.save-screenshot': '保存截图',
                     'file.publish': '发布...',
                     'file.export': '导出',
                     'file.export.compressed-ply': '压缩 PLY',

--- a/src/ui/localization.ts
+++ b/src/ui/localization.ts
@@ -206,6 +206,10 @@ const localizeInit = () => {
                     'file.export.splat': 'Splat file (.splat)',
                     'file.export.viewer': 'Viewer App...',
 
+                    'render': 'Render',
+                    'render.screenshot': 'Screenshot',
+                    'render.video': 'Video',
+
                     // Selection menu
                     'select': 'Select',
                     'select.all': 'All',

--- a/src/ui/menu.ts
+++ b/src/ui/menu.ts
@@ -171,23 +171,17 @@ class Menu extends Container {
             text: localize('file.publish'),
             icon: createSvg(scenePublish),
             isEnabled: () => !events.invoke('scene.empty'),
-            onSelect: () => events.invoke('scene.publish')
+            onSelect: async () => await events.invoke('show.publishSettingsDialog')
         }]);
 
         const renderMenuPanel = new MenuPanel([{
-            text: localize('render.screenshot'),
+            text: localize('render.image'),
             icon: createSvg(sceneExport),
-            onSelect: () => events.invoke('render.screenshot')
+            onSelect: () => events.invoke('render.image')
         }, {
             text: localize('render.video'),
             icon: createSvg(sceneExport),
-            onSelect: () => events.invoke('render.video', {
-                startFrame: 0,
-                endFrame: events.invoke('timeline.frames') - 1,
-                frameRate: events.invoke('timeline.frameRate'),
-                width: 1920,
-                height: 1080
-            })
+            onSelect: async () => await events.invoke('show.videoSettingsDialog')
         }]);
 
         const selectionMenuPanel = new MenuPanel([{

--- a/src/ui/menu.ts
+++ b/src/ui/menu.ts
@@ -99,8 +99,8 @@ class Menu extends Container {
             id: 'menu-bar-options'
         });
         buttonsContainer.append(scene);
-        buttonsContainer.append(render);
         buttonsContainer.append(selection);
+        buttonsContainer.append(render);
         buttonsContainer.append(help);
         buttonsContainer.append(collapse);
         buttonsContainer.append(arrow);

--- a/src/ui/menu.ts
+++ b/src/ui/menu.ts
@@ -174,16 +174,6 @@ class Menu extends Container {
             onSelect: async () => await events.invoke('show.publishSettingsDialog')
         }]);
 
-        const renderMenuPanel = new MenuPanel([{
-            text: localize('render.image'),
-            icon: createSvg(sceneExport),
-            onSelect: () => events.invoke('render.image')
-        }, {
-            text: localize('render.video'),
-            icon: createSvg(sceneExport),
-            onSelect: async () => await events.invoke('show.videoSettingsDialog')
-        }]);
-
         const selectionMenuPanel = new MenuPanel([{
             text: localize('select.all'),
             icon: createSvg(selectAll),
@@ -235,6 +225,16 @@ class Menu extends Container {
             onSelect: () => events.fire('select.separate')
         }]);
 
+        const renderMenuPanel = new MenuPanel([{
+            text: localize('render.image'),
+            icon: createSvg(sceneExport),
+            onSelect: () => events.invoke('render.image')
+        }, {
+            text: localize('render.video'),
+            icon: createSvg(sceneExport),
+            onSelect: async () => await events.invoke('show.videoSettingsDialog')
+        }]);
+
         const helpMenuPanel = new MenuPanel([{
             text: localize('help.shortcuts'),
             icon: 'E136',
@@ -278,19 +278,19 @@ class Menu extends Container {
         this.append(menubar);
         this.append(fileMenuPanel);
         this.append(exportMenuPanel);
-        this.append(renderMenuPanel);
         this.append(selectionMenuPanel);
+        this.append(renderMenuPanel);
         this.append(helpMenuPanel);
 
         const options: { dom: HTMLElement, menuPanel: MenuPanel }[] = [{
             dom: scene.dom,
             menuPanel: fileMenuPanel
         }, {
-            dom: render.dom,
-            menuPanel: renderMenuPanel
-        }, {
             dom: selection.dom,
             menuPanel: selectionMenuPanel
+        }, {
+            dom: render.dom,
+            menuPanel: renderMenuPanel
         }, {
             dom: help.dom,
             menuPanel: helpMenuPanel

--- a/src/ui/menu.ts
+++ b/src/ui/menu.ts
@@ -61,6 +61,11 @@ class Menu extends Container {
             class: 'menu-option'
         });
 
+        const render = new Label({
+            text: localize('render'),
+            class: 'menu-option'
+        });
+
         const selection = new Label({
             text: localize('select'),
             class: 'menu-option'
@@ -94,6 +99,7 @@ class Menu extends Container {
             id: 'menu-options-container'
         });
         buttonsContainer.append(scene);
+        buttonsContainer.append(render);
         buttonsContainer.append(selection);
         buttonsContainer.append(help);
         buttonsContainer.append(collapse);
@@ -126,7 +132,7 @@ class Menu extends Container {
             onSelect: () => events.invoke('scene.export', 'viewer')
         }]);
 
-        const sceneMenuPanel = new MenuPanel([{
+        const fileMenuPanel = new MenuPanel([{
             text: localize('file.new'),
             icon: createSvg(sceneNew),
             isEnabled: () => !events.invoke('scene.empty'),
@@ -150,11 +156,6 @@ class Menu extends Container {
             isEnabled: () => !events.invoke('scene.empty'),
             onSelect: async () => await events.invoke('doc.saveAs')
         }, {
-            text: localize('file.save-screenshot'),
-            icon: createSvg(sceneExport),
-            isEnabled: () => true,
-            onSelect: () => events.invoke('scene.saveScreenshot')
-        }, {
             // separator
         }, {
             text: localize('file.import'),
@@ -171,6 +172,22 @@ class Menu extends Container {
             icon: createSvg(scenePublish),
             isEnabled: () => !events.invoke('scene.empty'),
             onSelect: () => events.invoke('scene.publish')
+        }]);
+
+        const renderMenuPanel = new MenuPanel([{
+            text: localize('render.screenshot'),
+            icon: createSvg(sceneExport),
+            onSelect: () => events.invoke('render.screenshot')
+        }, {
+            text: localize('render.video'),
+            icon: createSvg(sceneExport),
+            onSelect: () => events.invoke('render.video', {
+                startFrame: 0,
+                endFrame: events.invoke('timeline.frames') - 1,
+                frameRate: events.invoke('timeline.frameRate'),
+                width: 1920,
+                height: 1080
+            })
         }]);
 
         const selectionMenuPanel = new MenuPanel([{
@@ -265,14 +282,18 @@ class Menu extends Container {
         }]);
 
         this.append(menubar);
-        this.append(sceneMenuPanel);
+        this.append(fileMenuPanel);
         this.append(exportMenuPanel);
+        this.append(renderMenuPanel);
         this.append(selectionMenuPanel);
         this.append(helpMenuPanel);
 
         const options: { dom: HTMLElement, menuPanel: MenuPanel }[] = [{
             dom: scene.dom,
-            menuPanel: sceneMenuPanel
+            menuPanel: fileMenuPanel
+        }, {
+            dom: render.dom,
+            menuPanel: renderMenuPanel
         }, {
             dom: selection.dom,
             menuPanel: selectionMenuPanel

--- a/src/ui/menu.ts
+++ b/src/ui/menu.ts
@@ -96,7 +96,7 @@ class Menu extends Container {
         arrow.dom.addEventListener('click', toggleCollapsed);
 
         const buttonsContainer = new Container({
-            id: 'menu-options-container'
+            id: 'menu-bar-options'
         });
         buttonsContainer.append(scene);
         buttonsContainer.append(render);

--- a/src/ui/publish-settings-dialog.ts
+++ b/src/ui/publish-settings-dialog.ts
@@ -217,7 +217,7 @@ class PublishSettingsDialog extends Container {
 
         // function implementations
 
-        this.show = async () => {
+        this.show = () => {
             // check user is logged in
             reset();
 
@@ -230,7 +230,7 @@ class PublishSettingsDialog extends Container {
                     resolve(null);
                 };
 
-                onOK = async () => {
+                onOK = () => {
                     const frames = events.invoke('timeline.frames');
                     const frameRate = events.invoke('timeline.frameRate');
 

--- a/src/ui/publish-settings-dialog.ts
+++ b/src/ui/publish-settings-dialog.ts
@@ -16,7 +16,7 @@ const createSvg = (svgString: string, args = {}) => {
 };
 
 class PublishSettingsDialog extends Container {
-    show: () => void;
+    show: () => Promise<PublishSettings | null>;
     hide: () => void;
     destroy: () => void;
 
@@ -219,26 +219,15 @@ class PublishSettingsDialog extends Container {
 
         this.show = async () => {
             // check user is logged in
-            const canPublish = await events.invoke('publish.enabled');
-
-            if (!canPublish) {
-                await events.invoke('showPopup', {
-                    type: 'error',
-                    header: localize('popup.error'),
-                    message: localize('publish.please-log-in')
-                });
-                return false;
-            }
-
             reset();
 
             this.hidden = false;
             this.dom.addEventListener('keydown', keydown);
             this.dom.focus();
 
-            return new Promise<boolean>((resolve) => {
+            return new Promise<PublishSettings>((resolve) => {
                 onCancel = () => {
-                    resolve(false);
+                    resolve(null);
                 };
 
                 onOK = async () => {
@@ -325,15 +314,13 @@ class PublishSettingsDialog extends Container {
                         removeInvalid: true                     // remove gaussians with any NaN data
                     };
 
-                    const result = await events.invoke('scene.publish', {
+                    resolve({
                         title: titleInput.value,
                         description: descInput.value,
                         listed: listBoolean.value,
                         serializeSettings,
                         experienceSettings
                     });
-
-                    resolve(result);
                 };
             }).finally(() => {
                 this.dom.removeEventListener('keydown', keydown);

--- a/src/ui/scss/menu.scss
+++ b/src/ui/scss/menu.scss
@@ -10,7 +10,6 @@
     position: absolute;
     top: 24px;
     left: 24px;
-    width: 320px;
     height: 50px;
     border-radius: 8px;
 
@@ -39,7 +38,7 @@
     flex-direction: column;
 }
 
-#menu-options-container {
+#menu-bar-options {
     display: flex;
     flex-direction: row;
     flex-grow: 1;

--- a/src/ui/scss/settings-dialog.scss
+++ b/src/ui/scss/settings-dialog.scss
@@ -1,6 +1,6 @@
 @use 'colors.scss' as *;
 
-#publish-settings-dialog {
+.settings-dialog {
     width: 100%;
     height: 100%;
 

--- a/src/ui/scss/style.scss
+++ b/src/ui/scss/style.scss
@@ -15,10 +15,10 @@
 @use 'data-panel.scss';
 @use 'popup.scss';
 @use 'mode-toggle.scss';
+@use 'settings-dialog.scss';
 @use 'spinner.scss';
 @use 'viewer-export-popup.scss';
 @use 'timeline-panel.scss';
-@use 'publish-settings-dialog.scss';
 
 * {
     font-size: 12px;

--- a/src/ui/video-settings-dialog.ts
+++ b/src/ui/video-settings-dialog.ts
@@ -1,0 +1,225 @@
+import { BooleanInput, Button, ColorPicker, Container, Element, Label, SelectInput, SliderInput, TextAreaInput, TextInput } from 'pcui';
+
+import { Pose } from '../camera-poses';
+import { Events } from '../events';
+import { localize } from './localization';
+import { PublishSettings } from '../publish';
+import { AnimTrack, ExperienceSettings } from '../splat-serialize';
+import sceneExport from './svg/export.svg';
+
+const createSvg = (svgString: string, args = {}) => {
+    const decodedStr = decodeURIComponent(svgString.substring('data:image/svg+xml,'.length));
+    return new Element({
+        dom: new DOMParser().parseFromString(decodedStr, 'image/svg+xml').documentElement,
+        ...args
+    });
+};
+
+class VideoSettingsDialog extends Container {
+    show: () => void;
+    hide: () => void;
+    destroy: () => void;
+
+    constructor(events: Events, args = {}) {
+        args = {
+            ...args,
+            id: 'video-settings-dialog',
+            class: 'settings-dialog',
+            hidden: true,
+            tabIndex: -1
+        };
+
+        super(args);
+
+        const dialog = new Container({
+            id: 'dialog'
+        });
+
+        // header
+
+        const headerIcon = createSvg(sceneExport, { id: 'icon' });
+        const headerText = new Label({ id: 'text', text: localize('video.header') });
+        const header = new Container({ id: 'header' });
+        header.append(headerIcon);
+        header.append(headerText);
+
+        // resolution
+
+        const resolutionLabel = new Label({ class: 'label', text: localize('video.resolution') });
+        const resolutionSelect = new SelectInput({
+            class: 'select',
+            defaultValue: '1080',
+            options: [
+                { v: '540', t: '960x540' },
+                { v: '720', t: '1280x720' },
+                { v: '1080', t: '1920x1080' },
+                { v: '1440', t:  '2560x1440' },
+                { v: '4k', t: '3840x2160' }
+            ]
+        });
+        const resolutionRow = new Container({ class: 'row' });
+        resolutionRow.append(resolutionLabel);
+        resolutionRow.append(resolutionSelect);
+
+        // bitrate
+
+        const bitrateLabel = new Label({ class: 'label', text: localize('video.resolution') });
+        const bitrateSelect = new SelectInput({
+            class: 'select',
+            defaultValue: '5',
+            options: [
+                { v: '2', t: '2mbps' },
+                { v: '5', t: '5mbps' },
+                { v: '8', t:  '8mbps' },
+                { v: '16', t: '16mbps' }
+            ]
+        });
+        const bitrateRow = new Container({ class: 'row' });
+        bitrateRow.append(bitrateLabel);
+        bitrateRow.append(bitrateSelect);
+
+        // transparent background
+
+        const transparentBgLabel = new Label({ class: 'label', text: localize('video.transparentBg') });
+        const transparentBgBoolean = new BooleanInput({ class: 'boolean', value: false });
+        const transparentBgRow = new Container({ class: 'row' });
+        transparentBgRow.append(transparentBgLabel);
+        transparentBgRow.append(transparentBgBoolean);
+
+        // hide transparent background till we add support for webm
+        // video container
+        transparentBgRow.hidden = true;
+
+        // show debug overlays
+
+        const showDebugLabel = new Label({ class: 'label', text: localize('video.showDebug') });
+        const showDebugBoolean = new BooleanInput({ class: 'boolean', value: false });
+        const showDebugRow = new Container({ class: 'row' });
+        showDebugRow.append(showDebugLabel);
+        showDebugRow.append(showDebugBoolean);
+
+        // content
+
+        const content = new Container({ id: 'content' });
+        content.append(resolutionRow);
+        content.append(bitrateRow);
+        content.append(transparentBgRow);
+        content.append(showDebugRow);
+
+        // footer
+
+        const footer = new Container({ id: 'footer' });
+
+        const cancelButton = new Button({
+            class: 'button',
+            text: localize('publish.cancel')
+        });
+
+        const okButton = new Button({
+            class: 'button',
+            text: localize('publish.ok')
+        });
+
+        footer.append(cancelButton);
+        footer.append(okButton);
+
+        dialog.append(header);
+        dialog.append(content);
+        dialog.append(footer);
+
+        this.append(dialog);
+
+        // handle key bindings for enter and escape
+
+        let onCancel: () => void;
+        let onOK: () => void;
+
+        cancelButton.on('click', () => onCancel());
+        okButton.on('click', () => onOK());
+
+        const keydown = (e: KeyboardEvent) => {
+            switch (e.key) {
+                case 'Escape':
+                    onCancel();
+                    break;
+                case 'Enter':
+                    if (!e.shiftKey) onOK();
+                    break;
+                default:
+                    e.stopPropagation();
+                    break;
+            }
+        };
+
+        // reset UI and configure for current state
+        const reset = () => {
+            
+        };
+
+        // function implementations
+
+        this.show = () => {
+            reset();
+
+            this.hidden = false;
+            this.dom.addEventListener('keydown', keydown);
+            this.dom.focus();
+
+            return new Promise<null | PublishSettings>((resolve) => {
+                onCancel = () => {
+                    resolve(null);
+                };
+
+                onOK = async () => {
+
+                    const widths: Record<string, number> = {
+                        '540': 960,
+                        '720': 1280,
+                        '1080': 1920,
+                        '1440': 2560,
+                        '4k': 3840
+                    };
+
+                    const heights: Record<string, number> = {
+                        '540': 540,
+                        '720': 720,
+                        '1080': 1080,
+                        '1440': 1440,
+                        '4k': 2160
+                    };
+
+                    const videoSettings = {
+                        startFrame: 0,
+                        endFrame: events.invoke('timeline.frames') - 1,
+                        frameRate: events.invoke('timeline.frameRate'),
+                        width: widths[resolutionSelect.value],
+                        height: heights[resolutionSelect.value],
+                        bitrate: parseInt(bitrateSelect.value) * 1e8,
+                        transparentBg: transparentBgBoolean.value,
+                        showDebug: showDebugBoolean.value
+                    };
+
+                    console.log(videoSettings);
+
+                    const result = await events.invoke('render.video', videoSettings);
+
+                    resolve(result);
+                };
+            }).finally(() => {
+                this.dom.removeEventListener('keydown', keydown);
+                this.hide();
+            });
+        };
+
+        this.hide = () => {
+            this.hidden = true;
+        };
+
+        this.destroy = () => {
+            this.hide();
+            super.destroy();
+        };
+    }
+}
+
+export { VideoSettingsDialog };

--- a/src/ui/video-settings-dialog.ts
+++ b/src/ui/video-settings-dialog.ts
@@ -1,7 +1,7 @@
 import { BooleanInput, Button, Container, Element, Label, SelectInput } from 'pcui';
 
-import { VideoSettings } from '../render';
 import { Events } from '../events';
+import { VideoSettings } from '../render';
 import { localize } from './localization';
 import sceneExport from './svg/export.svg';
 
@@ -177,7 +177,7 @@ class VideoSettingsDialog extends Container {
                     resolve(null);
                 };
 
-                onOK = async () => {
+                onOK = () => {
 
                     const widths: Record<string, number> = {
                         '540': 960,

--- a/src/ui/video-settings-dialog.ts
+++ b/src/ui/video-settings-dialog.ts
@@ -1,10 +1,8 @@
-import { BooleanInput, Button, ColorPicker, Container, Element, Label, SelectInput, SliderInput, TextAreaInput, TextInput } from 'pcui';
+import { BooleanInput, Button, Container, Element, Label, SelectInput } from 'pcui';
 
-import { Pose } from '../camera-poses';
+import { VideoSettings } from '../render';
 import { Events } from '../events';
 import { localize } from './localization';
-import { PublishSettings } from '../publish';
-import { AnimTrack, ExperienceSettings } from '../splat-serialize';
 import sceneExport from './svg/export.svg';
 
 const createSvg = (svgString: string, args = {}) => {
@@ -16,7 +14,7 @@ const createSvg = (svgString: string, args = {}) => {
 };
 
 class VideoSettingsDialog extends Container {
-    show: () => void;
+    show: () => Promise<VideoSettings | null>;
     hide: () => void;
     destroy: () => void;
 
@@ -174,7 +172,7 @@ class VideoSettingsDialog extends Container {
             this.dom.addEventListener('keydown', keydown);
             this.dom.focus();
 
-            return new Promise<null | PublishSettings>((resolve) => {
+            return new Promise<VideoSettings | null>((resolve) => {
                 onCancel = () => {
                     resolve(null);
                 };
@@ -210,11 +208,7 @@ class VideoSettingsDialog extends Container {
                         showDebug: showDebugBoolean.value
                     };
 
-                    console.log(videoSettings);
-
-                    const result = await events.invoke('render.video', videoSettings);
-
-                    resolve(result);
+                    resolve(videoSettings);
                 };
             }).finally(() => {
                 this.dom.removeEventListener('keydown', keydown);

--- a/src/ui/video-settings-dialog.ts
+++ b/src/ui/video-settings-dialog.ts
@@ -53,7 +53,7 @@ class VideoSettingsDialog extends Container {
                 { v: '540', t: '960x540' },
                 { v: '720', t: '1280x720' },
                 { v: '1080', t: '1920x1080' },
-                { v: '1440', t:  '2560x1440' },
+                { v: '1440', t: '2560x1440' },
                 { v: '4k', t: '3840x2160' }
             ]
         });
@@ -70,7 +70,7 @@ class VideoSettingsDialog extends Container {
             options: [
                 { v: '2', t: '2mbps' },
                 { v: '5', t: '5mbps' },
-                { v: '8', t:  '8mbps' },
+                { v: '8', t: '8mbps' },
                 { v: '16', t: '16mbps' }
             ]
         });
@@ -162,7 +162,7 @@ class VideoSettingsDialog extends Container {
 
         // reset UI and configure for current state
         const reset = () => {
-            
+
         };
 
         // function implementations
@@ -205,7 +205,7 @@ class VideoSettingsDialog extends Container {
                         frameRate: events.invoke('timeline.frameRate'),
                         width: (portrait ? heights : widths)[resolutionSelect.value],
                         height: (portrait ? widths : heights)[resolutionSelect.value],
-                        bitrate: parseInt(bitrateSelect.value) * 1e8,
+                        bitrate: parseInt(bitrateSelect.value, 10) * 1e8,
                         transparentBg: transparentBgBoolean.value,
                         showDebug: showDebugBoolean.value
                     };

--- a/src/ui/video-settings-dialog.ts
+++ b/src/ui/video-settings-dialog.ts
@@ -63,7 +63,7 @@ class VideoSettingsDialog extends Container {
 
         // bitrate
 
-        const bitrateLabel = new Label({ class: 'label', text: localize('video.resolution') });
+        const bitrateLabel = new Label({ class: 'label', text: localize('video.bitrate') });
         const bitrateSelect = new SelectInput({
             class: 'select',
             defaultValue: '5',
@@ -77,6 +77,14 @@ class VideoSettingsDialog extends Container {
         const bitrateRow = new Container({ class: 'row' });
         bitrateRow.append(bitrateLabel);
         bitrateRow.append(bitrateSelect);
+
+        // portrait mode
+
+        const portraitLabel = new Label({ class: 'label', text: localize('video.portrait') });
+        const portraitBoolean = new BooleanInput({ class: 'boolean', value: false });
+        const portraitRow = new Container({ class: 'row' });
+        portraitRow.append(portraitLabel);
+        portraitRow.append(portraitBoolean);
 
         // transparent background
 
@@ -103,6 +111,7 @@ class VideoSettingsDialog extends Container {
         const content = new Container({ id: 'content' });
         content.append(resolutionRow);
         content.append(bitrateRow);
+        content.append(portraitRow);
         content.append(transparentBgRow);
         content.append(showDebugRow);
 
@@ -188,12 +197,14 @@ class VideoSettingsDialog extends Container {
                         '4k': 2160
                     };
 
+                    const portrait = portraitBoolean.value;
+
                     const videoSettings = {
                         startFrame: 0,
                         endFrame: events.invoke('timeline.frames') - 1,
                         frameRate: events.invoke('timeline.frameRate'),
-                        width: widths[resolutionSelect.value],
-                        height: heights[resolutionSelect.value],
+                        width: (portrait ? heights : widths)[resolutionSelect.value],
+                        height: (portrait ? widths : heights)[resolutionSelect.value],
                         bitrate: parseInt(bitrateSelect.value) * 1e8,
                         transparentBg: transparentBgBoolean.value,
                         showDebug: showDebugBoolean.value


### PR DESCRIPTION
Fixes: #430

This PR adds support for exporting a video of the camera animation.

The main menu is updated with a new render menu:

<img width="382" alt="Screenshot 2025-03-12 at 14 52 48" src="https://github.com/user-attachments/assets/9b9ace3d-123f-4b85-8759-51c5bcce555a" />

Image render works as it did before.

The Render -> Video... option displays a settings dialog:

<img width="411" alt="Screenshot 2025-03-12 at 14 53 45" src="https://github.com/user-attachments/assets/49538743-272c-465c-a46a-298f0dd2d940" />

## Notes:
- only simple export options are available. we can add to these as users put in requests
- transparent background option is not exposed. we can add support for this using webm container (mp4 doesn't support transparent background)
- file is downloaded as usual browser download, we may wish to show file selector popup instead
