### PR TITLE
Video/Image Renders - use splat file name as render file name

### DIFF
--- a/src/render-filename.ts
+++ b/src/render-filename.ts
@@ -1,0 +1,45 @@
+import { path } from 'playcanvas';
+
+import type { Splat } from './splat';
+
+const removeExtension = (filename: string) => {
+    return filename.substring(0, filename.length - path.getExtension(filename).length);
+};
+
+const isInvalidFilenameChar = (char: string) => {
+    return /[<>:"/\\|?*]/.test(char) || char.charCodeAt(0) < 32;
+};
+
+const sanitizeFilename = (filename: string) => {
+    const sanitized = Array.from(filename, (char) => {
+        return isInvalidFilenameChar(char) ? '_' : char;
+    }).join('').trim();
+
+    return sanitized.length > 0 ? sanitized : 'supersplat';
+};
+
+const getImportedFilename = (filename: string) => {
+    const trimmed = filename.split(/[?#]/)[0];
+
+    if (trimmed.includes('://') || trimmed.startsWith('blob:')) {
+        try {
+            return path.getBasename(new URL(trimmed).pathname);
+        } catch {
+            // fall back to the raw filename below
+        }
+    }
+
+    return path.getBasename(trimmed);
+};
+
+const getRenderBaseName = (splats: Splat[]) => {
+    const sourceName = splats[0]?.filename ?? splats[0]?.name ?? 'supersplat';
+    return sanitizeFilename(removeExtension(getImportedFilename(sourceName)));
+};
+
+const getRenderFilename = (splats: Splat[], extension: string) => {
+    const normalizedExtension = extension.startsWith('.') ? extension : `.${extension}`;
+    return `${getRenderBaseName(splats)}${normalizedExtension}`;
+};
+
+export { getRenderFilename };

--- a/src/render.ts
+++ b/src/render.ts
@@ -1,11 +1,12 @@
 import { BufferTarget, EncodedPacket, EncodedVideoPacketSource, MkvOutputFormat, MovOutputFormat, Mp4OutputFormat, Output, StreamTarget, WebMOutputFormat } from 'mediabunny';
-import { Color, path, Vec3 } from 'playcanvas';
+import { Color, Vec3 } from 'playcanvas';
 
 import { ElementType } from './element';
 import { Events } from './events';
 import { PngCompressor } from './png-compressor';
+import { getRenderFilename } from './render-filename';
 import { Scene } from './scene';
-import { Splat } from './splat';
+import type { Splat } from './splat';
 import { localize } from './ui/localization';
 
 const nullClr = new Color(0, 0, 0, 0);
@@ -45,10 +46,6 @@ type VideoSettings = {
     codec: 'h264' | 'h265' | 'vp9' | 'av1';
 };
 
-const removeExtension = (filename: string) => {
-    return filename.substring(0, filename.length - path.getExtension(filename).length);
-};
-
 const downloadFile = (arrayBuffer: ArrayBuffer, filename: string) => {
     const blob = new Blob([arrayBuffer], { type: 'application/octet-stream' });
     const url = window.URL.createObjectURL(blob);
@@ -61,6 +58,7 @@ const downloadFile = (arrayBuffer: ArrayBuffer, filename: string) => {
 
 const registerRenderEvents = (scene: Scene, events: Events) => {
     let compressor: PngCompressor;
+    const getCurrentSplats = () => scene.getElementsByType(ElementType.splat) as Splat[];
 
     // wait for postrender to fire
     const postRender = () => {
@@ -116,12 +114,11 @@ const registerRenderEvents = (scene: Scene, events: Events) => {
         }
     });
 
-    events.function('render.image', async (imageSettings: ImageSettings) => {
+    events.function('render.image', async (imageSettings: ImageSettings, fileStream?: FileSystemWritableFileStream) => {
         events.fire('startSpinner');
 
         try {
             const { width, height, transparentBg, showDebug } = imageSettings;
-            const bgClr = events.invoke('bgClr');
 
             // start rendering to offscreen buffer only
             scene.camera.startOffscreenMode(width, height);
@@ -158,12 +155,12 @@ const registerRenderEvents = (scene: Scene, events: Events) => {
                 height
             );
 
-            // construct filename
-            const selected = events.invoke('selection') as Splat;
-            const filename = `${removeExtension(selected?.name ?? 'SuperSplat')}-image.png`;
-
-            // download
-            downloadFile(arrayBuffer, filename);
+            if (fileStream) {
+                await fileStream.write(new Uint8Array(arrayBuffer));
+                await fileStream.close();
+            } else {
+                downloadFile(arrayBuffer, getRenderFilename(getCurrentSplats(), '.png'));
+            }
 
             return true;
         } catch (error) {
@@ -172,6 +169,7 @@ const registerRenderEvents = (scene: Scene, events: Events) => {
                 header: localize('panel.render.failed'),
                 message: `'${error.message ?? error}'`
             });
+            return false;
         } finally {
             scene.camera.endOffscreenMode();
             scene.camera.renderOverlays = true;
@@ -182,7 +180,7 @@ const registerRenderEvents = (scene: Scene, events: Events) => {
         }
     });
 
-    events.function('render.video', (videoSettings: VideoSettings, fileStream: FileSystemWritableFileStream) => {
+    events.function('render.video', (videoSettings: VideoSettings, fileStream?: FileSystemWritableFileStream) => {
         const renderImpl = async () => {
             events.fire('progressStart', localize('panel.render.render-video'), true);
 
@@ -382,8 +380,7 @@ const registerRenderEvents = (scene: Scene, events: Events) => {
 
                 // Download (skip if cancelled -- the caller will delete the file)
                 if (!cancelled && !fileStream) {
-                    const currentSplats = (scene.getElementsByType(ElementType.splat) as Splat[]).filter(splat => splat.visible);
-                    downloadFile((output.target as BufferTarget).buffer, `${removeExtension(currentSplats[0]?.name ?? 'supersplat')}.${fileExtension}`);
+                    downloadFile((output.target as BufferTarget).buffer, getRenderFilename(getCurrentSplats(), fileExtension));
                 }
 
                 return !cancelled;

--- a/src/ui/editor.ts
+++ b/src/ui/editor.ts
@@ -1,5 +1,5 @@
 import { Container, Label } from '@playcanvas/pcui';
-import { Mat4, path, Vec3 } from 'playcanvas';
+import { Mat4, Vec3 } from 'playcanvas';
 
 import { DataPanel } from './data-panel';
 import { Events } from '../events';
@@ -16,6 +16,8 @@ import { Popup, ShowOptions } from './popup';
 import { Progress } from './progress';
 import { PublishSettingsDialog } from './publish-settings-dialog';
 import { RightToolbar } from './right-toolbar';
+import { getRenderFilename } from '../render-filename';
+import type { Splat } from '../splat';
 import { ScenePanel } from './scene-panel';
 import { ShortcutsPopup } from './shortcuts-popup';
 import { Spinner } from './spinner';
@@ -30,8 +32,9 @@ import { version } from '../../package.json';
 // ts compiler and vscode find this type, but eslint does not
 type FilePickerAcceptType = unknown;
 
-const removeExtension = (filename: string) => {
-    return filename.substring(0, filename.length - path.getExtension(filename).length);
+const getSceneRenderFilename = (events: Events, extension: string) => {
+    const splats = events.invoke('scene.allSplats') as Splat[];
+    return getRenderFilename(splats, extension);
 };
 
 class EditorUI {
@@ -249,7 +252,39 @@ class EditorUI {
             const imageSettings = await imageSettingsDialog.show();
 
             if (imageSettings) {
-                await events.invoke('render.image', imageSettings);
+                try {
+                    const suggestedName = getSceneRenderFilename(events, '.png');
+                    let writable;
+                    let fileHandle: FileSystemFileHandle | undefined;
+
+                    if (window.showSaveFilePicker) {
+                        fileHandle = await window.showSaveFilePicker({
+                            id: 'SuperSplatImageFileExport',
+                            types: [{
+                                description: 'PNG Image',
+                                accept: { 'image/png': ['.png'] }
+                            }],
+                            suggestedName
+                        });
+                        writable = await fileHandle.createWritable();
+                    }
+
+                    const result = await events.invoke('render.image', imageSettings, writable);
+
+                    if (result === false && fileHandle?.remove) {
+                        await fileHandle.remove();
+                    }
+                } catch (error) {
+                    if (error instanceof DOMException && error.name === 'AbortError') {
+                        return;
+                    }
+
+                    await events.invoke('showPopup', {
+                        type: 'error',
+                        header: 'Failed to render image',
+                        message: `'${error.message ?? error}'`
+                    });
+                }
             }
         });
 
@@ -257,10 +292,7 @@ class EditorUI {
             const videoSettings = await videoSettingsDialog.show();
 
             if (videoSettings) {
-
                 try {
-                    const docName = events.invoke('doc.name');
-
                     // Determine file extension and mime type based on format
                     let fileExtension: string;
                     let filePickerTypes: FilePickerAcceptType[];
@@ -300,8 +332,7 @@ class EditorUI {
                         }];
                     }
 
-                    const suggested = `${removeExtension(docName ?? 'supersplat')}${fileExtension}`;
-
+                    const suggestedName = getSceneRenderFilename(events, fileExtension);
                     let writable;
                     let fileHandle: FileSystemFileHandle | undefined;
 
@@ -309,7 +340,7 @@ class EditorUI {
                         fileHandle = await window.showSaveFilePicker({
                             id: 'SuperSplatVideoFileExport',
                             types: filePickerTypes,
-                            suggestedName: suggested
+                            suggestedName
                         });
 
                         writable = await fileHandle.createWritable();


### PR DESCRIPTION
## Summary

Use the first imported splat's filename as the suggested save name for rendered images and videos.

## What changed

- derive render save names from the first scene splat instead of the document name or `supersplat`
- preserve the existing `showSaveFilePicker` flow so saving to macOS locations like Downloads and Documents continues to work
- keep the existing browser download fallback for environments without the file save picker
- share the render filename logic between image and video export paths

## Notes

This PR intentionally keeps the save flow close to stock `supersplat`.
It updates the suggested filename, but does not add folder inspection or auto-incremented `(1)`, `(2)` collision handling.

## Validation

- `npm run lint`
- `npm run build`
- browser sanity check in Chrome: importing `splat1.ply` suggests `splat1.png` in the save picker
- manual verification that the same branch no longer hits the folder-access error caused by `showDirectoryPicker`