### PR TITLE
Allow passing filename as URL params for special urls

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -269,13 +269,19 @@ const main = async () => {
 
     // handle load params
     const loadList = url.searchParams.getAll('load');
-    for (const value of loadList) {
+    const filenameList = url.searchParams.getAll('filename');
+    for (const [i, value] of loadList.entries()) {
         const decoded = decodeURIComponent(value);
+        const filename = i < filenameList.length 
+            ? decodeURIComponent(filenameList[i])
+            : decoded.split('/').pop();
+
         await events.invoke('import', [{
-            filename: decoded.split('/').pop(),
+            filename,
             url: decoded
         }]);
     }
+
 
     // handle OS-based file association in PWA mode
     if ('launchQueue' in window) {


### PR DESCRIPTION
See https://github.com/playcanvas/supersplat/issues/718 for context

This PR aims at offering the user the ability to pass URL-params not only for 3dgs scenes via the `load` url-param (already does so) but also for their filenames, so it is possible to pass filenames for weird URLs like ones which do not end with the extension. 