### PR TITLE
Ply sequence fixes

### DIFF
--- a/src/file-handler.ts
+++ b/src/file-handler.ts
@@ -213,7 +213,7 @@ const initFileHandler = (scene: Scene, events: Events, dropTarget: HTMLElement, 
             // a frame number, e.g. "frame0001.ply", "frame0002.ply", etc.
             const isSequence = () => {
                 // eslint-disable-next-line regexp/no-super-linear-backtracking
-                const regex = /(.*?)(\d+).ply$/;
+                const regex = /(.*?)(\d+)(?:\.compressed)?\.ply$/;
                 const baseMatch = entries[0].file.name?.toLowerCase().match(regex);
                 if (!baseMatch) {
                     return false;

--- a/src/ply-sequence.ts
+++ b/src/ply-sequence.ts
@@ -10,12 +10,12 @@ const registerPlySequenceEvents = (events: Events) => {
 
     const setFrames = (files: File[]) => {
         // eslint-disable-next-line regexp/no-super-linear-backtracking
-        const regex = /(.*?)(\d+).ply$/;
+        const regex = /(.*?)(\d+)(?:\.compressed)?\.ply$/;
 
         // sort frames by trailing number, if it exists
         const sorter = (a: File, b: File) => {
-            const avalue = a.name?.match(regex)?.[2];
-            const bvalue = b.name?.match(regex)?.[2];
+            const avalue = a.name?.toLowerCase().match(regex)?.[2];
+            const bvalue = b.name?.toLowerCase().match(regex)?.[2];
             return (avalue && bvalue) ? parseInt(avalue, 10) - parseInt(bvalue, 10) : 0;
         };
 


### PR DESCRIPTION
Fixes for loading ply sequences:
- support .ply and .compressed.ply filename convention
- fix bug where sequences with capitals in extension (PLY) weren't correctly ordered