### PR TITLE
Fix backspace deleting gaussians when measure tool is active

### DIFF
--- a/src/editor.ts
+++ b/src/editor.ts
@@ -487,6 +487,10 @@ const registerEditorEvents = (events: Events, editHistory: EditHistory, scene: S
     });
 
     events.on('select.delete', () => {
+        // Don't delete gaussians when measure tool is active (backspace deletes measure points instead)
+        if (events.invoke('tool.active') === 'measure') {
+            return;
+        }
         selectedSplats().forEach((splat) => {
             editHistory.add(new DeleteSelectionOp(splat));
         });


### PR DESCRIPTION
## Fix backspace deleting gaussians when measure tool is active

Pressing Backspace while the measure tool is active now only deletes the selected measure point, instead of also deleting selected gaussians.

### Changes
- Added guard in `select.delete` handler to skip gaussian deletion when measure tool is active

### Technical Details
Both `editor.ts` and `measure-tool.ts` listen to the `select.delete` event. Previously, both handlers would fire when pressing Backspace, causing both measure points and gaussians to be deleted. The fix checks `events.invoke('tool.active')` and returns early if the measure tool is active.