### PR TITLE
fix: Remove edit operations when splat is deleted from scene

### DIFF
--- a/src/editor.ts
+++ b/src/editor.ts
@@ -3,6 +3,7 @@ import { Color, Mat4, path, Texture, Vec3, Vec4 } from 'playcanvas';
 
 import { EditHistory } from './edit-history';
 import { SelectAllOp, SelectNoneOp, SelectInvertOp, SelectOp, HideSelectionOp, UnhideAllOp, DeleteSelectionOp, ResetOp, MultiOp, AddSplatOp } from './edit-ops';
+import { Element, ElementType } from './element';
 import { Events } from './events';
 import { MappedReadFileSystem } from './io';
 import { Scene } from './scene';
@@ -53,6 +54,13 @@ const registerEditorEvents = (events: Events, editHistory: EditHistory, scene: S
         scene.clear();
         editHistory.clear();
         lastExportCursor = 0;
+    });
+
+    // When a splat is removed from the scene, remove all edit operations that reference it
+    events.on('scene.elementRemoved', (element: Element) => {
+        if (element.type === ElementType.splat) {
+            editHistory.removeForSplat(element as Splat);
+        }
     });
 
     events.function('scene.dirty', () => {


### PR DESCRIPTION
Closes #585

## Summary

- Fixes crash when clicking Undo after deleting a splat via the trash icon in SCENE MANAGER
- Adds \
emoveForSplat()\ method to \EditHistory\ to remove all operations referencing a deleted splat
- Adds \opReferencesSplat()\ helper that recursively checks operations (including nested \MultiOp\)
- Listens to \scene.elementRemoved\ event to trigger cleanup when splats are removed

## Repro steps (before fix)

1. Drag a PLY into the SuperSplat Editor
2. Enable Rect Select
3. Select some Gaussians
4. Hit Delete
5. In SCENE MANAGER, click the Trash icon for the loaded PLY
6. Undo is still active. Click it and an exception is thrown.

## Test plan

- [x] Follow repro steps above - undo button should now be disabled after deleting the splat
- [x] Verify no crash occurs
- [x] Test with multiple splats loaded and operations on each