### PR TITLE
Fix transform panel on ssproj load

### DIFF
--- a/src/doc.ts
+++ b/src/doc.ts
@@ -109,7 +109,7 @@ const registerDocEvents = (scene: Scene, events: Events) => {
                 URL.revokeObjectURL(url);
 
                 scene.add(splat);
-                
+
                 splat.docDeserialize(splatSettings);
             }
 


### PR DESCRIPTION
After loading all the splats and deserializing their saved transforms, this updated code manually refreshes the pivot to match the loaded position. Without this, the pivot would still be at the default [0,0,0] position from when the splat was first auto-selected (before deserialize ran), and the Transform Panel would show incorrect values.