### PR TITLE
fix: normalize dblclick coordinates for Safari cross-browser compatibility

### DIFF
--- a/src/controllers.ts
+++ b/src/controllers.ts
@@ -299,7 +299,9 @@ class PointerController {
             event.preventDefault();
         };
 
-        // FIXME: safari sends canvas as target of dblclick event but chrome sends the target element
+        // Safari fires dblclick with the canvas element as event.target instead of the
+        // overlay element (target). offsetX/offsetY are then relative to the canvas, not
+        // target, so we must normalize to target-space via clientX/clientY.
         const canvas = camera.scene.app.graphicsDevice.canvas;
 
         const dblclick = (event: globalThis.MouseEvent) => {
@@ -308,7 +310,16 @@ class PointerController {
                 if (camera.controlMode === 'fly') {
                     camera.scene.events.fire('camera.setControlMode', 'orbit');
                 }
-                camera.pickFocalPoint(event.offsetX / target.clientWidth, event.offsetY / target.clientHeight);
+
+                let x = event.offsetX;
+                let y = event.offsetY;
+                if (event.target === canvas) {
+                    const tr = target.getBoundingClientRect();
+                    x = event.clientX - tr.left;
+                    y = event.clientY - tr.top;
+                }
+
+                camera.pickFocalPoint(x / target.clientWidth, y / target.clientHeight);
             }
         };
 


### PR DESCRIPTION
## Summary

Safari fires `dblclick` with the `canvas` element as `event.target` instead of the overlay element (`#canvas-container`). This means `offsetX`/`offsetY` are relative to the canvas, not the overlay — so `pickFocalPoint` receives wrong normalized coordinates on Safari, causing the focal point to land at the incorrect position when double-clicking to focus.

## What changed

- `src/controllers.ts`: detect when `event.target === canvas` (Safari path) and compute `x/y` from `clientX/clientY - target.getBoundingClientRect()` instead of using `offsetX/offsetY` directly
- Chrome path unchanged — `offsetX/offsetY` used as before since `event.target === target` there
- Replaces the `FIXME` comment with an explanation of why the two browsers differ

## Validation

- `npm run lint` — clean
- `npm run build` — clean
- Chrome: double-click to focus behaviour unchanged (Chrome path not touched)
- Safari: focal point now lands at the correct position matching the clicked point