### PR TITLE
Support reading colmap camera poses (images.txt)

### DIFF
--- a/src/file-handler.ts
+++ b/src/file-handler.ts
@@ -39,7 +39,7 @@ const filePickerTypes: { [key: string]: FilePickerAcceptType } = {
     'compressedPly': {
         description: 'Compressed Gaussian Splat PLY File',
         accept: {
-            'application/ply': ['.compressed.ply']
+            'application/ply': ['.ply']
         }
     },
     'sog': {
@@ -83,7 +83,7 @@ const filePickerTypes: { [key: string]: FilePickerAcceptType } = {
 };
 
 const allImportTypes = {
-    description: 'Supported files',
+    description: 'Supported Files',
     accept: {
         'application/ply': ['.ply'],
         'application/x-gaussian-splat': ['.json', '.sog', '.splat'],


### PR DESCRIPTION
This PR adds the option of loading camera poses from colmap `images.txt` file.

Only the camera position and direction is loaded, not camera tilt and intrinsic parameters (FOV etc).

The poses are added as keys to the camera animation.