### PR TITLE
Reorganize Help menu items

### DIFF
--- a/src/ui/menu.ts
+++ b/src/ui/menu.ts
@@ -267,27 +267,17 @@ class Menu extends Container {
         }]);
 
         const helpMenuPanel = new MenuPanel([{
-            text: localize('menu.help.shortcuts'),
-            icon: 'E136',
-            onSelect: () => events.fire('show.shortcuts')
+            text: localize('menu.help.video-tutorials'),
+            icon: 'E261',
+            subMenu: videoTutorialsMenuPanel
         }, {
             text: localize('menu.help.user-guide'),
             icon: 'E232',
             onSelect: () => window.open('https://developer.playcanvas.com/user-manual/gaussian-splatting/editing/supersplat/', '_blank')?.focus()
         }, {
-            text: localize('menu.help.log-issue'),
-            icon: 'E336',
-            onSelect: () => window.open('https://github.com/playcanvas/supersplat/issues', '_blank')?.focus()
-        }, {
-            text: localize('menu.help.github-repo'),
-            icon: 'E259',
-            onSelect: () => window.open('https://github.com/playcanvas/supersplat', '_blank')?.focus()
-        }, {
-            // separator
-        }, {
-            text: localize('menu.help.video-tutorials'),
-            icon: 'E261',
-            subMenu: videoTutorialsMenuPanel
+            text: localize('menu.help.shortcuts'),
+            icon: 'E136',
+            onSelect: () => events.fire('show.shortcuts')
         }, {
             // separator
         }, {
@@ -298,6 +288,16 @@ class Menu extends Container {
             text: localize('menu.help.forum'),
             icon: 'E432',
             onSelect: () => window.open('https://forum.playcanvas.com', '_blank')?.focus()
+        }, {
+            // separator
+        }, {
+            text: localize('menu.help.github-repo'),
+            icon: 'E259',
+            onSelect: () => window.open('https://github.com/playcanvas/supersplat', '_blank')?.focus()
+        }, {
+            text: localize('menu.help.log-issue'),
+            icon: 'E336',
+            onSelect: () => window.open('https://github.com/playcanvas/supersplat/issues', '_blank')?.focus()
         }, {
             // separator
         }, {


### PR DESCRIPTION
Reorganizes the Help menu items into logical groups to improve user experience and make it easier to find related items.

<img width="664" height="517" alt="image" src="https://github.com/user-attachments/assets/19224a24-f697-40b7-9775-a7014a4e483a" />

### Changes

The Help menu items are now organized into four clear sections:

1. **Learning & Getting Started**
   - Video Tutorials (submenu)
   - User Guide
   - Keyboard Shortcuts

2. **Community & Support**
   - Discord Server
   - Forum

3. **Development & Contributing**
   - GitHub Repo
   - Log an Issue

4. **About**
   - About SuperSplat

### Benefits

- **Better organization**: Related items are grouped together logically
- **Improved discoverability**: Users can more easily find what they're looking for
- **Clearer hierarchy**: Separators visually distinguish different types of resources
- **Consistent flow**: Follows a logical progression from learning → community → development → about

### Technical Details

- Reordered items in the `helpMenuPanel` array in `src/ui/menu.ts`
- Maintained existing functionality and formatting style
- No localization changes required