### PR TITLE
fix: Reduce size of the menu bar when collapsed

### DIFF
--- a/src/ui/scss/menu.scss
+++ b/src/ui/scss/menu.scss
@@ -71,7 +71,8 @@
 
 .collapsed {
     #menu-bar {
-        width: 90px;
+        width: auto;
+        height: auto;
     }
 
     #menu-collapse {
@@ -80,6 +81,7 @@
 
     #menu-arrow {
         display: block;
+        padding: 10px;
     }
 
     .menu-option {


### PR DESCRIPTION
Now it's not so chunky!

https://github.com/user-attachments/assets/f2c721d7-1732-4fe2-a190-23f3a518f33d

