### PR TITLE
Add particle dissolve effect with MediaPipe hand gesture control

### DIFF
--- a/src/gesture-controller.ts
+++ b/src/gesture-controller.ts
@@ -1,0 +1,202 @@
+import { Events } from './events';
+
+const THUMB_TIP = 4;
+const INDEX_TIP = 8;
+
+class GestureController {
+    private events: Events;
+    private video: HTMLVideoElement;
+    private canvas: HTMLCanvasElement;
+    private ctx: CanvasRenderingContext2D;
+    private handLandmarker: any = null;
+    private active = false;
+    private smoothedProgress = 0;
+    private handVisible = false;
+    private handLostTime = 0;
+
+    constructor(events: Events) {
+        this.events = events;
+
+        // hidden video for webcam
+        this.video = document.createElement('video');
+        this.video.setAttribute('playsinline', '');
+        this.video.setAttribute('autoplay', '');
+        this.video.style.display = 'none';
+        document.body.appendChild(this.video);
+
+        // small preview canvas in corner
+        this.canvas = document.createElement('canvas');
+        this.canvas.id = 'gesture-preview';
+        this.canvas.width = 240;
+        this.canvas.height = 180;
+        this.canvas.style.cssText = `
+            position: fixed;
+            bottom: 80px;
+            left: 16px;
+            border: 2px solid #30363d;
+            border-radius: 8px;
+            z-index: 100;
+            display: none;
+            background: #000;
+            transform: scaleX(-1);
+        `;
+        document.body.appendChild(this.canvas);
+        this.ctx = this.canvas.getContext('2d')!;
+
+        events.on('gesture.toggle', () => {
+            if (this.active) this.stop(); else this.start();
+        });
+    }
+
+    private async start() {
+        if (this.active) return;
+        console.log('[Gesture] Starting...');
+
+        try {
+            // dynamically import MediaPipe vision module
+            const cdnUrl = 'https://cdn.jsdelivr.net/npm/@mediapipe/tasks-vision@latest/vision_bundle.mjs';
+            const vision = await (new Function('url', 'return import(url)'))(cdnUrl);
+
+            const { HandLandmarker, FilesetResolver } = vision;
+
+            const resolver = await FilesetResolver.forVisionTasks(
+                'https://cdn.jsdelivr.net/npm/@mediapipe/tasks-vision@latest/wasm'
+            );
+
+            this.handLandmarker = await HandLandmarker.createFromOptions(resolver, {
+                baseOptions: {
+                    modelAssetPath: 'https://storage.googleapis.com/mediapipe-models/hand_landmarker/hand_landmarker/float16/latest/hand_landmarker.task',
+                    delegate: 'GPU'
+                },
+                runningMode: 'VIDEO',
+                numHands: 1
+            });
+
+            console.log('[Gesture] HandLandmarker ready');
+
+            // start webcam
+            const stream = await navigator.mediaDevices.getUserMedia({
+                video: { width: 320, height: 240, facingMode: 'user' }
+            });
+            this.video.srcObject = stream;
+            await this.video.play();
+
+            this.active = true;
+            this.canvas.style.display = 'block';
+            this.smoothedProgress = 0;
+            this.events.fire('gesture.active', true);
+
+            // set dissolve effect as the active effect
+            this.events.fire('particle.setEffect', 'dissolve');
+
+            this.detect();
+        } catch (err) {
+            console.error('[Gesture] Failed:', err);
+        }
+    }
+
+    private stop() {
+        if (!this.active) return;
+        this.active = false;
+        this.canvas.style.display = 'none';
+
+        const stream = this.video.srcObject as MediaStream;
+        if (stream) {
+            stream.getTracks().forEach(t => t.stop());
+            this.video.srcObject = null;
+        }
+
+        // reset effect
+        this.events.fire('particle.setProgress', 0);
+        this.events.fire('gesture.active', false);
+    }
+
+    private detect() {
+        if (!this.active) return;
+
+        // draw camera feed
+        this.ctx.drawImage(this.video, 0, 0, this.canvas.width, this.canvas.height);
+
+        const now = performance.now();
+        const results = this.handLandmarker.detectForVideo(this.video, now);
+
+        if (results.landmarks && results.landmarks.length > 0) {
+            const hand = results.landmarks[0];
+            this.handVisible = true;
+            this.handLostTime = 0;
+
+            // draw landmarks
+            this.drawHand(hand);
+
+            // pinch distance: thumb tip ↔ index tip
+            const pinchDist = this.dist(hand[THUMB_TIP], hand[INDEX_TIP]);
+
+            // map pinch to progress:
+            // pinched (small distance ~0.03) → progress = 0 (intact scene)
+            // spread  (large distance ~0.18) → progress = 1 (fully dissolved)
+            const minD = 0.04;
+            const maxD = 0.18;
+            const targetProgress = Math.max(0, Math.min(1, (pinchDist - minD) / (maxD - minD)));
+
+            // smooth
+            this.smoothedProgress += (targetProgress - this.smoothedProgress) * 0.15;
+
+            this.events.fire('particle.setProgress', this.smoothedProgress);
+
+        } else {
+            // hand not visible → slowly return to intact
+            if (this.handVisible) {
+                this.handVisible = false;
+                this.handLostTime = now;
+            }
+
+            // after 0.5s of no hand, start fading back
+            if (now - this.handLostTime > 500 && this.smoothedProgress > 0.001) {
+                this.smoothedProgress *= 0.95; // exponential decay
+                this.events.fire('particle.setProgress', this.smoothedProgress);
+            }
+        }
+
+        requestAnimationFrame(() => this.detect());
+    }
+
+    private dist(a: any, b: any): number {
+        const dx = a.x - b.x;
+        const dy = a.y - b.y;
+        return Math.sqrt(dx * dx + dy * dy);
+    }
+
+    private drawHand(landmarks: any[]) {
+        const w = this.canvas.width;
+        const h = this.canvas.height;
+
+        const thumb = landmarks[THUMB_TIP];
+        const index = landmarks[INDEX_TIP];
+
+        // draw only thumb tip and index tip
+        this.ctx.fillStyle = '#ffffff';
+        for (const lm of [thumb, index]) {
+            this.ctx.beginPath();
+            this.ctx.arc(lm.x * w, lm.y * h, 4, 0, Math.PI * 2);
+            this.ctx.fill();
+        }
+
+        // pinch line in white
+        this.ctx.strokeStyle = '#ffffff';
+        this.ctx.lineWidth = 2;
+        this.ctx.beginPath();
+        this.ctx.moveTo(thumb.x * w, thumb.y * h);
+        this.ctx.lineTo(index.x * w, index.y * h);
+        this.ctx.stroke();
+
+        // progress bar at bottom of preview
+        const pinchDist = this.dist(thumb, index);
+        const progress = Math.max(0, Math.min(1, (pinchDist - 0.04) / (0.18 - 0.04)));
+        this.ctx.fillStyle = '#333';
+        this.ctx.fillRect(0, h - 8, w, 8);
+        this.ctx.fillStyle = '#ffffff';
+        this.ctx.fillRect(0, h - 8, w * this.smoothedProgress, 8);
+    }
+}
+
+export { GestureController };

