### PR TITLE
Track engine-dev API changes and fix edit-history race conditions

### DIFF
--- a/src/camera.ts
+++ b/src/camera.ts
@@ -425,7 +425,7 @@ class Camera extends Element {
         this.splatPass?.destroy();
         this.gizmoPass?.destroy();
         this.finalPass?.destroy();
-        this.camera.renderPasses = null;
+        this.camera.framePasses = null;
 
         scene.cameraRoot.removeChild(this.mainCamera);
 
@@ -547,7 +547,7 @@ class Camera extends Element {
             this.finalPass.init(null);
 
             // assign render passes to camera
-            this.camera.renderPasses = [this.clearPass, this.mainPass, this.splatPass, this.gizmoPass, this.finalPass];
+            this.camera.framePasses = [this.clearPass, this.mainPass, this.splatPass, this.gizmoPass, this.finalPass];
         } else {
             // resize existing render targets
             const { splatTarget, colorTarget, workTarget } = this;

--- a/src/edit-history.ts
+++ b/src/edit-history.ts
@@ -26,39 +26,22 @@ class EditHistory {
     constructor(events: Events) {
         this.events = events;
 
-        events.on('edit.undo', () => {
-            this.queue(async () => {
-                if (this.canUndo()) {
-                    await this.undo();
-                }
-            });
-        });
-
-        events.on('edit.redo', () => {
-            this.queue(async () => {
-                if (this.canRedo()) {
-                    await this.redo();
-                }
-            });
-        });
-
-        events.on('edit.add', (editOp: EditOp, suppressOp = false) => {
-            this.queue(() => this.add(editOp, suppressOp));
-        });
+        events.on('edit.undo', () => this.undo());
+        events.on('edit.redo', () => this.redo());
+        events.on('edit.add', (editOp: EditOp, suppressOp = false) => this.add(editOp, suppressOp));
     }
 
-    private queue(fn: () => Promise<void>) {
+    // enqueue arbitrary async work onto the serialized history chain. exposed so external
+    // callers (e.g. transform handlers) can serialize their own GPU readbacks alongside
+    // history mutations and avoid the same race conditions.
+    queue(fn: () => Promise<void>) {
         const next = this.chain.then(fn);
         this.chain = next.catch(() => {});
         return next;
     }
 
-    async add(editOp: EditOp, suppressOp = false) {
-        while (this.cursor < this.history.length) {
-            this.history.pop().destroy?.();
-        }
-        this.history.push(editOp);
-        await this.redo(suppressOp);
+    add(editOp: EditOp, suppressOp = false) {
+        return this.queue(() => this._add(editOp, suppressOp));
     }
 
     canUndo() {
@@ -69,14 +52,38 @@ class EditHistory {
         return this.cursor < this.history.length;
     }
 
-    async undo() {
+    undo() {
+        return this.queue(async () => {
+            if (this.canUndo()) {
+                await this._undo();
+            }
+        });
+    }
+
+    redo(suppressOp = false) {
+        return this.queue(async () => {
+            if (this.canRedo()) {
+                await this._redo(suppressOp);
+            }
+        });
+    }
+
+    private async _add(editOp: EditOp, suppressOp = false) {
+        while (this.cursor < this.history.length) {
+            this.history.pop().destroy?.();
+        }
+        this.history.push(editOp);
+        await this._redo(suppressOp);
+    }
+
+    private async _undo() {
         const editOp = this.history[--this.cursor];
         await editOp.undo();
         this.events.fire('edit.apply', editOp);
         this.fireEvents();
     }
 
-    async redo(suppressOp = false) {
+    private async _redo(suppressOp = false) {
         const editOp = this.history[this.cursor++];
         if (!suppressOp) {
             await editOp.do();

--- a/src/edit-history.ts
+++ b/src/edit-history.ts
@@ -102,12 +102,13 @@ class EditHistory {
     clear() {
         // route through the queue so any in-flight add/undo/redo finishes before we wipe
         // history, preventing queued ops from running against a cleared state.
-        return this.queue(async () => {
+        return this.queue(() => {
             this.history.forEach((editOp) => {
                 editOp.destroy?.();
             });
             this.history = [];
             this.cursor = 0;
+            return Promise.resolve();
         });
     }
 
@@ -115,7 +116,7 @@ class EditHistory {
     removeForSplat(splat: Splat) {
         // serialize with the chain so we don't reshape history while a queued op is mid-flight
         // (which could leave queued undo/redo pointing at indices that no longer exist).
-        return this.queue(async () => {
+        return this.queue(() => {
             let newCursor = 0;
             const newHistory: EditOp[] = [];
 
@@ -135,6 +136,7 @@ class EditHistory {
             this.history = newHistory;
             this.cursor = newCursor;
             this.fireEvents();
+            return Promise.resolve();
         });
     }
 }

--- a/src/edit-history.ts
+++ b/src/edit-history.ts
@@ -36,7 +36,9 @@ class EditHistory {
     // history mutations and avoid the same race conditions.
     queue(fn: () => Promise<void>) {
         const next = this.chain.then(fn);
-        this.chain = next.catch(() => {});
+        this.chain = next.catch((err) => {
+            console.error('EditHistory queued operation failed', err);
+        });
         return next;
     }
 
@@ -98,34 +100,42 @@ class EditHistory {
     }
 
     clear() {
-        this.history.forEach((editOp) => {
-            editOp.destroy?.();
+        // route through the queue so any in-flight add/undo/redo finishes before we wipe
+        // history, preventing queued ops from running against a cleared state.
+        return this.queue(async () => {
+            this.history.forEach((editOp) => {
+                editOp.destroy?.();
+            });
+            this.history = [];
+            this.cursor = 0;
         });
-        this.history = [];
-        this.cursor = 0;
     }
 
     // Remove all operations that reference a specific splat
     removeForSplat(splat: Splat) {
-        let newCursor = 0;
-        const newHistory: EditOp[] = [];
+        // serialize with the chain so we don't reshape history while a queued op is mid-flight
+        // (which could leave queued undo/redo pointing at indices that no longer exist).
+        return this.queue(async () => {
+            let newCursor = 0;
+            const newHistory: EditOp[] = [];
 
-        for (let i = 0; i < this.history.length; i++) {
-            const op = this.history[i];
-            // Skip ops referencing the splat; don't destroy them since the caller handles that
-            if (!opReferencesSplat(op, splat)) {
-                // Keep this operation
-                newHistory.push(op);
-                // Track cursor position (count kept operations before original cursor)
-                if (i < this.cursor) {
-                    newCursor++;
+            for (let i = 0; i < this.history.length; i++) {
+                const op = this.history[i];
+                // Skip ops referencing the splat; don't destroy them since the caller handles that
+                if (!opReferencesSplat(op, splat)) {
+                    // Keep this operation
+                    newHistory.push(op);
+                    // Track cursor position (count kept operations before original cursor)
+                    if (i < this.cursor) {
+                        newCursor++;
+                    }
                 }
             }
-        }
 
-        this.history = newHistory;
-        this.cursor = newCursor;
-        this.fireEvents();
+            this.history = newHistory;
+            this.cursor = newCursor;
+            this.fireEvents();
+        });
     }
 }
 

--- a/src/edit-history.ts
+++ b/src/edit-history.ts
@@ -79,17 +79,23 @@ class EditHistory {
     }
 
     private async _undo() {
-        const editOp = this.history[--this.cursor];
+        // only advance the cursor after a successful undo so a thrown editOp leaves
+        // history in a consistent state for subsequent undo/redo.
+        const editOp = this.history[this.cursor - 1];
         await editOp.undo();
+        this.cursor--;
         this.events.fire('edit.apply', editOp);
         this.fireEvents();
     }
 
     private async _redo(suppressOp = false) {
-        const editOp = this.history[this.cursor++];
+        // only advance the cursor after a successful redo so a thrown editOp leaves
+        // history in a consistent state for subsequent undo/redo.
+        const editOp = this.history[this.cursor];
         if (!suppressOp) {
             await editOp.do();
         }
+        this.cursor++;
         this.events.fire('edit.apply', editOp);
         this.fireEvents();
     }
@@ -108,6 +114,7 @@ class EditHistory {
             });
             this.history = [];
             this.cursor = 0;
+            this.fireEvents();
             return Promise.resolve();
         });
     }

--- a/src/edit-history.ts
+++ b/src/edit-history.ts
@@ -17,24 +17,40 @@ class EditHistory {
     cursor = 0;
     events: Events;
 
+    // serialize all history-modifying operations so an in-flight op (including its async GPU
+    // readback in updatePositions) completes before the next add/undo/redo begins. without this,
+    // rapid Ctrl+Z / Ctrl+Shift+Z events race with pending updatePositions calls and corrupt the
+    // sorter's centers buffer in centers-overlay mode.
+    private chain: Promise<void> = Promise.resolve();
+
     constructor(events: Events) {
         this.events = events;
 
-        events.on('edit.undo', async () => {
-            if (this.canUndo()) {
-                await this.undo();
-            }
+        events.on('edit.undo', () => {
+            this.queue(async () => {
+                if (this.canUndo()) {
+                    await this.undo();
+                }
+            });
         });
 
-        events.on('edit.redo', async () => {
-            if (this.canRedo()) {
-                await this.redo();
-            }
+        events.on('edit.redo', () => {
+            this.queue(async () => {
+                if (this.canRedo()) {
+                    await this.redo();
+                }
+            });
         });
 
-        events.on('edit.add', async (editOp: EditOp, suppressOp = false) => {
-            await this.add(editOp, suppressOp);
+        events.on('edit.add', (editOp: EditOp, suppressOp = false) => {
+            this.queue(() => this.add(editOp, suppressOp));
         });
+    }
+
+    private queue(fn: () => Promise<void>) {
+        const next = this.chain.then(fn);
+        this.chain = next.catch(() => {});
+        return next;
     }
 
     async add(editOp: EditOp, suppressOp = false) {

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -714,11 +714,12 @@ const registerEditorEvents = (events: Events, editHistory: EditHistory, scene: S
     });
 
     events.on('camera.setPose', (pose: { position: Vec3, target: Vec3, fov?: number }, speed = 1) => {
-        scene.camera.setPose(pose.position, pose.target, speed);
+        // assign fov before setPose so distance is computed using the new fovFactor
         if (pose.fov !== undefined) {
             scene.camera.fov = pose.fov;
             events.fire('camera.fov', pose.fov);
         }
+        scene.camera.setPose(pose.position, pose.target, speed);
     });
 
     // hack: fire events to initialize UI

--- a/src/main.ts
+++ b/src/main.ts
@@ -83,6 +83,10 @@ const main = async () => {
     // edit history
     const editHistory = new EditHistory(events);
 
+    // expose edit history queue so subsystems (e.g. transform handlers) can serialize their
+    // own async work onto the same chain that gates add/undo/redo.
+    events.function('edit.queue', (fn: () => Promise<void>) => editHistory.queue(fn));
+
     // init localization
     await localizeInit();
 

--- a/src/shaders/splat-shader.ts
+++ b/src/shaders/splat-shader.ts
@@ -132,7 +132,7 @@ void main(void) {
         color.a = clamp(color.a, 0.0, 1.0);
 
         // apply tonemapping
-        color = vec4(prepareOutputFromGamma(max(color.xyz, 0.0)), color.w);
+        color = vec4(prepareOutputFromGamma(max(color.xyz, 0.0), -center.view.z), color.w);
 
         // apply locked/selected colors
         if ((vertexState & 2u) != 0u) {

--- a/src/splats-transform-handler.ts
+++ b/src/splats-transform-handler.ts
@@ -157,14 +157,7 @@ class SplatsTransformHandler implements TransformHandler {
     async end() {
         const { splat, transform, paletteMap } = this;
 
-        // TODO: consider moving this to update() function above so splats are sorted correctly
-        // for render during drag (which is slower).
-        await splat.updatePositions();
-        splat.selectionAlpha = 1;
-        splat.scene.outline.enabled = true;
-        splat.scene.underlay.enabled = true;
-
-        // create op for splat transform
+        // create op for splat transform (already applied to GPU during update())
         const top = new SplatsTransformOp({
             splat,
             transform: transform.clone(),
@@ -177,8 +170,20 @@ class SplatsTransformHandler implements TransformHandler {
         const newt = pivot.transform.clone();
         const pop = new PlacePivotOp({ pivot, newt, oldt });
 
-        // add the editop without applying it
+        // record the editop on the EditHistory chain BEFORE awaiting any async work.
+        // events.fire synchronously enqueues the add onto EditHistory's serialized chain, so
+        // any subsequent undo/redo event (e.g. user pressing Ctrl+Z while updatePositions
+        // is still resolving) is guaranteed to land AFTER this op on the chain — which means
+        // the undo will revert this translate rather than the prior selection op.
         this.events.fire('edit.add', new MultiOp([top, pop]), true);
+
+        // TODO: consider moving this to update() function above so splats are sorted correctly
+        // for render during drag (which is slower).
+        await splat.updatePositions();
+
+        splat.selectionAlpha = 1;
+        splat.scene.outline.enabled = true;
+        splat.scene.underlay.enabled = true;
     }
 }
 

--- a/src/splats-transform-handler.ts
+++ b/src/splats-transform-handler.ts
@@ -177,9 +177,11 @@ class SplatsTransformHandler implements TransformHandler {
         // the undo will revert this translate rather than the prior selection op.
         this.events.fire('edit.add', new MultiOp([top, pop]), true);
 
+        // enqueue the GPU readback onto the same serialized chain so any subsequent
+        // undo/redo waits for it to finish before mutating the sorter's centers buffer.
         // TODO: consider moving this to update() function above so splats are sorted correctly
         // for render during drag (which is slower).
-        await splat.updatePositions();
+        await this.events.invoke('edit.queue', () => splat.updatePositions());
 
         splat.selectionAlpha = 1;
         splat.scene.outline.enabled = true;

--- a/src/splats-transform-handler.ts
+++ b/src/splats-transform-handler.ts
@@ -174,7 +174,7 @@ class SplatsTransformHandler implements TransformHandler {
         // events.fire synchronously enqueues the add onto EditHistory's serialized chain, so
         // any subsequent undo/redo event (e.g. user pressing Ctrl+Z while updatePositions
         // is still resolving) is guaranteed to land AFTER this op on the chain — which means
-        // the undo will revert this translate rather than the prior selection op.
+        // the undo will revert this transform operation rather than the prior selection op.
         this.events.fire('edit.add', new MultiOp([top, pop]), true);
 
         // enqueue the GPU readback onto the same serialized chain so any subsequent


### PR DESCRIPTION
## Summary

Adopts upcoming PlayCanvas engine API changes and fixes a race in edit history that could be triggered by rapid undo/redo during/after splat transforms.

### Engine API updates
- **`camera.ts`**: rename `camera.renderPasses` → `camera.framePasses` to match the engine's renamed property.
- **`shaders/splat-shader.ts`**: pass view-space depth (`-center.view.z`) as the second argument to `prepareOutputFromGamma`, matching the engine's updated tonemapping signature.

### Edit history race fix
- **`edit-history.ts`**: serialize `edit.add` / `edit.undo` / `edit.redo` through an internal promise chain. Previously, rapid Ctrl+Z / Ctrl+Shift+Z could race with an in-flight `updatePositions` GPU readback and corrupt the sorter's centers buffer in centers-overlay mode.
- **`splats-transform-handler.ts`**: fire `edit.add` for the transform op *before* awaiting `updatePositions()`. Because `events.fire` synchronously enqueues onto the serialized history chain, any undo pressed while the readback is still pending is now guaranteed to revert the transform op (rather than the prior selection op). The post-drag visual restoration (`selectionAlpha`, outline, underlay) is moved after the await since the GPU state is already applied during `update()`.

### Camera pose ordering
- **`editor.ts`**: in `camera.setPose`, assign `fov` *before* calling `scene.camera.setPose(...)` so the camera distance is computed using the new `fovFactor`.

## Test plan

- [ ] Verify rendering still works against the engine-dev branch (no console errors, splat tonemapping looks correct).
- [ ] Stress-test undo/redo: perform several splat transforms, then mash Ctrl+Z / Ctrl+Shift+Z while drags are still resolving — sorter / centers buffer should remain stable.
- [ ] Confirm undoing immediately after a transform reverts the *transform* (not the previous selection).
- [ ] Trigger `camera.setPose` with a `fov` change and confirm the resulting framing uses the new FOV.