### PR TITLE
Publish camera animation frameRate

### DIFF
--- a/src/data-processor.ts
+++ b/src/data-processor.ts
@@ -17,7 +17,6 @@ import {
     BlendState
 } from 'playcanvas';
 
-
 import { vertexShader as boundVS, fragmentShader as boundFS } from './shaders/bound-shader';
 import { vertexShader as intersectionVS, fragmentShader as intersectionFS } from './shaders/intersection-shader';
 import { vertexShader as positionVS, fragmentShader as positionFS } from './shaders/position-shader';

--- a/src/splat-serialize.ts
+++ b/src/splat-serialize.ts
@@ -36,6 +36,7 @@ type SerializeSettings = {
 type AnimTrack = {
     name: string,
     duration: number,
+    frameRate: number,
     target: 'camera',
     loopMode: 'none' | 'repeat' | 'pingpong',
     interpolation: 'step' | 'spline',

--- a/src/ui/publish-settings-dialog.ts
+++ b/src/ui/publish-settings-dialog.ts
@@ -272,14 +272,15 @@ class PublishSettingsDialog extends Container {
                             const target = [];
                             for (let i = 0; i < orderedPoses.length; ++i) {
                                 const p = orderedPoses[i];
-                                times.push(p.frame / frameRate);
+                                times.push(p.frame);
                                 position.push(p.position.x, p.position.y, p.position.z);
                                 target.push(p.target.x, p.target.y, p.target.z);
                             }
 
                             animTracks.push({
                                 name: 'cameraAnim',
-                                duration: frames / frameRate,
+                                duration: frames,
+                                frameRate,
                                 target: 'camera',
                                 loopMode: 'repeat',
                                 interpolation: 'spline',


### PR DESCRIPTION
SuperSplat was exporting normalised camera animation keyframes (based on time) which was changing the spline smoothness since we calculate tangents based on keys.

This PR publishes the frameRate and original key times instead.,