### PR TITLE
Update default pivot and camera

### DIFF
--- a/src/file-handler.ts
+++ b/src/file-handler.ts
@@ -129,7 +129,7 @@ const loadCameraPoses = async (url: string, filename: string, events: Events) =>
 const initFileHandler = (scene: Scene, events: Events, dropTarget: HTMLElement, remoteStorageDetails: RemoteStorageDetails) => {
 
     // returns a promise that resolves when the file is loaded
-    const handleImport = async (url: string, filename?: string, focusCamera = true, animationFrame = false) => {
+    const handleImport = async (url: string, filename?: string, animationFrame = false) => {
         try {
             if (!filename) {
                 // extract filename from url if one isn't provided
@@ -148,7 +148,6 @@ const initFileHandler = (scene: Scene, events: Events, dropTarget: HTMLElement, 
             } else if (lowerFilename.endsWith('.ply') || lowerFilename.endsWith('.splat')) {
                 const model = await scene.assetLoader.loadModel({ url, filename, animationFrame });
                 scene.add(model);
-                if (focusCamera) scene.camera.focus();
                 return model;
             } else {
                 throw new Error('Unsupported file type');
@@ -162,8 +161,8 @@ const initFileHandler = (scene: Scene, events: Events, dropTarget: HTMLElement, 
         }
     };
 
-    events.function('import', (url: string, filename?: string, focusCamera = true, animationFrame = false) => {
-        return handleImport(url, filename, focusCamera, animationFrame);
+    events.function('import', (url: string, filename?: string, animationFrame = false) => {
+        return handleImport(url, filename, animationFrame);
     });
 
     // create a file selector element as fallback when showOpenFilePicker isn't available

--- a/src/pivot.ts
+++ b/src/pivot.ts
@@ -66,7 +66,7 @@ const registerPivotEvents = (events: Events) => {
     });
 
     // pivot mode
-    let origin: PivotOrigin = 'boundCenter';
+    let origin: PivotOrigin = 'center';
 
     const setOrigin = (o: PivotOrigin) => {
         if (o !== origin) {

--- a/src/ply-sequence.ts
+++ b/src/ply-sequence.ts
@@ -67,7 +67,7 @@ const registerPlySequenceEvents = (events: Events) => {
 
         const file = sequenceFiles[frame];
         const url = URL.createObjectURL(file);
-        const newSplat = await events.invoke('import', url, file.name, !sequenceSplat, true) as Splat;
+        const newSplat = await events.invoke('import', url, file.name, true) as Splat;
         URL.revokeObjectURL(url);
 
         // wait for first frame render

--- a/src/ui/bottom-toolbar.ts
+++ b/src/ui/bottom-toolbar.ts
@@ -98,7 +98,7 @@ class BottomToolbar extends Container {
 
         const origin = new Button({
             id: 'bottom-toolbar-origin',
-            class: ['bottom-toolbar-toggle', 'active'],
+            class: ['bottom-toolbar-toggle'],
             icon: 'E189'
         });
 


### PR DESCRIPTION
This PR makes two changes to the editor defaults:
- place gizmo at the model's origin instead of bounding box center by default
- don't reframe the camera when importing models

Since these settings come up frequently as issues for users.