### PR TITLE
Trigger rebuild on saving .scss files

### DIFF
--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -85,7 +85,8 @@ const application = {
                 .then(result => result.css);
             },
             fileName: 'index.css',
-            includePaths: [`${PCUI_DIR}/dist`]
+            includePaths: [`${PCUI_DIR}/dist`],
+            watch: 'src/ui/scss'
         }),
         BUILD_TYPE === 'release' &&
         strip({


### PR DESCRIPTION
At the moment, when running `npm run develop`, saving a `.scss` file will not trigger a rebuild. This PR fixes that.