### PR TITLE
Add timeline animation for entity

### DIFF
--- a/src/camera-poses.ts
+++ b/src/camera-poses.ts
@@ -104,12 +104,12 @@ const registerCameraPosesEvents = (events: Events) => {
     const movePose = (index: number, frame: number) => {
         // remove target frame pose
         const toIndex = poses.findIndex(p => p.frame === frame);
+        // move pose
+        poses[index].frame = frame;
         if (toIndex !== -1) {
             removePose(toIndex);
         }
 
-        // move pose
-        poses[index].frame = frame;
         rebuildSpline();
         events.fire('timeline.setKey', index, frame);
     };

--- a/src/doc.ts
+++ b/src/doc.ts
@@ -118,8 +118,11 @@ const registerDocEvents = (scene: Scene, events: Events) => {
                 console.error('this should never fire');
             }
 
+            const splats = events.invoke('scene.allSplats') as Splat[];
+
             events.invoke('docDeserialize.timeline', document.timeline);
             events.invoke('docDeserialize.poseSets', document.poseSets);
+            events.invoke('docDeserialize.splatTransforms', splats, document.splatTransforms);
             events.invoke('docDeserialize.view', document.view);
             scene.camera.docDeserialize(document.camera);
         } catch (error) {
@@ -144,6 +147,7 @@ const registerDocEvents = (scene: Scene, events: Events) => {
                 camera: scene.camera.docSerialize(),
                 view: events.invoke('docSerialize.view'),
                 poseSets: events.invoke('docSerialize.poseSets'),
+                splatTransforms: events.invoke('docSerialize.splatTransforms', splats),
                 timeline: events.invoke('docSerialize.timeline'),
                 splats: splats.map(s => s.docSerialize())
             };

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,7 @@
 import { Color, createGraphicsDevice } from 'playcanvas';
 
 import { registerCameraPosesEvents } from './camera-poses';
+import { registerSplatAnimEvents } from './splat-anim'; 
 import { registerDocEvents } from './doc';
 import { EditHistory } from './edit-history';
 import { registerEditorEvents } from './editor';
@@ -242,6 +243,7 @@ const main = async () => {
     registerSelectionEvents(events, scene);
     registerTimelineEvents(events);
     registerCameraPosesEvents(events);
+    registerSplatAnimEvents(events);
     registerTransformHandlerEvents(events);
     registerPlySequenceEvents(events);
     registerPublishEvents(events);

--- a/src/render.ts
+++ b/src/render.ts
@@ -198,7 +198,6 @@ const registerRenderEvents = (scene: Scene, events: Events) => {
                 const pos = scene.camera.entity.getPosition();
                 const forward = scene.camera.entity.forward;
                 if (last_pos.equals(pos) && last_forward.equals(forward)) {
-                    console.log('camera did not move, skipping sort');
                     return;
                 } else {
                     last_pos.copy(pos);

--- a/src/render.ts
+++ b/src/render.ts
@@ -84,9 +84,7 @@ const registerRenderEvents = (scene: Scene, events: Events) => {
             const { colorBuffer } = renderTarget;
 
             // read the rendered frame
-            console.time('read pixels');
             await colorBuffer.read(0, 0, width, height, { renderTarget, data });
-            console.timeEnd('read pixels');
 
             // the render buffer contains premultiplied alpha. so apply background color.
             if (!transparentBg) {
@@ -239,9 +237,7 @@ const registerRenderEvents = (scene: Scene, events: Events) => {
                 const { colorBuffer } = renderTarget;
 
                 // read the rendered frame
-                console.time('read pixels');
                 await colorBuffer.read(0, 0, width, height, { renderTarget, data });
-                console.timeEnd('read pixels');
 
                 // flip the buffer vertically
                 for (let y = 0; y < height / 2; y++) {
@@ -269,22 +265,16 @@ const registerRenderEvents = (scene: Scene, events: Events) => {
 
             for (let frameTime = 0; frameTime <= duration; frameTime += 1.0 / frameRate) {
                 // special case the first frame
-                console.time('prepare frame');
                 await prepareFrame(startFrame + frameTime * animFrameRate);
-                console.timeEnd('prepare frame');
                 
                 // render a frame
                 scene.lockedRender = true;
 
                 // wait for render to finish
-                console.time('render frame');
                 await postRender();
-                console.timeEnd('render frame');
 
                 // wait for capture
-                console.time('capture frame');
                 await captureFrame(frameTime);
-                console.timeEnd('capture frame');
 
                 events.fire('progressUpdate', {
                     text: localize('render.rendering'),

--- a/src/splat-anim.ts
+++ b/src/splat-anim.ts
@@ -38,7 +38,6 @@ const registerSplatAnimEvents = (events: Events) => {
         // construct the spline points to be interpolated
         const splines: Map<Splat, CubicSpline> = new Map();
         orderedTransforms.forEach((fts, splat) => {
-            console.log('rebuildSpline with frame:', fts.length);
             if (fts.length < 2) {
                 onTimelineChange = null;
                 return;
@@ -156,7 +155,6 @@ const registerSplatAnimEvents = (events: Events) => {
     // timeline events
 
     events.on('timeline.add', (frame: number) => {
-        console.log('splatanime.timeline.add', frame);
         // get the selected splat
         const splat = events.invoke('selection') as Splat;
         if (!splat) {
@@ -168,7 +166,6 @@ const registerSplatAnimEvents = (events: Events) => {
 
     events.on('timeline.move', (frameFrom: number, frameTo: number) => {
         if (frameFrom === frameTo) return;
-        console.log('splatanime.timeline.move', frameFrom, frameTo);
         transforms.forEach((fts) => {
             const fromIndex = fts.findIndex(p => p.frame === frameFrom);
             if (fromIndex === -1) {

--- a/src/splat-anim.ts
+++ b/src/splat-anim.ts
@@ -97,6 +97,12 @@ const registerSplatAnimEvents = (events: Events) => {
         };
     };
 
+    // clear all splat transforms on scene clear
+    events.on('scene.clear', () => {
+        transforms.clear();
+        onTimelineChange = null;
+    });
+
     events.on('timeline.time', (time: number) => {
         onTimelineChange?.(time);
     });

--- a/src/splat-anim.ts
+++ b/src/splat-anim.ts
@@ -1,0 +1,200 @@
+import { Vec3, Quat } from 'playcanvas';
+
+import { CubicSpline } from './anim/spline';
+import { Events } from './events';
+import { Splat } from './splat';
+import { Transform } from './transform';
+
+type FrameTransform = {
+    frame: number,
+    transform: Transform
+}
+
+const registerSplatAnimEvents = (events: Events) => {
+    const transforms: Map<Splat, FrameTransform[]> = new Map();
+
+    let onTimelineChange: (frame: number) => void;
+
+    const rebuildSpline = () => {
+        if (transforms.size === 0) {
+            onTimelineChange = null;
+            return;
+        }
+
+        const duration = events.invoke('timeline.frames');
+
+        const orderedTransforms: Map<Splat, FrameTransform[]> = new Map();
+        transforms.forEach((fts, splat) => {
+            const ordered = fts.slice()
+                // filter out keys beyond the end of the timeline
+                .filter(a => a.frame < duration)
+                // order keys by time for spline
+                .sort((a, b) => a.frame - b.frame);
+            if (ordered.length > 0) {
+                orderedTransforms.set(splat, ordered);
+            }
+        });
+
+        // construct the spline points to be interpolated
+        const splines: Map<Splat, CubicSpline> = new Map();
+        orderedTransforms.forEach((fts, splat) => {
+            console.log('rebuildSpline with frame:', fts.length);
+            if (fts.length < 2) {
+                onTimelineChange = null;
+                return;
+            }
+            const times = fts.map(p => p.frame);
+            const points = [];
+            for (let i = 0; i < fts.length; ++i) {
+                const p = fts[i];
+                points.push(p.transform.position.x, p.transform.position.y, p.transform.position.z);
+                // use euler angles for interpolation
+                const rotation = new Vec3();
+                p.transform.rotation.getEulerAngles(rotation);
+                points.push(rotation.x, rotation.y, rotation.z);
+                points.push(p.transform.scale.x, p.transform.scale.y, p.transform.scale.z);
+            }
+
+            // interpolate camera positions and camera target positions
+            const spline = CubicSpline.fromPointsLooping(duration, times, points, events.invoke('timeline.smoothness'));
+            splines.set(splat, spline);
+        });
+
+        // handle application update tick
+        onTimelineChange = (frame: number) => {
+            const time = frame;
+            const selected = events.invoke('selection') as Splat;
+            // update all splats with transforms
+            transforms.forEach((fts, splat) => {
+                const spline = splines.get(splat);
+                if (!spline) {
+                    return;
+                }
+
+                if (fts.length < 2) {
+                    return;
+                }
+
+                const pos = new Vec3();
+                const rot = new Quat();
+                const scale = new Vec3();
+                const result: number[] = [];
+
+                // evaluate the spline at current time
+                spline.evaluate(time, result);
+
+                // set splat transform
+                pos.set(result[0], result[1], result[2]);
+                rot.setFromEulerAngles(result[3], result[4], result[5]);
+                scale.set(result[6], result[7], result[8]);
+
+                splat.move(pos, rot, scale);
+                if (splat === selected) {
+                    // if the splat is selected, also place the pivot
+                    const transform = new Transform(pos, rot, scale);
+                    events.fire('pivot.place', transform);
+                }
+            });
+        };
+    };
+
+    events.on('timeline.time', (time: number) => {
+        onTimelineChange?.(time);
+    });
+
+    events.on('timeline.frame', (frame: number) => {
+        onTimelineChange?.(frame);
+    });
+
+    events.on('timeline.frames', () => {
+        rebuildSpline();
+        // done in camera poses
+        // events.fire('timeline.time', events.invoke('timeline.frame'));
+    });
+
+    events.on('timeline.smoothness', () => {
+        rebuildSpline();
+        // done in camera poses
+        // events.fire('timeline.time', events.invoke('timeline.frame'));
+    });
+
+    // FrameTransform
+
+    const addTransform = (splat: Splat, frame: number) => {
+        if (!transforms.has(splat)) {
+            transforms.set(splat, []);
+        }
+        const transform = new Transform(splat.entity.getLocalPosition(), splat.entity.getLocalRotation(), splat.entity.getLocalScale());
+        const idx = transforms.get(splat)!.findIndex(p => p.frame === frame);
+        if (idx !== -1) {
+            transforms.get(splat)![idx].transform = transform;
+        }
+        else {
+            transforms.get(splat)!.push({ frame, transform });
+        }
+
+        rebuildSpline();
+    };
+
+    const removeTransform = (index: number) => {
+        transforms.forEach((fts) => {
+            fts.splice(index, 1);
+        });
+
+        rebuildSpline();
+    };
+
+    events.function('splat.transforms', (splat: Splat) => {
+        return transforms.get(splat) || [];
+    });
+
+    events.on('splat.removeTransform', (splat: Splat) => {
+        transforms.delete(splat);
+        rebuildSpline();
+    });
+
+    // timeline events
+
+    events.on('timeline.add', (frame: number) => {
+        console.log('splatanime.timeline.add', frame);
+        // get the selected splat
+        const splat = events.invoke('selection') as Splat;
+        if (!splat) {
+            return;
+        }
+
+        addTransform(splat, frame);
+    });
+
+    events.on('timeline.move', (frameFrom: number, frameTo: number) => {
+        if (frameFrom === frameTo) return;
+        console.log('splatanime.timeline.move', frameFrom, frameTo);
+        transforms.forEach((fts) => {
+            const fromIndex = fts.findIndex(p => p.frame === frameFrom);
+            if (fromIndex === -1) {
+                return;
+            }
+
+            const toIndex = fts.findIndex(p => p.frame === frameTo);
+            fts[fromIndex].frame = frameTo;
+            if (toIndex !== -1) {
+                fts.splice(toIndex, 1);
+            }
+        });
+
+        rebuildSpline();
+    });
+
+    events.on('timeline.remove', (index: number) => {
+        removeTransform(index);
+    });
+
+    events.on('timeline.frames', () => {
+        rebuildSpline();
+    });
+
+    // doc
+    // todo:
+};
+
+export { registerSplatAnimEvents };

--- a/src/ui/splat-list.ts
+++ b/src/ui/splat-list.ts
@@ -264,6 +264,8 @@ class SplatList extends Container {
             });
 
             if (result?.action === 'yes') {
+                // remove the splat from timeline animation list
+                events.fire('splat.removeTransform', splat);
                 splat.destroy();
             }
         });


### PR DESCRIPTION
### New feature: Added animation for splat entity
Timeline keyframes can now record position, rotation and scales of entities and interpolate to get animations.
Also serialized animation data into document.

https://github.com/user-attachments/assets/97d4e7d7-81ea-4b09-933b-f4644f5a0bdf

Making it easier to create camera orbit animation.

### Bug Fix: drag keyframes in camera poses
The original version of drag keyframe has a bug: The pose list may be changed if removed first:
```
const movePose = (index: number, frame: number) => {
        // remove target frame pose
        const toIndex = poses.findIndex(p => p.frame === frame);
        if (toIndex !== -1) {
            removePose(toIndex);// List may be changed!!!
        }

        // move pose
        poses[index].frame = frame;
        rebuildSpline();
        events.fire('timeline.setKey', index, frame);
    };
```
So the pose on index should be assigned new value before removing.