### PR TITLE
fix lint errors: reorder import statement and remove unnecessary whitespace

### DIFF
--- a/src/doc.ts
+++ b/src/doc.ts
@@ -4,6 +4,7 @@ import { DownloadWriter, FileStreamWriter } from './serialize/writer';
 import { ZipWriter } from './serialize/zip-writer';
 import { Splat } from './splat';
 import { serializePly } from './splat-serialize';
+import { Transform } from './transform';
 import { localize } from './ui/localization';
 
 // ts compiler and vscode find this type, but eslint does not
@@ -122,6 +123,16 @@ const registerDocEvents = (scene: Scene, events: Events) => {
             events.invoke('docDeserialize.poseSets', document.poseSets);
             events.invoke('docDeserialize.view', document.view);
             scene.camera.docDeserialize(document.camera);
+
+            // refresh the pivot to reflect the loaded transform
+            const currentSelection = events.invoke('selection');
+            if (currentSelection) {
+                const pivot = events.invoke('pivot');
+                const transform = new Transform();
+                const pivotOrigin = events.invoke('pivot.origin');
+                currentSelection.getPivot(pivotOrigin, false, transform);
+                pivot.place(transform);
+            }
         } catch (error) {
             await events.invoke('showPopup', {
                 type: 'error',


### PR DESCRIPTION
I see the main branch CICD failed due to linting errors from my previous PR #634.

```
(base) nagakarumuri@Nagas-MacBook-Air supersplat % npm run lint

> supersplat@2.13.2 lint
> eslint src


/Users/nagakarumuri/Documents/development/supersplat/src/doc.ts
    8:1  error  `./transform` import should occur before import of `./ui/localization`  import/order
  126:1  error  Trailing spaces not allowed                                             no-trailing-spaces

✖ 2 problems (2 errors, 0 warnings)
  2 errors and 0 warnings potentially fixable with the `--fix` option.
```

Adjusted doc.ts to satisfy ESLint: reordered the Transform import ahead of localization to meet import/order and removed the trailing whitespace flagged on line 126.