### PR TITLE
Update default settings

### DIFF
--- a/src/camera.ts
+++ b/src/camera.ts
@@ -76,7 +76,7 @@ class Camera extends Element {
 
     sceneRadius = 1;
 
-    flySpeed = 2;
+    flySpeed = 1;
 
     controlMode: 'orbit' | 'fly' = 'orbit';
 

--- a/src/scene-config.ts
+++ b/src/scene-config.ts
@@ -14,11 +14,11 @@ const sceneConfig = {
     camera: {
         pixelScale: 1,
         multisample: false,
-        fov: 65,
+        fov: 75,
         exposure: 1.0,
         toneMapping: 'linear',
         debugRender: '',
-        overlay: true,
+        overlay: false,
         highPrecision: true
     },
     show: {

--- a/src/ui/view-panel.ts
+++ b/src/ui/view-panel.ts
@@ -216,7 +216,7 @@ class ViewPanel extends Container {
             min: 0.1,
             max: 30,
             precision: 1,
-            value: 2
+            value: 1
         });
 
         cameraFlySpeedRow.append(cameraFlySpeedLabel);


### PR DESCRIPTION
## Update default settings

Updates several default values to improve the initial user experience:

- Change default camera FOV from 65° to 75°
- Set splat overlay to off by default
- Reduce default fly speed from 2 to 1

### Files Changed

- `src/scene-config.ts` - FOV and overlay defaults
- `src/camera.ts` - Fly speed class property
- `src/ui/view-panel.ts` - Fly speed slider initial value