### PR TITLE
Fix video codec reclamation when tab is backgrounded

### DIFF
--- a/src/render.ts
+++ b/src/render.ts
@@ -354,8 +354,10 @@ const registerRenderEvents = (scene: Scene, events: Events) => {
 
                     // if the codec was reclaimed (e.g. browser backgrounded the tab),
                     // recreate the encoder and continue
+                    let forceKeyFrame = false;
                     if (encoder.state === 'closed' && encoderError?.message?.includes('reclaimed')) {
                         encoder = createEncoder();
+                        forceKeyFrame = true;
                     }
 
                     // check for non-recoverable encoder errors
@@ -364,7 +366,7 @@ const registerRenderEvents = (scene: Scene, events: Events) => {
                         throw encoderError;
                     }
 
-                    encoder.encode(videoFrame);
+                    encoder.encode(videoFrame, { keyFrame: forceKeyFrame });
                     videoFrame.close();
                 };
 


### PR DESCRIPTION
## Summary

When the browser tab is backgrounded during video encoding, Chrome reclaims `VideoEncoder` codec resources after ~60 seconds of inactivity, causing the error: `Codec reclaimed due to inactivity`.

This PR addresses the issue with two complementary strategies:

- **Web Lock API**: Acquires a lock during encoding to signal the browser that the tab is actively working, which may help prevent aggressive background throttling and resource reclamation
- **Encoder recovery**: If the codec is still reclaimed despite the lock, the encoder is automatically recreated and encoding continues from the current frame rather than failing entirely

The encoder creation logic is extracted into a `createEncoder()` helper that can be called both initially and when recovering from reclamation. Before encoding each frame, the code checks if the encoder was closed due to reclamation and recreates it if needed.

## Test plan

- [x] Start a long video render (e.g. 300+ frames)
- [x] Switch to another browser tab for 2+ minutes
- [x] Switch back and verify that encoding continued/completed successfully
- [x] Verify normal (non-backgrounded) video rendering still works correctly
- [x] Test in a browser without Web Locks API support (e.g. older browser) to verify graceful fallback
