### PR TITLE
Add additional frame rate options for video export

### DIFF
--- a/src/ui/video-settings-dialog.ts
+++ b/src/ui/video-settings-dialog.ts
@@ -85,8 +85,11 @@ class VideoSettingsDialog extends Container {
             defaultValue: '30',
             options: [
                 { v: '12', t: '12 fps' },
+                { v: '15', t: '15 fps' },
                 { v: '24', t: '24 fps' },
+                { v: '25', t: '25 fps' },
                 { v: '30', t: '30 fps' },
+                { v: '48', t: '48 fps' },
                 { v: '60', t: '60 fps' },
                 { v: '120', t: '120 fps' }
             ]
@@ -264,8 +267,11 @@ class VideoSettingsDialog extends Container {
 
                     const frameRates: Record<string, number> = {
                         '12': 12,
+                        '15': 15,
                         '24': 24,
+                        '25': 25,
                         '30': 30,
+                        '48': 48,
                         '60': 60,
                         '120': 120
                     };


### PR DESCRIPTION
Expands the frame rate options in the video export dialog to support more international standards and common use cases.

**Changes**
Added three new frame rate options:
* 15 fps - Low bandwidth web video, time-lapses
* 25 fps - PAL broadcast standard (Europe/International)
* 48 fps - High frame rate cinema

**Frame Rate Options (Before → After)**
Before: 12, 24, 30, 60, 120 fps (5 options)
After: 12, 15, 24, 25, 30, 48, 60, 120 fps (8 options)

**Rationale**
The most notable addition is 25 fps, which is the PAL broadcast standard used throughout Europe, UK, Australia, and most of the world outside North America and Japan. This was a significant omission for international users.
15 fps provides a good option for lower bandwidth requirements and web-optimized content, while 48 fps supports the modern high frame rate cinema standard popularized by filmmakers like Peter Jackson and James Cameron.

<img width="650" height="539" alt="image" src="https://github.com/user-attachments/assets/a263624e-1208-4ad8-9a87-ac8c9e62f9d8" />
