### PR TITLE
Preserve color picker hue when selecting white

### DIFF
--- a/src/ui/color-panel.ts
+++ b/src/ui/color-panel.ts
@@ -1,7 +1,8 @@
-import { ColorPicker, Container, Label, SliderInput } from '@playcanvas/pcui';
+import { Container, Label, SliderInput } from '@playcanvas/pcui';
 import { Color } from 'playcanvas';
 
 import { Events } from '../events';
+import { ColorPicker } from './color-picker';
 import { localize } from './localization';
 import { Tooltips } from './tooltips';
 import { SetSplatColorAdjustmentOp } from '../edit-ops';

--- a/src/ui/color-picker.ts
+++ b/src/ui/color-picker.ts
@@ -1,0 +1,48 @@
+import { ColorPicker as PcuiColorPicker, type ColorPickerArgs } from '@playcanvas/pcui';
+
+import { hsv2rgb } from './color';
+
+const isAchromaticRgb = (color: number[]) => {
+    return color.length >= 3 && color[0] === color[1] && color[1] === color[2];
+};
+
+class ColorPicker extends PcuiColorPicker {
+    protected _setPickerColor(color: number[]) {
+        if (this._changing || this._dragging) {
+            super._setPickerColor(color);
+            return;
+        }
+
+        const hue = this._colorHSV[0];
+        super._setPickerColor(color);
+        this._restoreHueForAchromaticColor(color, hue);
+    }
+
+    protected _callPicker(color: number[]) {
+        const hue = this._colorHSV[0];
+        super._callPicker(color);
+        this._restoreHueForAchromaticColor(color, hue);
+    }
+
+    private _restoreHueForAchromaticColor(color: number[], hue: number) {
+        if (!isAchromaticRgb(color)) {
+            return;
+        }
+
+        this._colorHSV[0] = hue;
+
+        const rgb = hsv2rgb({ h: hue, s: 1, v: 1 });
+        const plainColor = [
+            Math.round(rgb.r * 255),
+            Math.round(rgb.g * 255),
+            Math.round(rgb.b * 255)
+        ].join(',');
+
+        this._pickHueHandle.style.top = `${Math.floor(this._size * hue)}px`;
+        this._pickRect.style.backgroundColor = `rgb(${plainColor})`;
+        this._pickHueHandle.style.backgroundColor = `rgb(${plainColor})`;
+    }
+}
+
+export { ColorPicker };
+export type { ColorPickerArgs };

--- a/src/ui/export-popup.ts
+++ b/src/ui/export-popup.ts
@@ -1,8 +1,9 @@
-import { BooleanInput, Button, ColorPicker, Container, Element, Label, SelectInput, SliderInput, TextInput } from '@playcanvas/pcui';
+import { BooleanInput, Button, Container, Element, Label, SelectInput, SliderInput, TextInput } from '@playcanvas/pcui';
 
 import { Pose } from '../camera-poses';
 import { localize } from './localization';
 import { Events } from '../events';
+import { ColorPicker } from './color-picker';
 import { ExportType, SceneExportOptions } from '../file-handler';
 import { AnimTrack, ExperienceSettings, defaultPostEffectSettings } from '../splat-serialize';
 import sceneExport from './svg/export.svg';

--- a/src/ui/publish-settings-dialog.ts
+++ b/src/ui/publish-settings-dialog.ts
@@ -1,7 +1,8 @@
-import { BooleanInput, Button, ColorPicker, Container, Element, Label, SelectInput, SliderInput, TextAreaInput, TextInput } from '@playcanvas/pcui';
+import { BooleanInput, Button, Container, Element, Label, SelectInput, SliderInput, TextAreaInput, TextInput } from '@playcanvas/pcui';
 
 import { Pose } from '../camera-poses';
 import { Events } from '../events';
+import { ColorPicker } from './color-picker';
 import { localize } from './localization';
 import { PublishSettings, UserStatus } from '../publish';
 import { AnimTrack, ExperienceSettings, defaultPostEffectSettings } from '../splat-serialize';

--- a/src/ui/view-panel.ts
+++ b/src/ui/view-panel.ts
@@ -1,8 +1,9 @@
-import { BooleanInput, ColorPicker, Container, Label, SelectInput, SliderInput } from '@playcanvas/pcui';
+import { BooleanInput, Container, Label, SelectInput, SliderInput } from '@playcanvas/pcui';
 import { Color } from 'playcanvas';
 
 import { Events } from '../events';
 import { ShortcutManager } from '../shortcut-manager';
+import { ColorPicker } from './color-picker';
 import { localize } from './localization';
 import { Tooltips } from './tooltips';
 


### PR DESCRIPTION
## Summary
- add a local ColorPicker wrapper that restores the previous hue for achromatic RGB selections
- route Supersplat color pickers through the wrapper so selecting white no longer resets the hue UI to red

Fixes #818

## Testing
- npm run build
- npm run lint
