### PR TITLE
Select largest x% of splats

### DIFF
--- a/src/edit-ops.ts
+++ b/src/edit-ops.ts
@@ -440,8 +440,8 @@ class SelectLargestSplatsOp extends StateOp {
             const scaleY = splatData.getProp('scale_1');
             const scaleZ = splatData.getProp('scale_2');
             
-            // Calculate volumes for each splat
-            const volumes = new Array(splatData.numSplats);
+            // Calculate size metric for each splat (using max exponentiated scale)
+            const sizeMetrics = new Array(splatData.numSplats);
             const eligibleIndices = [];
             
             for (let i = 0; i < splatData.numSplats; i++) {
@@ -450,10 +450,9 @@ class SelectLargestSplatsOp extends StateOp {
                     continue;
                 }
                 
-                // Calculate approximate volume using exponentiated scales
-                const volume = Math.exp(scaleX[i]) * Math.exp(scaleY[i]) * Math.exp(scaleZ[i]);
-                // Alternative: const volume = Math.exp(scaleX[i] + scaleY[i] + scaleZ[i]);
-                volumes[i] = volume;
+                // Calculate size metric using the maximum exponentiated scale
+                const maxSize = Math.max(Math.exp(scaleX[i]), Math.exp(scaleY[i]), Math.exp(scaleZ[i]));
+                sizeMetrics[i] = maxSize;
                 eligibleIndices.push(i);
             }
             
@@ -462,8 +461,8 @@ class SelectLargestSplatsOp extends StateOp {
                 return;
             }
             
-            // Sort indices by volume (largest first)
-            eligibleIndices.sort((a, b) => volumes[b] - volumes[a]);
+            // Sort indices by size metric (largest first)
+            eligibleIndices.sort((a, b) => sizeMetrics[b] - sizeMetrics[a]);
             
             // Select the top percentage
             // Ensure percentage is in decimal form (1% = 0.01)

--- a/src/edit-ops.ts
+++ b/src/edit-ops.ts
@@ -450,8 +450,9 @@ class SelectLargestSplatsOp extends StateOp {
                     continue;
                 }
                 
-                // Calculate approximate volume
-                const volume = scaleX[i] * scaleY[i] * scaleZ[i];
+                // Calculate approximate volume using exponentiated scales
+                const volume = Math.exp(scaleX[i]) * Math.exp(scaleY[i]) * Math.exp(scaleZ[i]);
+                // Alternative: const volume = Math.exp(scaleX[i] + scaleY[i] + scaleZ[i]);
                 volumes[i] = volume;
                 eligibleIndices.push(i);
             }
