### PR TITLE
Fix linting errors

### DIFF
--- a/src/doc.ts
+++ b/src/doc.ts
@@ -4,8 +4,8 @@ import { DownloadWriter, FileStreamWriter } from './serialize/writer';
 import { ZipWriter } from './serialize/zip-writer';
 import { Splat } from './splat';
 import { serializePly } from './splat-serialize';
-import { localize } from './ui/localization';
 import { Transform } from './transform';
+import { localize } from './ui/localization';
 
 // ts compiler and vscode find this type, but eslint does not
 type FilePickerAcceptType = unknown;
@@ -123,7 +123,7 @@ const registerDocEvents = (scene: Scene, events: Events) => {
             events.invoke('docDeserialize.poseSets', document.poseSets);
             events.invoke('docDeserialize.view', document.view);
             scene.camera.docDeserialize(document.camera);
-            
+
             // refresh the pivot to reflect the loaded transform
             const currentSelection = events.invoke('selection');
             if (currentSelection) {


### PR DESCRIPTION
I see the main branch CICD failed due to linting errors from my previous PR #634.

```
(base) nagakarumuri@Nagas-MacBook-Air supersplat % npm run lint

> supersplat@2.13.2 lint
> eslint src


/Users/nagakarumuri/Documents/development/supersplat/src/doc.ts
    8:1  error  `./transform` import should occur before import of `./ui/localization`  import/order
  126:1  error  Trailing spaces not allowed                                             no-trailing-spaces

✖ 2 problems (2 errors, 0 warnings)
  2 errors and 0 warnings potentially fixable with the `--fix` option.
```

Adjusted doc.ts to satisfy ESLint: reordered the Transform import ahead of localization to meet import/order and removed the trailing whitespace flagged on line 126.