### PR TITLE
feat: export improvements and UI fixes

### DIFF
--- a/src/camera.ts
+++ b/src/camera.ts
@@ -8,7 +8,6 @@ import {
     PIXELFORMAT_DEPTH,
     PROJECTION_ORTHOGRAPHIC,
     PROJECTION_PERSPECTIVE,
-    TONEMAP_NONE,
     TONEMAP_ACES,
     TONEMAP_ACES2,
     TONEMAP_FILMIC,
@@ -137,7 +136,6 @@ class Camera extends Element {
     // tonemapping
     set tonemapping(value: string) {
         const mapping: Record<string, number> = {
-            none: TONEMAP_NONE,
             linear: TONEMAP_LINEAR,
             neutral: TONEMAP_NEUTRAL,
             aces: TONEMAP_ACES,
@@ -156,7 +154,6 @@ class Camera extends Element {
 
     get tonemapping() {
         switch (this.camera.toneMapping) {
-            case TONEMAP_NONE: return 'none';
             case TONEMAP_LINEAR: return 'linear';
             case TONEMAP_NEUTRAL: return 'neutral';
             case TONEMAP_ACES: return 'aces';
@@ -164,7 +161,7 @@ class Camera extends Element {
             case TONEMAP_FILMIC: return 'filmic';
             case TONEMAP_HEJL: return 'hejl';
         }
-        return 'none';
+        return 'linear';
     }
 
     // near clip

--- a/src/file-handler.ts
+++ b/src/file-handler.ts
@@ -501,8 +501,8 @@ const initFileHandler = (scene: Scene, events: Events, dropTarget: HTMLElement) 
     });
 
     events.function('scene.write', async (fileType: FileType, options: SceneExportOptions, stream?: FileSystemWritableFileStream) => {
-        // SOG has its own progress UI, other formats use spinner
-        const useSpinner = fileType !== 'sog';
+        // SOG and viewer exports have their own progress UI, other formats use spinner
+        const useSpinner = fileType !== 'sog' && fileType !== 'htmlViewer' && fileType !== 'packageViewer';
 
         if (useSpinner) {
             events.fire('startSpinner');
@@ -546,7 +546,7 @@ const initFileHandler = (scene: Scene, events: Events, dropTarget: HTMLElement) 
                 }
                 case 'htmlViewer':
                 case 'packageViewer':
-                    await serializeViewer(splats, serializeSettings, viewerExportSettings!, fs);
+                    await serializeViewer(splats, serializeSettings, { ...viewerExportSettings!, events }, fs);
                     break;
             }
 

--- a/src/ui/export-popup.ts
+++ b/src/ui/export-popup.ts
@@ -16,8 +16,18 @@ const createSvg = (svgString: string, args = {}) => {
 };
 
 const removeKnownExtension = (filename: string) => {
-    // remove known extensions
-    const knownExtensions = ['.compressed.ply', '.ply', '.splat', '.sog', '.html', '.zip'];
+    // remove known extensions (ordered from longest to shortest for compound extensions)
+    const knownExtensions = [
+        '.compressed.ply',
+        '.ksplat',
+        '.splat',
+        '.html',
+        '.ply',
+        '.sog',
+        '.spz',
+        '.lcc',
+        '.zip'
+    ];
 
     for (let i = 0; i < knownExtensions.length; ++i) {
         const ext = knownExtensions[i];

--- a/src/ui/view-panel.ts
+++ b/src/ui/view-panel.ts
@@ -121,9 +121,8 @@ class ViewPanel extends Container {
 
         const tonemappingSelection = new SelectInput({
             class: 'view-panel-row-select',
-            defaultValue: 'none',
+            defaultValue: 'linear',
             options: [
-                { v: 'none', t: localize('panel.view-options.tonemapping.none') },
                 { v: 'linear', t: localize('panel.view-options.tonemapping.linear') },
                 { v: 'neutral', t: localize('panel.view-options.tonemapping.neutral') },
                 { v: 'aces', t: localize('panel.view-options.tonemapping.aces') },


### PR DESCRIPTION
## Summary

- Add progress bar to HTML/package viewer exports, matching the existing SOG export behavior
- Remove redundant NONE tonemapping option since it's identical to LINEAR
- Fix proposed filenames when exporting to strip all supported input file extensions

## Changes

### Progress bar for viewer exports
- Added `events` to `ViewerExportSettings` type
- Extracted common `createProgressLogger` helper function to avoid code duplication between SOG and viewer exports
- Updated `file-handler.ts` to pass events and use progress bar instead of spinner for viewer exports

### Remove NONE tonemapping
- Removed `TONEMAP_NONE` import and all references in `camera.ts`
- Changed default tonemapping from `'none'` to `'linear'` in both camera and UI
- Removed the NONE option from the tonemapping dropdown in view-panel

### Fix export filenames
- Added missing input extensions to `removeKnownExtension()`: `.ksplat`, `.spz`, `.lcc`
- Reordered extensions from longest to shortest to ensure compound extensions are matched first

## Test plan
- [ ] Export a splat as HTML viewer and verify progress bar appears
- [ ] Export a splat as package viewer and verify progress bar appears
- [ ] Verify tonemapping dropdown no longer shows NONE option
- [ ] Verify LINEAR is the default tonemapping selection
- [ ] Load a `.ksplat` file and export - verify proposed filename doesn't include `.ksplat`
- [ ] Load a `.spz` file and export - verify proposed filename doesn't include `.spz`