### PR TITLE
Speed up video recording

### DIFF
--- a/src/render.ts
+++ b/src/render.ts
@@ -184,8 +184,8 @@ const registerRenderEvents = (scene: Scene, events: Events) => {
             const splats = (scene.getElementsByType(ElementType.splat) as Splat[]).filter(splat => splat.visible);
 
             // remember last camera position so we can skip sorting if the camera didn't move
-            let last_pos = new Vec3(0, 0, 0);
-            let last_forward = new Vec3(1, 0, 0);
+            const last_pos = new Vec3(0, 0, 0);
+            const last_forward = new Vec3(1, 0, 0);
 
             // prepare the frame for rendering
             const prepareFrame = async (frameTime: number) => {


### PR DESCRIPTION
The video recording is slow when camera is not moving during some frames, because sorting does not work in this case, and the program will just wait until sorter time out
```
// in cases where the camera does not move between frames the sorter won't run
// and we need a timeout instead. this is a hack - the engine should allow us to
// know whether the sorter is running or not.
setTimeout(() => {
    resolve();
}, 1000);
```
which is annoying. So I recorded the camera position and forward for the last frame and skip sorting when their value don't change in the new frame.