### PR TITLE
Fix movePose bug

### DIFF
--- a/src/camera-poses.ts
+++ b/src/camera-poses.ts
@@ -104,12 +104,12 @@ const registerCameraPosesEvents = (events: Events) => {
     const movePose = (index: number, frame: number) => {
         // remove target frame pose
         const toIndex = poses.findIndex(p => p.frame === frame);
+        // move pose
+        poses[index].frame = frame;
         if (toIndex !== -1) {
             removePose(toIndex);
         }
 
-        // move pose
-        poses[index].frame = frame;
         rebuildSpline();
         events.fire('timeline.setKey', index, frame);
     };


### PR DESCRIPTION
### Bug Fix: drag keyframes in camera poses
The original version of drag keyframe has a bug: The pose list may be changed if removed first:
```
const movePose = (index: number, frame: number) => {
        // remove target frame pose
        const toIndex = poses.findIndex(p => p.frame === frame);
        if (toIndex !== -1) {
            removePose(toIndex);// List may be changed!!!
        }

        // move pose
        poses[index].frame = frame;
        rebuildSpline();
        events.fire('timeline.setKey', index, frame);
    };
```
So the pose on index should be assigned new value before removing.