--- a/src/main.ts
+++ b/src/main.ts
@@ -5,6 +5,8 @@ import { registerCameraPosesEvents } from './camera-poses';
 import { registerDocEvents } from './doc';
 import { EditHistory } from './edit-history';
 import { registerEditorEvents } from './editor';
+import { GestureController } from './gesture-controller';
+import { ParticleEffects } from './particle-effects';
 import { Events } from './events';
 import { initFileHandler } from './file-handler';
 import { registerIframeApi } from './iframe-api';
@@ -234,6 +236,12 @@ const main = async () => {
     editorUI.toolsContainer.dom.appendChild(maskCanvas);
 
     window.scene = scene;
+
+    // particle effects
+    const particleEffects = new ParticleEffects(events, scene);
+
+    // gesture controller
+    const gestureController = new GestureController(events);
 
     // register events that need scene or other dependencies
     registerEditorEvents(events, editHistory, scene);

--- a/src/particle-effects.ts
+++ b/src/particle-effects.ts
@@ -1,0 +1,141 @@
+import { Vec3 } from 'playcanvas';
+
+import { ElementType } from './element';
+import { Events } from './events';
+import { Scene } from './scene';
+import { Splat } from './splat';
+
+type EffectType = 'none' | 'dissolve';
+
+class ParticleEffects {
+    private events: Events;
+    private scene: Scene;
+    private activeEffect: EffectType = 'none';
+    private progress = 0;
+    private targetProgress = 0;
+    private sceneSize = 1;
+    private center = new Vec3();
+    private animating = false;
+    private resetting = false;
+    private directControl = false; // true when gesture is driving progress directly
+
+    constructor(events: Events, scene: Scene) {
+        this.events = events;
+        this.scene = scene;
+
+        // button-triggered effects
+        events.on('particle.trigger', (effect: EffectType) => {
+            console.log('[ParticleEffects] trigger:', effect);
+            this.directControl = false;
+            this.trigger(effect);
+        });
+
+        events.on('particle.reset', () => {
+            console.log('[ParticleEffects] reset');
+            this.directControl = false;
+            this.reset();
+        });
+
+        // gesture sets the active effect type (without starting animation)
+        events.on('particle.setEffect', (effect: EffectType) => {
+            this.activeEffect = effect;
+            this.ensureSceneInfo();
+        });
+
+        // gesture directly controls progress (continuous)
+        events.on('particle.setProgress', (value: number) => {
+            this.directControl = true;
+            this.progress = value;
+            this.animating = true;
+
+            if (this.activeEffect === 'none') {
+                this.activeEffect = 'dissolve';
+            }
+            this.ensureSceneInfo();
+            this.applyUniforms();
+        });
+
+        scene.app.on('update', (dt: number) => {
+            if (!this.directControl) {
+                this.update(dt);
+            }
+        });
+    }
+
+    private ensureSceneInfo() {
+        const splats = this.scene.getElementsByType(ElementType.splat) as Splat[];
+        if (splats.length > 0) {
+            const bound = splats[0].worldBound;
+            const he = bound.halfExtents;
+            this.sceneSize = Math.max(he.x, he.y, he.z) * 2;
+            this.center.copy(bound.center);
+        }
+    }
+
+    private trigger(effect: EffectType) {
+        if (effect === 'none') {
+            this.reset();
+            return;
+        }
+
+        this.activeEffect = effect;
+        this.progress = 0;
+        this.targetProgress = 1;
+        this.resetting = false;
+        this.ensureSceneInfo();
+        this.animating = true;
+        this.events.fire('particle.effectChanged', effect);
+    }
+
+    private reset() {
+        this.targetProgress = 0;
+        this.resetting = true;
+        this.animating = true;
+        this.events.fire('particle.effectChanged', 'none');
+    }
+
+    private update(dt: number) {
+        if (!this.animating) return;
+
+        const speed = this.resetting ? 3.0 : 1.2;
+        const diff = this.targetProgress - this.progress;
+
+        if (Math.abs(diff) < 0.001) {
+            this.progress = this.targetProgress;
+            if (this.targetProgress === 0) {
+                this.animating = false;
+                this.activeEffect = 'none';
+                this.resetting = false;
+            }
+        } else {
+            this.progress += diff * Math.min(1, dt * speed);
+        }
+
+        this.applyUniforms();
+    }
+
+    private applyUniforms() {
+        const effectId = this.getEffectId();
+        const splats = this.scene.getElementsByType(ElementType.splat) as Splat[];
+
+        for (const splat of splats) {
+            if (!splat.entity?.gsplat?.instance) continue;
+            const material = splat.entity.gsplat.instance.material;
+            material.setParameter('u_particleEffect', effectId);
+            material.setParameter('u_particleProgress', this.progress);
+            material.setParameter('u_particleCenter', [this.center.x, this.center.y, this.center.z]);
+            material.setParameter('u_particleSceneSize', this.sceneSize);
+        }
+
+        this.scene.forceRender = true;
+    }
+
+    private getEffectId(): number {
+        switch (this.activeEffect) {
+            case 'dissolve': return 2.0;
+            default: return 0.0;
+        }
+    }
+}
+
+export { ParticleEffects };

--- a/src/shaders/splat-shader.ts
+++ b/src/shaders/splat-shader.ts
@@ -246,8 +246,45 @@ uniform mat4 matrix_view;
     uniform mat4 matrix_projection;
 #endif
 
+// particle effect uniforms
+uniform float u_particleEffect;       // 0=none, 1=explode, 2=dissolve, 4=gravity
+uniform float u_particleProgress;     // 0..1
+uniform vec3 u_particleCenter;        // world-space center
+uniform float u_particleSceneSize;    // scene scale
+
+float particleHash(vec2 p) {
+    return fract(sin(dot(p, vec2(127.1, 311.7))) * 43758.5453123);
+}
+
+vec3 applyParticleEffect(vec3 pos) {
+    float p = u_particleProgress;
+    if (u_particleEffect < 0.5 || p <= 0.0) return pos;
+
+    float scale = u_particleSceneSize;
+
+    // use position components as independent seeds for truly random directions
+    float seedX = particleHash(vec2(pos.x * 12.9898, pos.y * 78.233));
+    float seedY = particleHash(vec2(pos.y * 39.346, pos.z * 91.127));
+    float seedZ = particleHash(vec2(pos.z * 45.164, pos.x * 63.542));
+
+    // DISSOLVE
+    float phase = particleHash(vec2(seedX * 53.1, seedY * 97.3));
+    float localP = smoothstep(phase * 0.5, phase * 0.5 + 0.5, p);
+    vec3 randDir = normalize(vec3(
+        seedX - 0.5,
+        seedY - 0.5,
+        seedZ - 0.5
+    ));
+    pos += randDir * localP * scale * 0.6;
+
+    return pos;
+}
+
 // project the model space gaussian center to view and clip space
 bool initCenter(vec3 modelCenter, inout SplatCenter center) {
+    // apply particle effect in model space
+    modelCenter = applyParticleEffect(modelCenter);
+
     mat4 modelView = matrix_view * applyPaletteTransform(matrix_model);
     vec4 centerView = modelView * vec4(modelCenter, 1.0);
 

--- a/src/ui/editor.ts
+++ b/src/ui/editor.ts
@@ -11,6 +11,7 @@ import { ImageSettingsDialog } from './image-settings-dialog';
 import { localize, localizeInit } from './localization';
 import { Menu } from './menu';
 import { ModeToggle } from './mode-toggle';
+import { ParticlePanel } from './particle-panel';
 import logo from './playcanvas-logo.png';
 import { Popup, ShowOptions } from './popup';
 import { Progress } from './progress';
@@ -127,6 +128,7 @@ class EditorUI {
         const rightToolbar = new RightToolbar(events, tooltips);
         const modeToggle = new ModeToggle(events, tooltips);
         const menu = new Menu(events);
+        const particlePanel = new ParticlePanel(events);
 
         canvasContainer.dom.appendChild(canvas);
         canvasContainer.append(appLabel);
@@ -135,10 +137,22 @@ class EditorUI {
         canvasContainer.append(scenePanel);
         canvasContainer.append(viewPanel);
         canvasContainer.append(colorPanel);
+        canvasContainer.append(particlePanel);
         canvasContainer.append(bottomToolbar);
         canvasContainer.append(rightToolbar);
         canvasContainer.append(modeToggle);
         canvasContainer.append(menu);
+
+        // toggle particle panel
+        events.on('particlePanel.toggleVisible', () => {
+            particlePanel.hidden = !particlePanel.hidden;
+            events.fire('particlePanel.visible', !particlePanel.hidden);
+        });
+
+        events.on('particlePanel.setVisible', (visible: boolean) => {
+            particlePanel.hidden = !visible;
+            events.fire('particlePanel.visible', visible);
+        });
 
         // view axes container
         const viewCube = new ViewCube(events);

--- a/src/ui/particle-panel.ts
+++ b/src/ui/particle-panel.ts
@@ -1,0 +1,69 @@
+import { Button, Container, Label } from '@playcanvas/pcui';
+
+import { Events } from '../events';
+
+class ParticlePanel extends Container {
+    constructor(events: Events, args = {}) {
+        args = {
+            ...args,
+            id: 'particle-panel',
+            hidden: true
+        };
+
+        super(args);
+
+        const header = new Label({
+            text: 'Particle Effects',
+            class: 'particle-panel-header'
+        });
+
+        const buttonsContainer = new Container({
+            class: 'particle-panel-buttons'
+        });
+
+        const effects = [
+            { id: 'dissolve', label: 'Dissolve' },
+            { id: 'none', label: 'Reset' }
+        ];
+
+        const buttons: Map<string, Button> = new Map();
+
+        for (const effect of effects) {
+            const btn = new Button({
+                text: effect.label,
+                class: 'particle-panel-btn'
+            });
+
+            // use DOM click event directly
+            btn.dom.addEventListener('click', (e: Event) => {
+                e.stopPropagation();
+                console.log('[ParticlePanel] clicked:', effect.id);
+                if (effect.id === 'none') {
+                    events.fire('particle.reset');
+                } else {
+                    events.fire('particle.trigger', effect.id);
+                }
+            });
+
+            buttons.set(effect.id, btn);
+            buttonsContainer.append(btn);
+        }
+
+        this.append(header);
+        this.append(buttonsContainer);
+
+        // stop pointer events from reaching the canvas
+        this.dom.addEventListener('pointerdown', (e: Event) => {
+            e.stopPropagation();
+        });
+
+        // highlight active effect
+        events.on('particle.effectChanged', (effect: string) => {
+            buttons.forEach((btn, id) => {
+                btn.class[id === effect ? 'add' : 'remove']('active');
+            });
+        });
+    }
+}
+
+export { ParticlePanel };

--- a/src/ui/right-toolbar.ts
+++ b/src/ui/right-toolbar.ts
@@ -66,6 +66,18 @@ class RightToolbar extends Container {
             class: 'right-toolbar-toggle'
         });
 
+        const particleBtn = new Button({
+            id: 'right-toolbar-particles',
+            class: 'right-toolbar-toggle',
+            icon: 'E366'
+        });
+
+        const gestureBtn = new Button({
+            id: 'right-toolbar-gesture',
+            class: 'right-toolbar-toggle',
+            icon: 'E321'
+        });
+
         const options = new Button({
             id: 'right-toolbar-options',
             class: 'right-toolbar-toggle',
@@ -95,6 +107,8 @@ class RightToolbar extends Container {
         this.append(cameraReset);
         this.append(new Element({ class: 'right-toolbar-separator' }));
         this.append(colorPanel);
+        this.append(particleBtn);
+        this.append(gestureBtn);
         this.append(options);
 
         // Helper to compose localized tooltip text with shortcut
@@ -131,6 +145,8 @@ class RightToolbar extends Container {
         cameraFrameSelection.on('click', () => events.fire('camera.focus'));
         cameraReset.on('click', () => events.fire('camera.reset'));
         colorPanel.on('click', () => events.fire('colorPanel.toggleVisible'));
+        particleBtn.on('click', () => events.fire('particlePanel.toggleVisible'));
+        gestureBtn.on('click', () => events.fire('gesture.toggle'));
         options.on('click', () => events.fire('viewPanel.toggleVisible'));
 
         events.on('camera.mode', (mode: string) => {
@@ -150,6 +166,14 @@ class RightToolbar extends Container {
 
         events.on('colorPanel.visible', (visible: boolean) => {
             colorPanel.class[visible ? 'add' : 'remove']('active');
+        });
+
+        events.on('particlePanel.visible', (visible: boolean) => {
+            particleBtn.class[visible ? 'add' : 'remove']('active');
+        });
+
+        events.on('gesture.active', (active: boolean) => {
+            gestureBtn.class[active ? 'add' : 'remove']('active');
         });
 
         events.on('viewPanel.visible', (visible: boolean) => {

--- a/src/ui/scss/particle-panel.scss
+++ b/src/ui/scss/particle-panel.scss
@@ -1,0 +1,44 @@
+@use 'colors.scss' as *;
+
+#particle-panel {
+    position: absolute;
+    top: 50%;
+    transform: translate(0, -50%);
+    right: 102px;
+    width: 200px;
+    flex-direction: column;
+    background-color: $bcg-darker;
+    border: 1px solid $bcg-lighter;
+    border-radius: 6px;
+    padding: 8px;
+    z-index: 10;
+
+    &:not(.pcui-hidden) {
+        display: flex;
+    }
+
+    .particle-panel-header {
+        font-weight: bold;
+        margin-bottom: 6px;
+        padding: 2px 4px;
+        color: $text-primary;
+    }
+
+    .particle-panel-buttons {
+        display: flex;
+        flex-direction: column;
+        gap: 4px;
+    }
+
+    .particle-panel-btn {
+        width: 100%;
+        height: 28px;
+        border-radius: 4px;
+        cursor: pointer;
+        text-align: center;
+
+        &.active {
+            background-color: $clr-default;
+        }
+    }
+}

--- a/src/ui/scss/style.scss
+++ b/src/ui/scss/style.scss
@@ -7,6 +7,7 @@
 @use 'scene-panel.scss';
 @use 'view-panel.scss';
 @use 'color-panel.scss';
+@use 'particle-panel.scss';
 @use 'splat-list.scss';
 @use 'transform.scss';
 @use 'bottom-toolbar.scss';


### PR DESCRIPTION
- Dissolve shader effect that scatters gaussians in random directions
- MediaPipe HandLandmarker pinch-to-dissolve gesture control via webcam
- Particle panel UI with dissolve/reset buttons
- Toolbar buttons for particle panel and gesture toggle