### PR TITLE
Update splat overlay keyboard toggle

### DIFF
--- a/src/shortcut-manager.ts
+++ b/src/shortcut-manager.ts
@@ -14,7 +14,7 @@ const defaultShortcuts: Record<string, ShortcutBinding> = {
     'camera.toggleControlMode': { keys: ['v'] },
 
     // Show
-    'camera.toggleOverlay': { keys: ['m'], shift: 'required' },
+    'camera.toggleOverlay': { keys: ['Tab'] },
     'camera.toggleMode': { keys: ['m'] },
     'grid.toggleVisible': { keys: ['g'] },
     'select.hide': { keys: ['h'] },
@@ -51,7 +51,6 @@ const defaultShortcuts: Record<string, ShortcutBinding> = {
     'tool.toggleCoordSpace': { keys: ['c'], shift: 'required' },
 
     // Other
-    'selection.next': { keys: ['Tab'] },
     'edit.undo': { keys: ['z'], ctrl: 'required', repeat: true, capture: true },
     'edit.redo': { keys: ['z'], ctrl: 'required', shift: 'required', repeat: true, capture: true },
     'dataPanel.toggle': { keys: ['d'], ctrl: 'required', capture: true },

--- a/src/ui/shortcuts-popup.ts
+++ b/src/ui/shortcuts-popup.ts
@@ -99,7 +99,6 @@ const popupConfig: Record<string, CategoryConfig> = {
     other: {
         localeKey: 'popup.shortcuts.other',
         shortcuts: [
-            { id: 'selection.next', localeKey: 'popup.shortcuts.select-next-splat' },
             { id: 'edit.undo', localeKey: 'popup.shortcuts.undo' },
             { id: 'edit.redo', localeKey: 'popup.shortcuts.redo' },
             { id: 'dataPanel.toggle', localeKey: 'popup.shortcuts.toggle-data-panel' }

--- a/static/locales/de.json
+++ b/static/locales/de.json
@@ -154,7 +154,6 @@
     "popup.shortcuts.unlock-all-splats": "Alle Splats entsperren",
     "popup.shortcuts.toggle-data-panel": "Splat Daten Panel anzeigen",
     "popup.shortcuts.other": "Weitere",
-    "popup.shortcuts.select-next-splat": "Nächsten Splat selektieren",
     "popup.shortcuts.undo": "Rückgängig",
     "popup.shortcuts.redo": "Wiederholen",
     "popup.shortcuts.toggle-splat-overlay": "Splateinblendung umschalten",

--- a/static/locales/en.json
+++ b/static/locales/en.json
@@ -154,7 +154,6 @@
     "popup.shortcuts.unlock-all-splats": "Unlock All Splats",
     "popup.shortcuts.toggle-data-panel": "Toggle Data Panel",
     "popup.shortcuts.other": "Other",
-    "popup.shortcuts.select-next-splat": "Select Next Splat",
     "popup.shortcuts.undo": "Undo",
     "popup.shortcuts.redo": "Redo",
     "popup.shortcuts.toggle-splat-overlay": "Toggle Splat Overlay",

--- a/static/locales/es.json
+++ b/static/locales/es.json
@@ -154,7 +154,6 @@
     "popup.shortcuts.unlock-all-splats": "Desbloquear todos los Splats",
     "popup.shortcuts.toggle-data-panel": "Alternar panel de datos",
     "popup.shortcuts.other": "Otros",
-    "popup.shortcuts.select-next-splat": "Seleccionar siguiente Splat",
     "popup.shortcuts.undo": "Deshacer",
     "popup.shortcuts.redo": "Rehacer",
     "popup.shortcuts.toggle-splat-overlay": "Alternar superposición de Splat",

--- a/static/locales/fr.json
+++ b/static/locales/fr.json
@@ -154,7 +154,6 @@
     "popup.shortcuts.unlock-all-splats": "Déverrouiller tous les splats",
     "popup.shortcuts.toggle-data-panel": "Afficher/Cacher l'onglet données",
     "popup.shortcuts.other": "Autres",
-    "popup.shortcuts.select-next-splat": "Sélectionner le splat suivant",
     "popup.shortcuts.undo": "Annuler",
     "popup.shortcuts.redo": "Rétablir",
     "popup.shortcuts.toggle-splat-overlay": "Basculer affichage splat",

--- a/static/locales/ja.json
+++ b/static/locales/ja.json
@@ -154,7 +154,6 @@
     "popup.shortcuts.unlock-all-splats": "すべてロック解除",
     "popup.shortcuts.toggle-data-panel": "データパネルの切り替え",
     "popup.shortcuts.other": "その他",
-    "popup.shortcuts.select-next-splat": "次のスプラットを選択",
     "popup.shortcuts.undo": "元に戻す",
     "popup.shortcuts.redo": "やり直し",
     "popup.shortcuts.toggle-splat-overlay": "スプラットオーバーレイの切り替え",

--- a/static/locales/ko.json
+++ b/static/locales/ko.json
@@ -154,7 +154,6 @@
     "popup.shortcuts.unlock-all-splats": "모든 Splat 잠금 해제",
     "popup.shortcuts.toggle-data-panel": "데이터 패널 전환",
     "popup.shortcuts.other": "기타",
-    "popup.shortcuts.select-next-splat": "다음 Splat 선택",
     "popup.shortcuts.undo": "실행 취소",
     "popup.shortcuts.redo": "다시 실행",
     "popup.shortcuts.toggle-splat-overlay": "Splat 오버레이 전환",

--- a/static/locales/pt-BR.json
+++ b/static/locales/pt-BR.json
@@ -154,7 +154,6 @@
     "popup.shortcuts.unlock-all-splats": "Desbloquear Todos os Splats",
     "popup.shortcuts.toggle-data-panel": "Alternar Painel de Dados",
     "popup.shortcuts.other": "Outro",
-    "popup.shortcuts.select-next-splat": "Selecionar Próximo Splat",
     "popup.shortcuts.undo": "Desfazer",
     "popup.shortcuts.redo": "Refazer",
     "popup.shortcuts.toggle-splat-overlay": "Alternar Sobreposição de Splat",

--- a/static/locales/ru.json
+++ b/static/locales/ru.json
@@ -154,7 +154,6 @@
     "popup.shortcuts.unlock-all-splats": "Разблокировать все сплаты",
     "popup.shortcuts.toggle-data-panel": "Переключить панель данных",
     "popup.shortcuts.other": "Прочее",
-    "popup.shortcuts.select-next-splat": "Выбрать следующий сплат",
     "popup.shortcuts.undo": "Отменить",
     "popup.shortcuts.redo": "Повторить",
     "popup.shortcuts.toggle-splat-overlay": "Переключить наложение сплатов",

--- a/static/locales/zh-CN.json
+++ b/static/locales/zh-CN.json
@@ -154,7 +154,6 @@
     "popup.shortcuts.unlock-all-splats": "解锁全部 Splat",
     "popup.shortcuts.toggle-data-panel": "切换数据面板",
     "popup.shortcuts.other": "其他",
-    "popup.shortcuts.select-next-splat": "选择下一个 Splat",
     "popup.shortcuts.undo": "撤销",
     "popup.shortcuts.redo": "重做",
     "popup.shortcuts.toggle-splat-overlay": "切换 Splat 叠加",


### PR DESCRIPTION
## Summary

Change the splat overlay toggle keyboard shortcut from `Shift+M` to `Tab` for quicker access.

- Rebind `camera.toggleOverlay` from `Shift+M` to `Tab`
- Remove the `selection.next` shortcut (previously bound to `Tab`) which cycled through loaded splats
- Clean up associated UI and localization entries

## Changed Files

- `src/shortcut-manager.ts` - Updated shortcut binding
- `src/ui/shortcuts-popup.ts` - Removed "Select Next Splat" from shortcuts popup
- `static/locales/*.json` - Removed unused localization string from all 9 locale files

## Breaking Changes

- The "Select Next Splat" shortcut (`Tab`) has been removed. Users with multiple splats loaded will need to use alternative methods to switch between them.