### PR TITLE
fix: move event registrations before UI creation

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -84,6 +84,14 @@ const main = async () => {
     // init localization
     await localizeInit();
 
+    // register events that only need the events object (before UI is created)
+    registerTimelineEvents(events);
+    registerCameraPosesEvents(events);
+    registerTransformHandlerEvents(events);
+    registerPlySequenceEvents(events);
+    registerPublishEvents(events);
+    registerIframeApi(events);
+
     // initialize shortcuts
     const shortcutManager = new ShortcutManager(events);
     events.function('shortcutManager', () => shortcutManager);
@@ -221,16 +229,11 @@ const main = async () => {
 
     window.scene = scene;
 
+    // register events that need scene or other dependencies
     registerEditorEvents(events, editHistory, scene);
     registerSelectionEvents(events, scene);
-    registerTimelineEvents(events);
-    registerCameraPosesEvents(events);
-    registerTransformHandlerEvents(events);
-    registerPlySequenceEvents(events);
-    registerPublishEvents(events);
     registerDocEvents(scene, events);
     registerRenderEvents(scene, events);
-    registerIframeApi(events);
     initFileHandler(scene, events, editorUI.appContainer.dom);
 
     // load async models


### PR DESCRIPTION
## Summary

- Fixes timeline panel crash caused by initialization order race condition
- Moves event registrations that only need `events` to before UI creation
- Organizes registrations into two clear groups: events-only (early) and scene-dependent (later)

## Details

The `ResizeObserver` in `TimelinePanel` fires immediately when created and calls `events.invoke('timeline.frames')` etc. Previously, `registerTimelineEvents()` was called after `EditorUI` was created, so these functions weren't registered yet, causing `undefined` to be returned and `.forEach()` to crash.

Closes #763
