### PR TITLE
Use orbit mode for rotation gizmo

### DIFF
--- a/src/tools/rotate-tool.ts
+++ b/src/tools/rotate-tool.ts
@@ -7,6 +7,7 @@ import { Scene } from '../scene';
 class RotateTool extends TransformTool {
     constructor(events: Events, scene: Scene) {
         const gizmo = new RotateGizmo(scene.camera.entity.camera, scene.gizmoLayer);
+        gizmo.rotationMode = 'orbit';
 
         super(gizmo, events, scene);
     }


### PR DESCRIPTION
Make the rotation indicator of the rotation gizmo point directly at the mouse pointer.

Fixes #292
