### PR TITLE
[FIX] Show units in measurement panel

### DIFF
--- a/src/tools/measure-tool.ts
+++ b/src/tools/measure-tool.ts
@@ -1,4 +1,4 @@
-import { Container, NumericInput } from '@playcanvas/pcui';
+import { Container, Label, NumericInput } from '@playcanvas/pcui';
 import { Entity, Mat4, Quat, TranslateGizmo, Vec3 } from 'playcanvas';
 
 import { EntityTransformOp } from '../edit-ops';
@@ -6,6 +6,7 @@ import { Events } from '../events';
 import { Scene } from '../scene';
 import { Splat } from '../splat';
 import { Transform } from '../transform';
+import { localize } from '../ui/localization';
 
 const mat = new Mat4();
 const mat1 = new Mat4();
@@ -67,9 +68,13 @@ class MeasureTool {
         svg.appendChild(lineEnd);
 
         // ui
+        const lengthLabel = new Label({
+            text: localize('measure.length')
+        });
+
         const lengthInput = new NumericInput({
-            width: 120,
-            placeholder: 'Length',
+            width: 90,
+            placeholder: 'm',
             precision: 2,
             min: 0.0001,
             value: 0
@@ -85,6 +90,7 @@ class MeasureTool {
             e.stopPropagation();
         });
 
+        selectToolbar.append(lengthLabel);
         selectToolbar.append(lengthInput);
         canvasContainer.append(selectToolbar);
 

--- a/static/locales/de.json
+++ b/static/locales/de.json
@@ -216,6 +216,7 @@
     "tooltip.bottom-toolbar.rotate": "Drehen ( 2 )",
     "tooltip.bottom-toolbar.scale": "Skalieren ( 3 )",
     "tooltip.bottom-toolbar.measure": "Messung",
+    "measure.length": "Länge",
     "tooltip.bottom-toolbar.local-space": "Gizmo in local-space",
     "tooltip.bottom-toolbar.bound-center": "Mittelpunkt verwenden",
     "tooltip.timeline.prev-key": "Zur vorherigen Keyframe springen",

--- a/static/locales/en.json
+++ b/static/locales/en.json
@@ -216,6 +216,7 @@
     "tooltip.bottom-toolbar.rotate": "Rotate ( 2 )",
     "tooltip.bottom-toolbar.scale": "Scale ( 3 )",
     "tooltip.bottom-toolbar.measure": "Measurement",
+    "measure.length": "Length",
     "tooltip.bottom-toolbar.local-space": "Use Local Orientation",
     "tooltip.bottom-toolbar.bound-center": "Use Bound Center",
     "tooltip.timeline.prev-key": "Jump to Previous Keyframe",

--- a/static/locales/es.json
+++ b/static/locales/es.json
@@ -216,6 +216,7 @@
     "tooltip.bottom-toolbar.rotate": "Rotar ( 2 )",
     "tooltip.bottom-toolbar.scale": "Escalar ( 3 )",
     "tooltip.bottom-toolbar.measure": "Medición",
+    "measure.length": "Longitud",
     "tooltip.bottom-toolbar.local-space": "Usar orientación local",
     "tooltip.bottom-toolbar.bound-center": "Usar centro de límites",
     "tooltip.timeline.prev-key": "Saltar al fotograma clave anterior",

--- a/static/locales/fr.json
+++ b/static/locales/fr.json
@@ -216,6 +216,7 @@
     "tooltip.bottom-toolbar.rotate": "Rotation ( 2 )",
     "tooltip.bottom-toolbar.scale": "Échelle ( 3 )",
     "tooltip.bottom-toolbar.measure": "Mesure",
+    "measure.length": "Longueur",
     "tooltip.bottom-toolbar.local-space": "Espace local gizmo",
     "tooltip.bottom-toolbar.bound-center": "Utiliser le centre de la limite",
     "tooltip.timeline.prev-key": "Aller à la clé précédente",

--- a/static/locales/ja.json
+++ b/static/locales/ja.json
@@ -216,6 +216,7 @@
     "tooltip.bottom-toolbar.rotate": "回転 ( 2 )",
     "tooltip.bottom-toolbar.scale": "スケール ( 3 )",
     "tooltip.bottom-toolbar.measure": "測定",
+    "measure.length": "長さ",
     "tooltip.bottom-toolbar.local-space": "ローカル座標へ切り替え",
     "tooltip.bottom-toolbar.bound-center": "バウンディングボックスの中心を使用",
     "tooltip.timeline.prev-key": "前のキーフレームに移動",

--- a/static/locales/ko.json
+++ b/static/locales/ko.json
@@ -216,6 +216,7 @@
     "tooltip.bottom-toolbar.rotate": "회전 ( 2 )",
     "tooltip.bottom-toolbar.scale": "크기 조정 ( 3 )",
     "tooltip.bottom-toolbar.measure": "측정",
+    "measure.length": "길이",
     "tooltip.bottom-toolbar.local-space": "로컬 공간",
     "tooltip.bottom-toolbar.bound-center": "바운드 중심 사용",
     "tooltip.timeline.prev-key": "이전 키로 이동",

--- a/static/locales/pt-BR.json
+++ b/static/locales/pt-BR.json
@@ -216,6 +216,7 @@
     "tooltip.bottom-toolbar.rotate": "Rotacionar ( 2 )",
     "tooltip.bottom-toolbar.scale": "Escalar ( 3 )",
     "tooltip.bottom-toolbar.measure": "Medir",
+    "measure.length": "Comprimento",
     "tooltip.bottom-toolbar.local-space": "Usar Orientação Local",
     "tooltip.bottom-toolbar.bound-center": "Usar Centro da Cena",
     "tooltip.timeline.prev-key": "Ir para o Quadro Anterior",

--- a/static/locales/ru.json
+++ b/static/locales/ru.json
@@ -216,6 +216,7 @@
     "tooltip.bottom-toolbar.rotate": "Вращение ( 2 )",
     "tooltip.bottom-toolbar.scale": "Масштабирование ( 3 )",
     "tooltip.bottom-toolbar.measure": "Измерение",
+    "measure.length": "Длина",
     "tooltip.bottom-toolbar.local-space": "Использовать локальную ориентацию",
     "tooltip.bottom-toolbar.bound-center": "Использовать центр границ",
     "tooltip.timeline.prev-key": "Перейти к предыдущему ключевому кадру",

--- a/static/locales/zh-CN.json
+++ b/static/locales/zh-CN.json
@@ -216,6 +216,7 @@
     "tooltip.bottom-toolbar.rotate": "旋转 ( 2 )",
     "tooltip.bottom-toolbar.scale": "缩放 ( 3 )",
     "tooltip.bottom-toolbar.measure": "测量",
+    "measure.length": "长度",
     "tooltip.bottom-toolbar.local-space": "局部坐标系",
     "tooltip.bottom-toolbar.bound-center": "使用边界中心",
     "tooltip.timeline.prev-key": "上一个关键帧",


### PR DESCRIPTION
Adds a "Length" label and "m" (meters) unit indicator to the measurement tool UI, addressing user feedback that the tool didn't specify what unit it was using.

<img width="877" height="582" alt="image" src="https://github.com/user-attachments/assets/fa9b8cbc-1816-4fbb-8ea9-ea35a251fc4e" />

Fixes #709