### PR TITLE
fix: Remove outdated <meta> tags

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -10,8 +10,6 @@
         <meta name="description" content="SuperSplat is an advanced browser-based editor for manipulating and optimizing 3D Gaussian Splats. It is open source and engine agnostic." />
         <meta name="viewport" content="width=device-width, user-scalable=no, minimum-scale=1.0, maximum-scale=1.0" />
 
-        <!-- ssr-head -->
-
         <!-- jszip -->
         <script src="jszip.js"></script>
 


### PR DESCRIPTION
## What's changed?

Currently the OpenGraph and Twitter `<meta>` tags are outdated (e.g. wrong URL). 

There are also some other SEO relevant tags that I want to add, but are not relevant for this repository:
* Canonical `<link rel="canonical">`
* Structured JSON (e.g. breadcrumbs)

~~I added a placeholder line (`<!-- ssr-head -->`) that allows us to dynamically inject the SEO tags on the server side by using something like `html.replace('<!-- ssr-head -->', '...')`. This allows us to quickly make changes to SEO tags without having to touch this repository.~~


