### PR TITLE
fix: prevent OOM when rendering large videos to file

### DIFF
--- a/src/render.ts
+++ b/src/render.ts
@@ -11,10 +11,10 @@ import { localize } from './ui/localization';
 const nullClr = new Color(0, 0, 0, 0);
 
 // Lookup maps for video output format and codec configuration
-const FORMAT_CONFIG: Record<string, { create: () => Mp4OutputFormat | MovOutputFormat | MkvOutputFormat | WebMOutputFormat; extension: string }> = {
-    mp4: { create: () => new Mp4OutputFormat({ fastStart: 'in-memory' }), extension: 'mp4' },
+const FORMAT_CONFIG: Record<string, { create: (streaming: boolean) => Mp4OutputFormat | MovOutputFormat | MkvOutputFormat | WebMOutputFormat; extension: string }> = {
+    mp4: { create: streaming => new Mp4OutputFormat({ fastStart: streaming ? false : 'in-memory' }), extension: 'mp4' },
     webm: { create: () => new WebMOutputFormat(), extension: 'webm' },
-    mov: { create: () => new MovOutputFormat({ fastStart: 'in-memory' }), extension: 'mov' },
+    mov: { create: streaming => new MovOutputFormat({ fastStart: streaming ? false : 'in-memory' }), extension: 'mov' },
     mkv: { create: () => new MkvOutputFormat(), extension: 'mkv' }
 };
 
@@ -200,7 +200,7 @@ const registerRenderEvents = (scene: Scene, events: Events) => {
 
                 // Configure output format and codec from lookup maps (default to mp4/h264)
                 const formatConfig = FORMAT_CONFIG[format] ?? FORMAT_CONFIG.mp4;
-                const outputFormat = formatConfig.create();
+                const outputFormat = formatConfig.create(!!fileStream);
                 const fileExtension = formatConfig.extension;
 
                 const codecConfig = CODEC_CONFIG[codecChoice] ?? CODEC_CONFIG.h264;


### PR DESCRIPTION
## Summary

- When rendering video to a file (via StreamTarget), the MP4/MOV muxer was configured with `fastStart`: 'in-memory', which forces **all** encoded video sample data to be accumulated in RAM until finalization
- For large videos (e.g. 4K @ 60fps @ 180 seconds), this causes an Array buffer allocation failed error at 100% progress when output.finalize() attempts to write the buffered data
- Changed MP4/MOV format factories to use `fastStart`: false when streaming to a file, which writes data incrementally to disk. The 'in-memory' mode is retained for the BufferTarget fallback path where data is already in memory

## Test plan

- [x] Render a large video (e.g. 4K, 60fps, 180 seconds) to MP4 and verify it completes without OOM
- [x] Render a shorter video to MP4 and verify playback works correctly
- [x] Verify MOV format also works for large renders
- [x] Verify WebM and MKV formats are unaffected