@@ -465,6 +466,7 @@ class SelectLargestSplatsOp extends StateOp {
             eligibleIndices.sort((a, b) => volumes[b] - volumes[a]);
             
             // Select the top percentage
+            // Ensure percentage is in decimal form (1% = 0.01)
             const numToSelect = Math.max(1, Math.round(eligibleIndices.length * percentage));
             for (let i = 0; i < numToSelect; i++) {
                 const idx = eligibleIndices[i];

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -1,12 +1,13 @@
 import { Color, Mat4, Texture, Vec3, Vec4 } from 'playcanvas';
 
 import { EditHistory } from './edit-history';
-import { SelectAllOp, SelectNoneOp, SelectInvertOp, SelectOp, HideSelectionOp, UnhideAllOp, DeleteSelectionOp, ResetOp, MultiOp, AddSplatOp } from './edit-ops';
+import { SelectAllOp, SelectNoneOp, SelectInvertOp, SelectOp, HideSelectionOp, UnhideAllOp, DeleteSelectionOp, ResetOp, MultiOp, AddSplatOp, SelectLargestSplatsOp } from './edit-ops';
 import { Events } from './events';
 import { Scene } from './scene';
 import { BufferWriter } from './serialize/writer';
 import { Splat } from './splat';
 import { serializePly } from './splat-serialize';
+import { localize } from './ui/localization'; // Import localize
 
 // register for editor and scene events
 const registerEditorEvents = (events: Events, editHistory: EditHistory, scene: Scene) => {
@@ -630,6 +631,24 @@ const registerEditorEvents = (events: Events, editHistory: EditHistory, scene: S
         events.fire('grid.setVisible', docView.showGrid);
         events.fire('camera.setBound', docView.showBound);
         events.fire('camera.setFlySpeed', docView.flySpeed);
+    });
+
+    events.on('select.largestPercent', async () => {
+        const result = await events.invoke('showPopup', {
+            type: 'okcancel',
+            header: localize('popup.percentageTitle'),
+            message: localize('popup.percentageMessage'),
+            input: true
+        });
+
+        if (result?.action === 'ok' && result?.value !== undefined) {
+            const percentage = parseFloat(result.value);
+            if (!isNaN(percentage) && percentage > 0 && percentage <= 100) {
+                selectedSplats().forEach((splat) => {
+                    events.fire('edit.add', new SelectLargestSplatsOp(splat, percentage / 100));
+                });
+            }
+        }
     });
 };
 

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -644,8 +644,10 @@ const registerEditorEvents = (events: Events, editHistory: EditHistory, scene: S
         if (result?.action === 'ok' && result?.value !== undefined) {
             const percentage = parseFloat(result.value);
             if (!isNaN(percentage) && percentage > 0 && percentage <= 100) {
+                // Convert from percentage (e.g. 3%) to decimal (0.03)
+                const percentageDecimal = percentage / 100;
                 selectedSplats().forEach((splat) => {
-                    events.fire('edit.add', new SelectLargestSplatsOp(splat, percentage / 100));
+                    events.fire('edit.add', new SelectLargestSplatsOp(splat, percentageDecimal));
                 });
             }
         }

--- a/src/ui/localization.ts
+++ b/src/ui/localization.ts
@@ -37,7 +37,7 @@ const localizeInit = () => {
                     'select.delete': 'Selektion aufheben',
                     'select.reset': 'Splats zurücksetzen',
                     'select.duplicate': 'Duplizieren',
-                    'select.separate': 'Trennen',
+                    'select.separate': 'Separieren',
                     'select.largestPercent': 'Größte X% auswählen...',
 
                     // Help menu

--- a/src/ui/localization.ts
+++ b/src/ui/localization.ts
@@ -37,7 +37,8 @@ const localizeInit = () => {
                     'select.delete': 'Selektion aufheben',
                     'select.reset': 'Splats zurücksetzen',
                     'select.duplicate': 'Duplizieren',
-                    'select.separate': 'Separieren',
+                    'select.separate': 'Trennen',
+                    'select.largestPercent': 'Größte X% auswählen...',
 
                     // Help menu
                     'help': 'Hilfe',
@@ -158,6 +159,8 @@ const localizeInit = () => {
                     'popup.error-loading': 'FEHLER BEIM LADEN DER DATEI',
                     'popup.drop-files': 'Bitte Dateien und Ordner ablegen',
                     'popup.copy-to-clipboard': 'Link in die Zwischenablage kopieren',
+                    'popup.percentageTitle': 'Größte Splats auswählen',
+                    'popup.percentageMessage': 'Geben Sie den Prozentsatz der größten auszuwählenden Splats ein:',
 
                     // Right toolbar
                     'tooltip.splat-mode': 'Splat Modus ( M )',
@@ -270,6 +273,7 @@ const localizeInit = () => {
                     'select.reset': 'Reset Splat',
                     'select.duplicate': 'Duplicate',
                     'select.separate': 'Separate',
+                    'select.largestPercent': 'Select Largest X%...',
 
                     // Help menu
                     'help': 'Help',
@@ -398,6 +402,8 @@ const localizeInit = () => {
                     'popup.error-loading': 'ERROR LOADING FILE',
                     'popup.drop-files': 'Please drop files and folders',
                     'popup.copy-to-clipboard': 'Copy link to clipboard',
+                    'popup.percentageTitle': 'Select Largest Splats',
+                    'popup.percentageMessage': 'Enter the percentage of largest splats to select:',
 
                     // Right toolbar
                     'tooltip.splat-mode': 'Splat Mode ( M )',
@@ -507,6 +513,7 @@ const localizeInit = () => {
                     'select.reset': 'Réinitialiser splat',
                     'select.duplicate': 'Dupliquer',
                     'select.separate': 'Séparer',
+                    'select.largestPercent': 'Sélectionner les X% plus grands...',
 
                     // Help menu
                     'help': 'Aide',
@@ -627,6 +634,8 @@ const localizeInit = () => {
                     'popup.error-loading': 'Erreur de chargement du fichier',
                     'popup.drop-files': 'Veuillez déposer des fichiers et des dossiers',
                     'popup.copy-to-clipboard': 'Copier le lien dans le presse-papiers',
+                    'popup.percentageTitle': 'Sélectionner les plus grands Splats',
+                    'popup.percentageMessage': 'Entrez le pourcentage des plus grands splats à sélectionner :',
 
                     // Right toolbar
                     'tooltip.splat-mode': 'Mode splat ( M )',
@@ -732,6 +741,7 @@ const localizeInit = () => {
                     'select.reset': '変更を全てリセット',
                     'select.duplicate': '複製',
                     'select.separate': '分離',
+                    'select.largestPercent': '大きい順にX%選択...',
 
                     // Help menu
                     'help': 'ヘルプ',
@@ -852,6 +862,8 @@ const localizeInit = () => {
                     'popup.error-loading': 'ファイルの読み込みエラー',
                     'popup.drop-files': 'ファイルやフォルダをドロップしてください',
                     'popup.copy-to-clipboard': 'リンクをクリップボードにコピー',
+                    'popup.percentageTitle': '大きい順にスプラットを選択',
+                    'popup.percentageMessage': '選択する最大のスプラットの割合を入力してください：',
 
                     // Right toolbar
                     'tooltip.splat-mode': 'スプラットモード ( M )',
@@ -957,6 +969,7 @@ const localizeInit = () => {
                     'select.reset': 'Splat 재설정',
                     'select.duplicate': '복제',
                     'select.separate': '분리',
+                    'select.largestPercent': '가장 큰 X% 선택...',
 
                     // Help menu
                     'help': '도움말',
@@ -1007,6 +1020,7 @@ const localizeInit = () => {
                     'colors': '색상',
                     'colors.tint': '색조',
                     'colors.temperature': '온도',
+                    'colors.saturation': '채도',
                     'colors.brightness': '밝기',
                     'colors.blackPoint': '검은 점',
                     'colors.whitePoint': '흰 점',
@@ -1076,6 +1090,8 @@ const localizeInit = () => {
                     'popup.error-loading': '파일 로드 오류',
                     'popup.drop-files': '파일 및 폴더를 드롭하세요',
                     'popup.copy-to-clipboard': '클립 보드에 링크 복사',
+                    'popup.percentageTitle': '가장 큰 Splat 선택',
+                    'popup.percentageMessage': '선택할 가장 큰 Splat의 백분율을 입력하십시오:',
 
                     // Right toolbar
                     'tooltip.splat-mode': 'Splat 모드 ( M )',
@@ -1181,6 +1197,7 @@ const localizeInit = () => {
                     'select.reset': '重置 Splat',
                     'select.duplicate': '复制',
                     'select.separate': '分离',
+                    'select.largestPercent': '选择最大的 X%...',
 
                     // Help menu
                     'help': '帮助',
@@ -1301,6 +1318,8 @@ const localizeInit = () => {
                     'popup.error-loading': '加载文件错误',
                     'popup.drop-files': '请拖放文件和文件夹',
                     'popup.copy-to-clipboard': '复制链接到剪贴板',
+                    'popup.percentageTitle': '选择最大的 Splat',
+                    'popup.percentageMessage': '输入要选择的最大 Splat 的百分比：',
 
                     // Right toolbar
                     'tooltip.splat-mode': 'Splat 模式 ( M )',

--- a/src/ui/menu.ts
+++ b/src/ui/menu.ts
@@ -192,6 +192,12 @@ class Menu extends Container {
         }, {
             // separator
         }, {
+            text: localize('select.largestPercent'),
+            isEnabled: () => !events.invoke('scene.empty'),
+            onSelect: () => events.fire('select.largestPercent')
+        }, {
+            // separator
+        }, {
             text: localize('select.lock'),
             icon: createSvg(selectLock),
             extra: 'H',

--- a/src/ui/popup.ts
+++ b/src/ui/popup.ts
@@ -45,7 +45,7 @@ class Popup extends Container {
 
         const inputField = new TextInput({
             id: 'popup-input-field',
-            value: '3'  // Set default value to 3%
+            value: '1'  // Set default value to 1%
         });
 
         inputContainer.append(inputField);

--- a/src/ui/popup.ts
+++ b/src/ui/popup.ts
@@ -8,6 +8,7 @@ interface ShowOptions {
     message: string;
     header?: string;
     link?: string;
+    input?: boolean;
 }
 
 class Popup extends Container {
@@ -36,6 +37,17 @@ class Popup extends Container {
         const text = new Label({
             id: 'popup-text'
         });
+
+        // Create the input field container and component
+        const inputContainer = new Container({
+            id: 'popup-input-container'
+        });
+
+        const inputField = new TextInput({
+            id: 'popup-input-field'
+        });
+
+        inputContainer.append(inputField);
 
         const linkText = new Label({
             id: 'popup-link-text'
@@ -84,6 +96,7 @@ class Popup extends Container {
 
         dialog.append(header);
         dialog.append(text);
+        dialog.append(inputContainer);
         dialog.append(linkRow);
         dialog.append(buttons);
 
@@ -128,7 +141,7 @@ class Popup extends Container {
             header.text = options.header;
             text.text = options.message;
 
-            const { type, link } = options;
+            const { type, link, input } = options;
 
             ['error', 'info', 'yesno', 'okcancel'].forEach((t) => {
                 text.class[t === type ? 'add' : 'remove'](t);
@@ -147,6 +160,8 @@ class Popup extends Container {
                 linkCopy.icon = 'E352';
             }
 
+            inputContainer.hidden = !input;
+
             // take keyboard focus so shortcuts stop working
             this.dom.focus();
 
@@ -154,7 +169,8 @@ class Popup extends Container {
                 okFn = () => {
                     this.hide();
                     resolve({
-                        action: 'ok'
+                        action: 'ok',
+                        value: input ? inputField.value : undefined
                     });
                 };
                 cancelFn = () => {

--- a/src/ui/popup.ts
+++ b/src/ui/popup.ts
@@ -44,7 +44,8 @@ class Popup extends Container {
         });
 
         const inputField = new TextInput({
-            id: 'popup-input-field'
+            id: 'popup-input-field',
+            value: '3'  // Set default value to 3%
         });
 
         inputContainer.append(inputField);


### PR DESCRIPTION
This pull request introduces a new feature to select the largest percentage of splats based on their size, along with the necessary UI and localization updates. The changes include implementing a new operation class, adding a menu option, creating a popup with input functionality, and supporting multiple languages for the feature.

### Core Feature Implementation:
* **New Operation Class**: Added `SelectLargestSplatsOp` in `src/edit-ops.ts` to enable selection of the largest splats by size. This includes methods for performing, undoing, and destroying the operation.
* **Export and Integration**: Exported `SelectLargestSplatsOp` and integrated it into the editor by registering the `select.largestPercent` event in `src/editor.ts`. [[1]](diffhunk://#diff-a5f849f96a46186e49a739ac2b49480619931d2c4ba1678ad0be01b85956552eL428-R532) [[2]](diffhunk://#diff-dd70db0fb8079930c3a427158aa01e27c1d1a1ff405b50d1f252d120afc79f63R635-R654)

### UI Enhancements:
* **Menu Option**: Added a new menu item for selecting the largest percentage of splats in `src/ui/menu.ts`.
* **Popup Input**: Enhanced the popup system in `src/ui/popup.ts` to support an input field for entering the percentage value. [[1]](diffhunk://#diff-decd7767c7a60ce4a0c5443e8218ed436b4f453e617be86d70c439cd7ce17837R11) [[2]](diffhunk://#diff-decd7767c7a60ce4a0c5443e8218ed436b4f453e617be86d70c439cd7ce17837R41-R52) [[3]](diffhunk://#diff-decd7767c7a60ce4a0c5443e8218ed436b4f453e617be86d70c439cd7ce17837R100) [[4]](diffhunk://#diff-decd7767c7a60ce4a0c5443e8218ed436b4f453e617be86d70c439cd7ce17837L131-R145) [[5]](diffhunk://#diff-decd7767c7a60ce4a0c5443e8218ed436b4f453e617be86d70c439cd7ce17837R164-R174)

### Localization Updates:
* **New Strings**: Added localized strings for the new feature in multiple languages, including English, German, French, Japanese, Korean, and Chinese, in `src/ui/localization.ts`. [[1]](diffhunk://#diff-4b1ca1f1d123f51dc0f44a16746c537039e2ea55eedd5e5a8b2038145f497271R41) [[2]](diffhunk://#diff-4b1ca1f1d123f51dc0f44a16746c537039e2ea55eedd5e5a8b2038145f497271R162-R163) [[3]](diffhunk://#diff-4b1ca1f1d123f51dc0f44a16746c537039e2ea55eedd5e5a8b2038145f497271R276) [[4]](diffhunk://#diff-4b1ca1f1d123f51dc0f44a16746c537039e2ea55eedd5e5a8b2038145f497271R405-R406) [[5]](diffhunk://#diff-4b1ca1f1d123f51dc0f44a16746c537039e2ea55eedd5e5a8b2038145f497271R516) [[6]](diffhunk://#diff-4b1ca1f1d123f51dc0f44a16746c537039e2ea55eedd5e5a8b2038145f497271R637-R638) [[7]](diffhunk://#diff-4b1ca1f1d123f51dc0f44a16746c537039e2ea55eedd5e5a8b2038145f497271R744) [[8]](diffhunk://#diff-4b1ca1f1d123f51dc0f44a16746c537039e2ea55eedd5e5a8b2038145f497271R865-R866) [[9]](diffhunk://#diff-4b1ca1f1d123f51dc0f44a16746c537039e2ea55eedd5e5a8b2038145f497271R972) [[10]](diffhunk://#diff-4b1ca1f1d123f51dc0f44a16746c537039e2ea55eedd5e5a8b2038145f497271R1023) [[11]](diffhunk://#diff-4b1ca1f1d123f51dc0f44a16746c537039e2ea55eedd5e5a8b2038145f497271R1093-R1094) [[12]](diffhunk://#diff-4b1ca1f1d123f51dc0f44a16746c537039e2ea55eedd5e5a8b2038145f497271R1200) [[13]](diffhunk://#diff-4b1ca1f1d123f51dc0f44a16746c537039e2ea55eedd5e5a8b2038145f497271R1321-R1322)