### PR TITLE
Add null-safety checks in Splat and SplatOverlay

### DIFF
--- a/src/splat-overlay.ts
+++ b/src/splat-overlay.ts
@@ -142,7 +142,7 @@ class SplatOverlay extends Element {
     detach() {
         // unsubscribe from sorter updates
         if (this.splat && this.onSorterUpdated) {
-            this.splat.entity.gsplat.instance.sorter.off('updated', this.onSorterUpdated);
+            this.splat.entity.gsplat?.instance.sorter.off('updated', this.onSorterUpdated);
             this.onSorterUpdated = null;
         }
 

--- a/src/splat-overlay.ts
+++ b/src/splat-overlay.ts
@@ -142,7 +142,7 @@ class SplatOverlay extends Element {
     detach() {
         // unsubscribe from sorter updates
         if (this.splat && this.onSorterUpdated) {
-            this.splat.entity.gsplat?.instance.sorter.off('updated', this.onSorterUpdated);
+            this.splat.entity.gsplat?.instance?.sorter?.off('updated', this.onSorterUpdated);
             this.onSorterUpdated = null;
         }
 

--- a/src/splat.ts
+++ b/src/splat.ts
@@ -436,7 +436,7 @@ class Splat extends Element {
     set visible(value: boolean) {
         if (value !== this.visible) {
             this._visible = value;
-            this.scene.events.fire('splat.visibility', this);
+            this.scene?.events.fire('splat.visibility', this);
         }
     }
 


### PR DESCRIPTION
## Summary
- Add optional chaining (`?.`) to `gsplat` access in `SplatOverlay.detach()` to prevent crashes when the gsplat component has already been removed before detach is called
- Add optional chaining (`?.`) to `scene` access in `Splat.visible` setter to prevent crashes when visibility is set during element destruction (after scene reference is cleared)

## Details
Both fixes guard against null reference errors that can occur during teardown/cleanup sequences where the order of destruction isn't guaranteed. Without these guards, accessing `.gsplat.instance` or `.events.fire()` on a null reference throws a runtime error.