### PR TITLE
Another build update

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,9 @@
         "build:local": "cross-env ENGINE_PATH=../engine npm run build",
         "watch:local": "cross-env ENGINE_PATH=../engine npm run watch",
         "lint": "eslint src",
-        "postinstall": "git submodule update --init && cd submodules/supersplat-viewer && npm i && npm run build"
+        "postinstall": "npm run install:deps && npm run build:deps",
+        "install:deps": "npm --prefix ./submodules/supersplat-viewer ci",
+        "build:deps": "npm --prefix ./submodules/supersplat-viewer run build"
     },
     "devDependencies": {
         "@playcanvas/eslint-config": "^2.0.9",


### PR DESCRIPTION
Actually an earlier build issue we experienced on Windows was due to an npm bug (see [here](https://github.com/npm/cli/issues/7722)).

This PR reverts back to the original build config, but uses `npm ci`, which works with prefix on Windows.

Also remove automatic `git submodule update` call since this clashes with CI.