### PR TITLE
fix: Add null check for splat in SplatOverlay.enabled getter

### DIFF
--- a/src/splat-overlay.ts
+++ b/src/splat-overlay.ts
@@ -140,9 +140,10 @@ class SplatOverlay extends Element {
     }
 
     get enabled() {
-        const { scene } = this;
+        const { scene, splat } = this;
         const { events } = scene;
-        return events.invoke('camera.splatSize') > 0 &&
+        return splat &&
+            events.invoke('camera.splatSize') > 0 &&
             scene.camera.renderOverlays &&
             events.invoke('camera.overlay') &&
             events.invoke('camera.mode') === 'centers';


### PR DESCRIPTION
## Summary

- Add null check for `this.splat` in the `enabled` getter to prevent TypeError when splat is undefined

Fixes #784

## Details

The `enabled` getter was returning `true` even when `this.splat` was undefined, causing a TypeError when `onPreRender()` accessed `this.splat.transformPalette.texture`.

This occurred in race conditions where `onPreRender()` ran before a selection event set `this.splat`, particularly on mobile browsers (reported on Chrome Mobile iOS on iPhone).

## Test plan

- [x] Verify the overlay renders correctly when a splat is selected and centers mode is active
- [x] Verify no error occurs when no splat is selected