### PR TITLE
fix: increase Field of View slider precision in view panel

### DIFF
--- a/src/ui/view-panel.ts
+++ b/src/ui/view-panel.ts
@@ -150,7 +150,7 @@ class ViewPanel extends Container {
             class: 'view-panel-row-slider',
             min: 10,
             max: 120,
-            precision: 1,
+            precision: 2,
             value: 60
         });
 


### PR DESCRIPTION
## Summary

Increases the FoV `SliderInput` precision in the view panel from 1 to 2 decimals so animated FoV reads back at ~0.01-degree resolution instead of ~0.1-degree.

## Why this matters

In #862 the reporter showed that animated FoV in a Bezier curve looked choppy because the FoV slider rounds the recorded value to one decimal. FoV flows from the view-panel slider through the `camera.setFov` event and is stored verbatim in camera-pose keyframes (`src/camera-poses.ts`), so widening the slider's rounding is sufficient to fix the keyframe resolution without changing the animation pipeline.

## Testing

- `src/ui/view-panel.ts` line 153: `precision: 1` -> `precision: 2`. Slider min/max (10/120) unchanged.
- `npm run lint` clean.
- `tsc --noEmit` clean.
- The companion FoV sliders in `publish-settings-dialog.ts` and `export-popup.ts` are intentionally left at `precision: 0` - those configure static exports, not live edits captured in keyframes.

Fixes #862
