### PR TITLE
Fix camera distance changing on viewport resize

### DIFF
--- a/src/camera.ts
+++ b/src/camera.ts
@@ -616,12 +616,9 @@ class Camera extends Element {
     }
 
     get fovFactor() {
-        // we set the fov of the longer axis. here we get the fov of the other (smaller) axis so framing
-        // doesn't cut off the scene.
-        const { width, height } = this.targetSize;
-        const aspect = (width && height) ? this.camera.horizontalFov ? height / width : width / height : 1;
-        const fov = 2 * Math.atan(Math.tan(this.fov * math.DEG_TO_RAD * 0.5) * aspect);
-        return Math.sin(fov * 0.5);
+        // use the larger axis fov (which is always this.fov) so camera distance
+        // stays constant regardless of viewport aspect ratio.
+        return Math.sin(this.fov * math.DEG_TO_RAD * 0.5);
     }
 
     getRay(screenX: number, screenY: number, ray: Ray) {


### PR DESCRIPTION
## Summary

The `fovFactor` getter was computing the FOV of the viewport's smaller axis and using it to scale the camera distance. This caused the camera to zoom in/out whenever the viewport aspect ratio changed (e.g. opening the SPLAT DATA or TIMELINE panel), even though the user hadn't touched the zoom controls.

The fix simplifies `fovFactor` to use the larger axis FOV (which is always the configured `this.fov`), making the camera distance independent of viewport shape. Resizing the viewport now simply crops the view on the shorter axis instead of changing the effective zoom level.

## Changes

- `fovFactor` now returns `sin(fov / 2)` (constant for a given FOV) instead of `sin(smallerAxisFov / 2)` (variable with aspect ratio)
- No changes needed to the `orthoHeight` calculation or other `fovFactor` consumers -- they remain internally consistent

## Test plan

- Load a scene in SuperSplat
- Toggle the SPLAT DATA panel on/off and verify the camera distance stays stable (the scene should crop vertically, not zoom out)
- Toggle the TIMELINE panel on/off and verify the same
- Resize the browser window and verify stable camera behavior
- Switch to ortho mode and repeat the above checks