### PR TITLE
Sample code for enabling type checking on eventbus

### DIFF
--- a/src/event-signatures.d.ts
+++ b/src/event-signatures.d.ts
@@ -1,0 +1,28 @@
+import { Vec3 } from 'playcanvas';
+
+
+/**
+ * A generic type that maps event names to their function signatures.
+ * It is used to type-check the on, fire, and invoke methods of the Events class.
+ */
+export interface EventSignatures {
+    /**
+     * Event to start the spinner.
+     */
+    'startSpinner': () => void;
+    /**
+     * Event to stop the spinner.
+     */
+    'stopSpinner': () => void;
+    /**
+     * Event to set the camera pose.
+     * @param pose - The camera pose.
+     * @param a - A number.
+     */
+    'camera.setPose': (pose: { position: Vec3; target: Vec3; }, a: number) => void;
+    /**
+     * Escape hatch for transition, allows for any string to be used as an event name.
+     * This provides a smoother transition path to fully typed events.
+     */
+    [key: string]: (...args: any[]) => any;
+}

--- a/src/events.ts
+++ b/src/events.ts
@@ -1,12 +1,17 @@
 import { EventHandler } from 'playcanvas';
+import { EventSignatures } from './event-signatures';
 
-type FunctionCallback = (...args: any[]) => any;
+// Type gymnastics for the definition below
+type EventName = keyof EventSignatures & string;
+type EventCallback<T extends EventName> = EventSignatures[T];
+type EventParams<T extends EventName> = Parameters<EventCallback<T>>;
+type EventReturn<T extends EventName> = ReturnType<EventCallback<T>>;
 
 class Events extends EventHandler {
-    functions = new Map<string, FunctionCallback>();
+    functions = new Map<string, EventCallback<any>>();
 
     // declare an editor function
-    function(name: string, fn: FunctionCallback) {
+    function<T extends EventName>(name: T, fn: EventCallback<T>) {
         if (this.functions.has(name)) {
             throw new Error(`error: function ${name} already exists`);
         }
@@ -14,13 +19,21 @@ class Events extends EventHandler {
     }
 
     // invoke an editor function
-    invoke(name: string, ...args: any[]) {
+    invoke<T extends EventName>(name: T, ...args: EventParams<T>): EventReturn<T> {
         const fn = this.functions.get(name);
         if (!fn) {
             console.log(`error: function not found '${name}'`);
             return;
         }
         return fn(...args);
+    }
+
+    on<T extends EventName>(name: T, callback: EventCallback<T>, scope?: any): any {
+        return super.on(name, callback, scope);
+    }
+
+    fire<T extends EventName>(name: T, ...args: EventParams<T>): any {
+        return super.fire(name, ...args);
     }
 }
 


### PR DESCRIPTION
Here are the sample changes for enabling type checking across the event bus.

If fully implemented, it can enforce that only defined events are emitted & handled, with the expected signature.

Just:
* add events (as well as docs) to src/event-signatures.d.ts
* and get rid of the escape hatch once done.
* btw, a more comprehensive review of the Events class's other methods might still be needed.
