### PR TITLE
Add Blender-style middle-mouse camera controls and MMB click-to-focus

### DIFF
--- a/src/controllers.ts
+++ b/src/controllers.ts
@@ -50,6 +50,10 @@ class PointerController {
         let pressedButton = -1;  // no button pressed, otherwise 0, 1, or 2
         let x: number, y: number;
 
+        // middle-mouse click-vs-drag tracking (for MMB single-click to focus)
+        const CLICK_DRAG_THRESHOLD = 4;
+        let mmbStartX = 0, mmbStartY = 0, mmbDragged = false;
+
         // touch state
         let touches: { id: number, x: number, y: number}[] = [];
         let midx: number, midy: number, midlen: number;
@@ -64,6 +68,11 @@ class PointerController {
                 pressedButton = event.button;
                 x = event.offsetX;
                 y = event.offsetY;
+                if (pressedButton === 1) {
+                    mmbStartX = x;
+                    mmbStartY = y;
+                    mmbDragged = false;
+                }
             } else if (event.pointerType === 'touch') {
                 if (touches.length === 0) {
                     target.setPointerCapture(event.pointerId);
@@ -86,6 +95,13 @@ class PointerController {
             if (event.pointerType === 'mouse') {
                 // Only release if this is the button that was initially pressed
                 if (event.button === pressedButton) {
+                    // MMB tap (no significant movement) -> focus on cursor point
+                    if (pressedButton === 1 && !mmbDragged) {
+                        if (camera.controlMode === 'fly') {
+                            camera.scene.events.fire('camera.setControlMode', 'orbit');
+                        }
+                        camera.pickFocalPoint(event.offsetX / target.clientWidth, event.offsetY / target.clientHeight);
+                    }
                     pressedButton = -1;
                     target.releasePointerCapture(event.pointerId);
                 }
@@ -138,18 +154,34 @@ class PointerController {
                         }
                     }
                 } else {
-                    // Orbit mode: existing behavior
-                    // right button can be used to orbit with ctrl key and to zoom with alt | meta key
-                    const mod = pressedButton === 2 ?
-                        (event.shiftKey || event.ctrlKey ? 'orbit' :
-                            (event.altKey || event.metaKey ? 'zoom' : null)) :
-                        null;
+                    // Orbit mode:
+                    // - left button: orbit
+                    // - middle button (Blender-style): orbit, Shift -> pan, Ctrl -> zoom
+                    //   (gated on a small drag threshold so a tap can be used to focus on release)
+                    // - right button: pan, Shift/Ctrl -> orbit, Alt/Meta -> zoom
+                    if (pressedButton === 1 && !mmbDragged) {
+                        if (dist(event.offsetX, event.offsetY, mmbStartX, mmbStartY) < CLICK_DRAG_THRESHOLD) {
+                            return;
+                        }
+                        mmbDragged = true;
+                    }
 
-                    if (mod === 'orbit' || (mod === null && pressedButton === 0)) {
+                    let mod: 'orbit' | 'pan' | 'zoom';
+                    if (pressedButton === 2) {
+                        mod = event.shiftKey || event.ctrlKey ? 'orbit' :
+                            (event.altKey || event.metaKey ? 'zoom' : 'pan');
+                    } else if (pressedButton === 1) {
+                        mod = event.shiftKey ? 'pan' :
+                            (event.ctrlKey ? 'zoom' : 'orbit');
+                    } else {
+                        mod = 'orbit';
+                    }
+
+                    if (mod === 'orbit') {
                         orbit(dx, dy);
-                    } else if (mod === 'zoom' || (mod === null && pressedButton === 1)) {
+                    } else if (mod === 'zoom') {
                         zoom(dy * -0.02);
-                    } else if (mod === 'pan' || (mod === null && pressedButton === 2)) {
+                    } else {
                         pan(x, y, dx, dy);
                     }
                 }

--- a/src/controllers.ts
+++ b/src/controllers.ts
@@ -95,11 +95,8 @@ class PointerController {
             if (event.pointerType === 'mouse') {
                 // Only release if this is the button that was initially pressed
                 if (event.button === pressedButton) {
-                    // MMB tap (no significant movement) -> focus on cursor point
-                    if (pressedButton === 1 && !mmbDragged) {
-                        if (camera.controlMode === 'fly') {
-                            camera.scene.events.fire('camera.setControlMode', 'orbit');
-                        }
+                    // MMB tap (no significant movement) -> focus on cursor point (orbit only; fly uses MMB for zoom)
+                    if (pressedButton === 1 && camera.controlMode === 'orbit' && !mmbDragged) {
                         camera.pickFocalPoint(event.offsetX / target.clientWidth, event.offsetY / target.clientHeight);
                     }
                     pressedButton = -1;


### PR DESCRIPTION
## Summary

Reworks middle-mouse-button (MMB) handling in orbit mode to match Blender's defaults, and adds a single MMB click as a shortcut to focus the camera on the cursor point.

In orbit mode:
- MMB drag -> orbit (was: zoom)
- Shift + MMB drag -> pan
- Ctrl + MMB drag -> zoom (dolly)
- MMB click (no drag) -> pick focal point at the cursor (same path as the existing LMB double-click)

A small drag threshold (4 px) distinguishes a click from a drag, so a tiny accidental wiggle doesn't both nudge the orbit and trigger focus.

## What is unchanged

- LMB drag (orbit), LMB double-click (focus)
- RMB drag (pan), with existing Shift/Ctrl -> orbit and Alt/Meta -> zoom modifiers
- Mouse wheel / trackpad gestures
- Touch gestures
- Fly mode behavior (MMB still zooms there; out of scope for this change)

## Implementation

All in `src/controllers.ts` inside `PointerController`:
- New state: `CLICK_DRAG_THRESHOLD`, `mmbStartX/Y`, `mmbDragged` (reset on each MMB `pointerdown`).
- `pointermove` (orbit branch) gates the MMB action dispatch on the drag threshold and flips `mmbDragged = true` once exceeded.
- `pointerup` for MMB with `!mmbDragged` calls `camera.pickFocalPoint(...)`, mirroring the existing dblclick handler (and switching from fly to orbit if needed).
- The orbit-mode dispatch was refactored to a clearer `mod: 'orbit' | 'pan' | 'zoom'` resolver per button.

## Test plan

- [ ] Orbit mode: MMB drag orbits; Shift+MMB drag pans; Ctrl+MMB drag zooms.
- [ ] Orbit mode: MMB tap (no movement) focuses the camera on the picked point.
- [ ] Orbit mode: a sub-threshold MMB wiggle does not orbit; release still focuses.
- [ ] Orbit mode: LMB drag still orbits; LMB double-click still focuses.
- [ ] Orbit mode: RMB drag pans; RMB+Shift/Ctrl orbits; RMB+Alt/Meta zooms.
- [ ] Wheel and trackpad gestures unchanged.
- [ ] Fly mode behavior unchanged (LMB look, MMB zoom, RMB look/zoom/pan with modifiers, WASD movement).
- [ ] Touch gestures unchanged on a touchscreen / trackpad.