### PR TITLE
fix: prevent infinite recursion when clearing scene with duplicated splats

### DIFF
--- a/src/edit-history.ts
+++ b/src/edit-history.ts
@@ -89,10 +89,8 @@ class EditHistory {
 
         for (let i = 0; i < this.history.length; i++) {
             const op = this.history[i];
-            if (opReferencesSplat(op, splat)) {
-                // Destroy the operation being removed
-                op.destroy?.();
-            } else {
+            // Skip ops referencing the splat; don't destroy them since the caller handles that
+            if (!opReferencesSplat(op, splat)) {
                 // Keep this operation
                 newHistory.push(op);
                 // Track cursor position (count kept operations before original cursor)


### PR DESCRIPTION
## Summary

- Fixes infinite recursion (stack overflow) when clearing the scene after duplicating splats
- `removeForSplat` no longer calls `op.destroy()` on removed history entries, since the splat is already being destroyed by the caller (`scene.clear()`)

The recursion cycle was: `Scene.remove` -> fires `scene.elementRemoved` -> `editHistory.removeForSplat` -> `AddSplatOp.destroy()` -> `splat.destroy()` -> `Element.destroy()` -> `Scene.remove` -> ...

Fixes #856