### PR TITLE
Improve mouse wheel vs trackpad classification for camera controls

### DIFF
--- a/src/controllers.ts
+++ b/src/controllers.ts
@@ -224,14 +224,43 @@ class PointerController {
             }
         };
 
-        // fuzzy detection of mouse wheel events vs trackpad events
-        const isMouseEvent = (deltaX: number, deltaY: number) => {
-            return (Math.abs(deltaX) > 50 && deltaY === 0) ||
-                   (Math.abs(deltaY) > 50 && deltaX === 0) ||
-                   (deltaX === 0 && deltaY !== 0) && !Number.isInteger(deltaY);
+        // Distinguish a physical mouse wheel from a trackpad two-finger
+        // scroll. A single wheel event is unreliable (Magic Mouse, hi-res
+        // mice, and macOS Shift-remapping all confuse per-event heuristics),
+        // so we classify on the first event of a burst and let the rest of
+        // the burst inherit that label. A burst is a run of wheel events
+        // separated by less than BURST_GAP_MS - trackpads stream at ~60Hz
+        // (~16ms), wheels emit one event per notch (typically >>50ms apart).
+        const BURST_GAP_MS = 80;
+        let lastWheelTime = 0;
+        let burstIsWheel = false;
+
+        const classifyWheel = (event: WheelEvent) => {
+            // Line/page-mode events are always physical wheels (Firefox).
+            if (event.deltaMode !== WheelEvent.DOM_DELTA_PIXEL) {
+                return true;
+            }
+            const { deltaX, deltaY } = event;
+            // Trackpads regularly scroll on both axes simultaneously; real
+            // wheels emit single-axis motion per notch.
+            if (deltaX !== 0 && deltaY !== 0) {
+                return false;
+            }
+            // Trackpads (and Magic Mouse) emit fractional pixel deltas;
+            // physical wheels emit integer pixel deltas.
+            if (!Number.isInteger(deltaX) || !Number.isInteger(deltaY)) {
+                return false;
+            }
+            return true;
         };
 
         const wheel = (event: WheelEvent) => {
+            const now = performance.now();
+            if (now - lastWheelTime > BURST_GAP_MS) {
+                burstIsWheel = classifyWheel(event);
+            }
+            lastWheelTime = now;
+
             const { deltaX, deltaY } = event;
 
             if (camera.controlMode === 'fly') {
@@ -242,17 +271,17 @@ class PointerController {
                 moveVec.copy(zAxis).mulScalar(deltaY * factor);
                 const p = camera.focalPoint.add(moveVec);
                 camera.setFocalPoint(p);
+            } else if (burstIsWheel) {
+                // Some browsers (notably Safari/Firefox on macOS) remap a
+                // vertical mouse wheel to deltaX when Shift is held. Use
+                // whichever axis carries motion so shift+wheel still zooms.
+                zoom((deltaY || deltaX) * -0.002);
+            } else if (event.ctrlKey || event.metaKey) {
+                zoom(deltaY * -0.02);
+            } else if (event.shiftKey) {
+                pan(event.offsetX, event.offsetY, deltaX, deltaY);
             } else {
-                // Orbit mode: existing behavior
-                if (isMouseEvent(deltaX, deltaY)) {
-                    zoom(deltaY * -0.002);
-                } else if (event.ctrlKey || event.metaKey) {
-                    zoom(deltaY * -0.02);
-                } else if (event.shiftKey) {
-                    pan(event.offsetX, event.offsetY, deltaX, deltaY);
-                } else {
-                    orbit(deltaX, deltaY);
-                }
+                orbit(deltaX, deltaY);
             }
 
             event.preventDefault();

--- a/src/controllers.ts
+++ b/src/controllers.ts
@@ -236,22 +236,30 @@ class PointerController {
         let burstIsWheel = false;
 
         const classifyWheel = (event: WheelEvent) => {
-            // Line/page-mode events are always physical wheels (Firefox).
+            // Firefox: physical wheels report line/page mode; trackpads report
+            // pixel mode. Firefox doesn't expose wheelDelta* so this is the
+            // only reliable signal on Firefox.
             if (event.deltaMode !== WheelEvent.DOM_DELTA_PIXEL) {
                 return true;
             }
+            // Chrome / Safari: the non-standard wheelDelta{X,Y} properties
+            // preserve the raw wheel-tick value (always multiples of ±120 per
+            // notch) regardless of macOS scroll smoothing applied to
+            // delta{X,Y}. Trackpads and Magic Mouse emit arbitrary values
+            // that are essentially never aligned to 120.
+            const e = event as WheelEvent & { wheelDeltaX?: number, wheelDeltaY?: number };
+            if (typeof e.wheelDeltaY === 'number' && e.wheelDeltaY !== 0) {
+                return e.wheelDeltaY % 120 === 0;
+            }
+            if (typeof e.wheelDeltaX === 'number' && e.wheelDeltaX !== 0) {
+                return e.wheelDeltaX % 120 === 0;
+            }
+            // Last-resort fallback for browsers without wheelDelta*.
             const { deltaX, deltaY } = event;
-            // Trackpads regularly scroll on both axes simultaneously; real
-            // wheels emit single-axis motion per notch.
             if (deltaX !== 0 && deltaY !== 0) {
                 return false;
             }
-            // Trackpads (and Magic Mouse) emit fractional pixel deltas;
-            // physical wheels emit integer pixel deltas.
-            if (!Number.isInteger(deltaX) || !Number.isInteger(deltaY)) {
-                return false;
-            }
-            return true;
+            return Number.isInteger(deltaX) && Number.isInteger(deltaY);
         };
 
         const wheel = (event: WheelEvent) => {

--- a/src/controllers.ts
+++ b/src/controllers.ts
@@ -232,7 +232,7 @@ class PointerController {
         // separated by less than BURST_GAP_MS - trackpads stream at ~60Hz
         // (~16ms), wheels emit one event per notch (typically >>50ms apart).
         const BURST_GAP_MS = 80;
-        let lastWheelTime = 0;
+        let lastWheelTime = -Infinity;
         let burstIsWheel = false;
 
         const classifyWheel = (event: WheelEvent) => {

--- a/src/controllers.ts
+++ b/src/controllers.ts
@@ -272,9 +272,11 @@ class PointerController {
             const { deltaX, deltaY } = event;
 
             // Some browsers (notably Safari/Firefox on macOS) remap a vertical
-            // mouse wheel to deltaX when Shift is held. Use whichever axis
-            // carries motion so shift+wheel still produces movement.
-            const wheelDelta = deltaY || deltaX;
+            // mouse wheel to deltaX when Shift is held. Only fall back to
+            // deltaX for that remapped case so horizontal-only scrolling
+            // (tilt wheel, horizontal trackpad swipe) is not treated as
+            // zoom / fly movement.
+            const wheelDelta = event.shiftKey && deltaY === 0 ? deltaX : deltaY;
 
             if (camera.controlMode === 'fly') {
                 // Fly mode: wheel moves forward/backward by moving focal point

--- a/src/controllers.ts
+++ b/src/controllers.ts
@@ -271,19 +271,21 @@ class PointerController {
 
             const { deltaX, deltaY } = event;
 
+            // Some browsers (notably Safari/Firefox on macOS) remap a vertical
+            // mouse wheel to deltaX when Shift is held. Use whichever axis
+            // carries motion so shift+wheel still produces movement.
+            const wheelDelta = deltaY || deltaX;
+
             if (camera.controlMode === 'fly') {
                 // Fly mode: wheel moves forward/backward by moving focal point
                 const factor = camera.flySpeed * 0.01;
                 const worldTransform = camera.mainCamera.getWorldTransform();
                 const zAxis = worldTransform.getZ();
-                moveVec.copy(zAxis).mulScalar(deltaY * factor);
+                moveVec.copy(zAxis).mulScalar(wheelDelta * factor);
                 const p = camera.focalPoint.add(moveVec);
                 camera.setFocalPoint(p);
             } else if (burstIsWheel) {
-                // Some browsers (notably Safari/Firefox on macOS) remap a
-                // vertical mouse wheel to deltaX when Shift is held. Use
-                // whichever axis carries motion so shift+wheel still zooms.
-                zoom((deltaY || deltaX) * -0.002);
+                zoom(wheelDelta * -0.002);
             } else if (event.ctrlKey || event.metaKey) {
                 zoom(deltaY * -0.02);
             } else if (event.shiftKey) {


### PR DESCRIPTION
## Summary

Replaces the per-event `isMouseEvent` heuristic in the camera controller's wheel handler with a stateful, burst-based device classifier. The previous heuristic relied on pixel-magnitude thresholds (`>50`) and integer-shape checks, which misclassified several common cases:

- Firefox on every platform reports physical wheels as `deltaMode === DOM_DELTA_LINE` with small (`±3`) values, so wheel events fell through to `shift → pan`.
- macOS Chrome/Safari smooth physical wheels into a stream of fractional `deltaY` events, making them indistinguishable from trackpad events under the old heuristic.
- macOS browsers remap vertical wheel motion to `deltaX` when Shift is held, leaving `deltaY === 0` and producing a no-op zoom.

## Approach

In `src/controllers.ts`:

- **Burst-based classification**: the first event in a burst (gap > 80 ms since the last wheel event) classifies the device, and all subsequent events in the same burst inherit that label. This eliminates mid-gesture flips between wheel and trackpad.
- **Per-browser signals**:
  - Firefox: `deltaMode !== DOM_DELTA_PIXEL` is a definitive wheel signal.
  - Chrome / Safari: the non-standard `wheelDeltaY` / `wheelDeltaX` properties preserve raw wheel-tick values (always multiples of ±120 per notch) regardless of OS scroll smoothing applied to `deltaY`. Trackpads and Magic Mouse emit arbitrary values that are not multiples of 120.
  - Fallback: integer-shape and single-axis checks for browsers without `wheelDelta*`.
- **Shift-remap handling**: the wheel zoom branch now reads `deltaY || deltaX` so macOS Shift-remapped wheels still produce a non-zero zoom.

## Behavior

| Input | Action |
|---|---|
| Mouse wheel (any modifier) | zoom |
| Trackpad two-finger swipe | orbit |
| Trackpad + Ctrl/Cmd | fine zoom |
| Trackpad + Shift | pan |

Two-finger orbit (Blender-style) is preserved. Magic Mouse remains classified as a trackpad since its events are physically indistinguishable from one.

## Test plan

- [ ] macOS Chrome: plain wheel zooms; Shift+wheel zooms; trackpad swipe orbits; Shift+trackpad pans; Cmd+trackpad zooms.
- [ ] macOS Safari: same as above.
- [ ] macOS Firefox: same as above (wheel via `deltaMode === LINE`).
- [ ] Windows Chrome / Edge: plain wheel zooms; Shift+wheel zooms.
- [ ] Windows / Linux Firefox: plain wheel zooms; Shift+wheel zooms (was previously broken).
- [ ] No regressions in fly-mode wheel handling (still moves focal point along view Z).