### PR TITLE
Add progress popup for SOG compression

### DIFF
--- a/src/file-handler.ts
+++ b/src/file-handler.ts
@@ -536,10 +536,15 @@ const initFileHandler = (scene: Scene, events: Events, dropTarget: HTMLElement) 
     });
 
     events.function('scene.write', async (fileType: FileType, options: SceneExportOptions, stream?: FileSystemWritableFileStream) => {
-        events.fire('startSpinner');
+        // SOG has its own progress UI, other formats use spinner
+        const useSpinner = fileType !== 'sog';
+
+        if (useSpinner) {
+            events.fire('startSpinner');
+        }
 
         try {
-            // setTimeout so spinner has a chance to activate
+            // setTimeout so spinner/progress has a chance to activate
             await new Promise<void>((resolve) => {
                 setTimeout(resolve);
             });
@@ -568,7 +573,8 @@ const initFileHandler = (scene: Scene, events: Events, dropTarget: HTMLElement) 
                             ...serializeSettings,
                             minOpacity: 1 / 255,
                             removeInvalid: true,
-                            iterations: options.sogIterations ?? 10
+                            iterations: options.sogIterations ?? 10,
+                            events
                         };
                         await serializeSog(splats, sogSettings, writer);
                         break;
@@ -589,7 +595,9 @@ const initFileHandler = (scene: Scene, events: Events, dropTarget: HTMLElement) 
                 message: `${error.message ?? error} while saving file`
             });
         } finally {
-            events.fire('stopSpinner');
+            if (useSpinner) {
+                events.fire('stopSpinner');
+            }
         }
     });
 };

--- a/src/splat-serialize.ts
+++ b/src/splat-serialize.ts
@@ -13,6 +13,7 @@ import {
 } from 'playcanvas';
 
 import { version } from '../package.json';
+import { Events } from './events';
 import {
     BufferWriter,
     ProgressWriter,
@@ -1120,10 +1121,11 @@ const serializeViewer = async (splats: Splat[], serializeSettings: SerializeSett
 
 type SogSettings = SerializeSettings & {
     iterations: number;
+    events?: Events;
 };
 
 const serializeSog = async (splats: Splat[], settings: SogSettings, writer: Writer): Promise<void> => {
-    const { maxSHBands = 3, iterations = 10 } = settings;
+    const { maxSHBands = 3, iterations = 10, events } = settings;
 
     // Determine which members to extract
     const shCoeffs = [0, 3, 8, 15][maxSHBands];
@@ -1157,7 +1159,7 @@ const serializeSog = async (splats: Splat[], settings: SogSettings, writer: Writ
         splats,
         getSingleSplat,
         filterFunc,
-        { iterations, maxSHBands },
+        { iterations, maxSHBands, events },
         writer
     );
 };


### PR DESCRIPTION
## Add progress popup for SOG compression

Adds a progress popup during SOG export that displays real-time progress for each compression stage. Each stage shows its own 0-100% progress bar, with k-means clustering stages updating per iteration.

### Changes

- Add `onProgress` callback to `kmeans` and `cluster1d` functions for iteration-level progress reporting
- Fire `progressStart`, `progressUpdate`, and `progressEnd` events during SOG serialization
- Pass `Events` object through the serialization call chain
- Skip spinner for SOG exports (progress popup handles UI feedback)

### Progress Stages

The popup displays progress for each stage:
- Extracting data
- Generating morton order
- Writing positions
- Writing quaternions
- Compressing scales (k-means iterations)
- Compressing colors (k-means iterations)
- Compressing spherical harmonics (k-means iterations, if present)
- Finalizing

### Public API Changes

**SogSettings** (in `splat-serialize.ts`):
```typescript
// Before
type SogSettings = SerializeSettings & {
    iterations: number;
};

// After
type SogSettings = SerializeSettings & {
    iterations: number;
    events?: Events;
};
```

**kmeans** and **cluster1d** (in `sog/k-means.ts`):
```typescript
// Before
const kmeans = async (points, k, iterations, device): Promise<KMeansResult>
const cluster1d = async (dataTable, iterations, device): Promise<...>

// After
const kmeans = async (points, k, iterations, device, onProgress?): Promise<KMeansResult>
const cluster1d = async (dataTable, iterations, device, onProgress?): Promise<...>
