### PR TITLE
Migrate from mp4-muxer to mediabunny

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,7 @@
                 "i18next": "^25.6.0",
                 "i18next-browser-languagedetector": "^8.2.0",
                 "jszip": "^3.10.1",
-                "mp4-muxer": "^5.2.2",
+                "mediabunny": "^1.24.0",
                 "playcanvas": "^2.12.3",
                 "postcss": "^8.5.6",
                 "rollup": "^4.52.4",
@@ -1350,6 +1350,16 @@
                 "tslib": "^2.4.0"
             }
         },
+        "node_modules/@types/dom-mediacapture-transform": {
+            "version": "0.1.11",
+            "resolved": "https://registry.npmjs.org/@types/dom-mediacapture-transform/-/dom-mediacapture-transform-0.1.11.tgz",
+            "integrity": "sha512-Y2p+nGf1bF2XMttBnsVPHUWzRRZzqUoJAKmiP10b5umnO6DDrWI0BrGDJy1pOHoOULVmGSfFNkQrAlC5dcj6nQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/dom-webcodecs": "*"
+            }
+        },
         "node_modules/@types/dom-webcodecs": {
             "version": "0.1.16",
             "resolved": "https://registry.npmjs.org/@types/dom-webcodecs/-/dom-webcodecs-0.1.16.tgz",
@@ -1435,7 +1445,6 @@
             "integrity": "sha512-6JSSaBZmsKvEkbRUkf7Zj7dru/8ZCrJxAqArcLaVMee5907JdtEbKGsZ7zNiIm/UAkpGUkaSMZEXShnN2D1HZA==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@typescript-eslint/scope-manager": "8.46.1",
                 "@typescript-eslint/types": "8.46.1",
@@ -1924,7 +1933,6 @@
             "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "bin": {
                 "acorn": "bin/acorn"
             },
@@ -2411,7 +2419,6 @@
                 }
             ],
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "caniuse-lite": "^1.0.30001737",
                 "electron-to-chromium": "^1.5.211",
@@ -3361,7 +3368,6 @@
             "integrity": "sha512-XyLmROnACWqSxiGYArdef1fItQd47weqB7iwtfr9JHwRrqIXZdcFMvvEcL9xHCmL0SNsOvF0c42lWyM1U5dgig==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.8.0",
                 "@eslint-community/regexpp": "^4.12.1",
@@ -5131,6 +5137,31 @@
                 "node": ">= 0.4"
             }
         },
+        "node_modules/mediabunny": {
+            "version": "1.24.0",
+            "resolved": "https://registry.npmjs.org/mediabunny/-/mediabunny-1.24.0.tgz",
+            "integrity": "sha512-9fQfAYlnuVSHMfbJtKK0pAgDlfwGDoyLQZ7gbOCug9jHPfjdi0XYQwvi/kaOFFMD70ouPkXzvKRc3AMPwkSK6Q==",
+            "dev": true,
+            "license": "MPL-2.0",
+            "workspaces": [
+                "packages/*"
+            ],
+            "dependencies": {
+                "@types/dom-mediacapture-transform": "^0.1.11",
+                "@types/dom-webcodecs": "0.1.13"
+            },
+            "funding": {
+                "type": "individual",
+                "url": "https://github.com/sponsors/Vanilagy"
+            }
+        },
+        "node_modules/mediabunny/node_modules/@types/dom-webcodecs": {
+            "version": "0.1.13",
+            "resolved": "https://registry.npmjs.org/@types/dom-webcodecs/-/dom-webcodecs-0.1.13.tgz",
+            "integrity": "sha512-O5hkiFIcjjszPIYyUSyvScyvrBoV3NOEEZx/pMlsu44TKzWNkLVBBxnxJz42in5n3QIolYOcBYFCPZZ0h8SkwQ==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/merge-stream": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
@@ -5275,25 +5306,6 @@
             "dev": true,
             "license": "MIT",
             "optional": true
-        },
-        "node_modules/mp4-muxer": {
-            "version": "5.2.2",
-            "resolved": "https://registry.npmjs.org/mp4-muxer/-/mp4-muxer-5.2.2.tgz",
-            "integrity": "sha512-dhozjTywI0h2qFzeShagt8YYw811fh1XlwiDCE2f6Aeqf6xG2CyuShoSa5E0AZDO8pPF0JOZ3wOmWBNWIGdSpQ==",
-            "deprecated": "This library is superseded by Mediabunny. Please migrate to it.",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@types/dom-webcodecs": "^0.1.6",
-                "@types/wicg-file-system-access": "^2020.9.5"
-            }
-        },
-        "node_modules/mp4-muxer/node_modules/@types/wicg-file-system-access": {
-            "version": "2020.9.8",
-            "resolved": "https://registry.npmjs.org/@types/wicg-file-system-access/-/wicg-file-system-access-2020.9.8.tgz",
-            "integrity": "sha512-ggMz8nOygG7d/stpH40WVaNvBwuyYLnrg5Mbyf6bmsj/8+gb6Ei4ZZ9/4PNpcPNTT8th9Q8sM8wYmWGjMWLX/A==",
-            "dev": true,
-            "license": "MIT"
         },
         "node_modules/ms": {
             "version": "2.1.3",
@@ -5771,7 +5783,6 @@
                 }
             ],
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "nanoid": "^3.3.11",
                 "picocolors": "^1.1.1",
@@ -6150,7 +6161,6 @@
             "integrity": "sha512-CLEVl+MnPAiKh5pl4dEWSyMTpuflgNQiLGhMv8ezD5W/qP8AKvmYpCOKRRNOh7oRKnauBZ4SyeYkMS+1VSyKwQ==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@types/estree": "1.0.8"
             },
@@ -6350,7 +6360,8 @@
             "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.26.0.tgz",
             "integrity": "sha512-NlHwttCI/l5gCPR3D1nNXtWABUmBwvZpEQiD4IXSbIDq8BzLIK/7Ir5gTFSGZDUu37K5cMNp0hFtzO38sC7gWA==",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/scslre": {
             "version": "0.3.0",
@@ -7117,8 +7128,7 @@
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
             "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
             "dev": true,
-            "license": "0BSD",
-            "peer": true
+            "license": "0BSD"
         },
         "node_modules/tunnel-agent": {
             "version": "0.6.0",
@@ -7244,7 +7254,6 @@
             "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
             "dev": true,
             "license": "Apache-2.0",
-            "peer": true,
             "bin": {
                 "tsc": "bin/tsc",
                 "tsserver": "bin/tsserver"
@@ -7279,7 +7288,6 @@
             "dev": true,
             "hasInstallScript": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "napi-postinstall": "^0.3.0"
             },

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
         "i18next": "^25.6.0",
         "i18next-browser-languagedetector": "^8.2.0",
         "jszip": "^3.10.1",
-        "mp4-muxer": "^5.2.2",
+        "mediabunny": "^1.24.0",
         "playcanvas": "^2.12.3",
         "postcss": "^8.5.6",
         "rollup": "^4.52.4",


### PR DESCRIPTION
Since `mp4-muxer` is now deprecated, this PR migrates the video recorder script to [mediabunny](https://mediabunny.dev/).