### PR TITLE
Ignore infinities when calculating bound

### DIFF
--- a/src/asset-loader.ts
+++ b/src/asset-loader.ts
@@ -177,7 +177,7 @@ class AssetLoader {
                     url: loadRequest.url,
                     filename: loadRequest.filename
                 });
-                asset.resource = new GSplatResource(this.app, gsplatData, []);
+                asset.resource = new GSplatResource(this.app.graphicsDevice, gsplatData, []);
                 resolve(new Splat(asset));
             })
             .catch((err) => {

--- a/src/data-processor.ts
+++ b/src/data-processor.ts
@@ -379,17 +379,23 @@ class DataProcessor {
 
         // resolve mins/maxs
         const { minData, maxData } = resources;
-        v1.set(minData[0], minData[1], minData[2]);
-        v2.set(maxData[0], maxData[1], maxData[2]);
+        v1.set(Infinity, Infinity, Infinity);
+        v2.set(-Infinity, -Infinity, -Infinity);
 
-        for (let i = 1; i < transformA.width; i++) {
-            v1.x = Math.min(v1.x, minData[i * 4]);
-            v1.y = Math.min(v1.y, minData[i * 4 + 1]);
-            v1.z = Math.min(v1.z, minData[i * 4 + 2]);
+        for (let i = 0; i < transformA.width; i++) {
+            const a = minData[i * 4];
+            const b = minData[i * 4 + 1];
+            const c = minData[i * 4 + 2];
+            if (isFinite(a)) v1.x = Math.min(v1.x, a);
+            if (isFinite(b)) v1.y = Math.min(v1.y, b);
+            if (isFinite(c)) v1.z = Math.min(v1.z, c);
 
-            v2.x = Math.max(v2.x, maxData[i * 4]);
-            v2.y = Math.max(v2.y, maxData[i * 4 + 1]);
-            v2.z = Math.max(v2.z, maxData[i * 4 + 2]);
+            const d = maxData[i * 4];
+            const e = maxData[i * 4 + 1];
+            const f = maxData[i * 4 + 2];
+            if (isFinite(d)) v2.x = Math.max(v2.x, d);
+            if (isFinite(e)) v2.y = Math.max(v2.y, e)
+            if (isFinite(f)) v2.z = Math.max(v2.z, f);
         }
 
         boundingBox.setMinMax(v1, v2);

--- a/src/data-processor.ts
+++ b/src/data-processor.ts
@@ -394,7 +394,7 @@ class DataProcessor {
             const e = maxData[i * 4 + 1];
             const f = maxData[i * 4 + 2];
             if (isFinite(d)) v2.x = Math.max(v2.x, d);
-            if (isFinite(e)) v2.y = Math.max(v2.y, e)
+            if (isFinite(e)) v2.y = Math.max(v2.y, e);
             if (isFinite(f)) v2.z = Math.max(v2.z, f);
         }
 

--- a/src/shaders/bound-shader.ts
+++ b/src/shaders/bound-shader.ts
@@ -16,8 +16,8 @@ const fragmentShader = /* glsl */ `
     // calculate min and max for a single column of splats
     void main(void) {
 
-        vec3 boundMin = vec3(100000.0);
-        vec3 boundMax = vec3(-100000.0);
+        vec3 boundMin = vec3(1e6);
+        vec3 boundMax = vec3(-1e6);
 
         for (int id = 0; id < splat_params.y; id++) {
             // calculate splatUV
@@ -54,8 +54,8 @@ const fragmentShader = /* glsl */ `
                 center = vec4(center, 1.0) * t;
             }
 
-            boundMin = min(boundMin, center);
-            boundMax = max(boundMax, center);
+            boundMin = min(boundMin, mix(center, boundMin, isinf(center)));
+            boundMax = max(boundMax, mix(center, boundMax, isinf(center)));
         }
 
         pcFragColor0 = vec4(boundMin, 0.0);

--- a/src/splat.ts
+++ b/src/splat.ts
@@ -141,7 +141,7 @@ class Splat extends Element {
 
         // pack spherical harmonic data
         const createTexture = (name: string, format: number) => {
-            return new Texture(splatResource.app.graphicsDevice, {
+            return new Texture(splatResource.device, {
                 name: name,
                 width: width,
                 height: height,
@@ -159,7 +159,7 @@ class Splat extends Element {
         this.transformTexture = createTexture('splatTransform', PIXELFORMAT_R16U);
 
         // create the transform palette
-        this.transformPalette = new TransformPalette(splatResource.app.graphicsDevice);
+        this.transformPalette = new TransformPalette(splatResource.device);
 
         // blend mode for splats
         const blendState = new BlendState(true, BLENDEQUATION_ADD, BLENDMODE_ONE, BLENDMODE_ONE_MINUS_SRC_ALPHA);


### PR DESCRIPTION
Scenes sometimes contain infinities, which result in invalid bounds being calculated.

This PR skips elements that are infinite during bounds calc.