### PR TITLE
Fix keyboard repeat events for brush size shortcuts

### DIFF
--- a/src/shortcut-manager.ts
+++ b/src/shortcut-manager.ts
@@ -36,8 +36,8 @@ const defaultShortcuts: Record<string, ShortcutBinding> = {
     'tool.brushSelection': { keys: ['b'] },
     'tool.floodSelection': { keys: ['o'] },
     'tool.eyedropperSelection': { keys: ['e'], ctrl: 'required', capture: true },
-    'tool.brushSelection.smaller': { keys: ['['] },
-    'tool.brushSelection.bigger': { keys: [']'] },
+    'tool.brushSelection.smaller': { keys: ['['], repeat: true },
+    'tool.brushSelection.bigger': { keys: [']'], repeat: true },
     'tool.deactivate': { keys: ['Escape'] },
     'tool.toggleCoordSpace': { keys: ['c'], shift: 'required' },
 
@@ -80,6 +80,7 @@ class ShortcutManager {
                 shift: binding.shift,
                 alt: binding.alt,
                 held: binding.held,
+                repeat: binding.repeat,
                 capture: binding.capture
             });
         }

--- a/src/shortcuts.ts
+++ b/src/shortcuts.ts
@@ -18,6 +18,7 @@ interface ShortcutBinding {
     shift?: ModifierState;
     alt?: ModifierState;
     held?: boolean;
+    repeat?: boolean;       // whether to fire on keyboard repeat events (for non-held shortcuts)
     capture?: boolean;      // whether to use capture phase for the event listener
 }
 
@@ -81,9 +82,9 @@ class Shortcuts {
                             return;
                         }
                     } else {
-                        // Non-held: ignore up events and repeated keydown events
-                        // (prevents conflicts with held keys like WASD when adding modifiers)
-                        if (!down || e.repeat) return;
+                        // Non-held: ignore up events
+                        // Also ignore repeated keydown events unless repeat is explicitly allowed
+                        if (!down || (e.repeat && !options.repeat)) return;
                     }
 
                     if (options.event) {


### PR DESCRIPTION
## Fix keyboard repeat events for brush size shortcuts

Fixes an issue where holding `[` or `]` keys no longer continuously adjusted the brush size after the recent shortcut refactor.

### Changes

- Add `repeat?: boolean` option to `ShortcutBinding` interface for shortcuts that should fire on keyboard repeat events
- Update shortcut handler to allow repeat events when `repeat: true` is set
- Enable `repeat: true` for brush size shortcuts (`tool.brushSelection.smaller` and `tool.brushSelection.bigger`)

### Background

Commit c526a2b added logic to ignore keyboard repeat events for non-held shortcuts to prevent conflicts with WASD fly camera controls. This inadvertently broke the brush size shortcuts which rely on repeat events to continuously resize the brush while the key is held.