### PR TITLE
fix: volume select ignores splats outside the camera frustum

### DIFF
--- a/src/shaders/intersection-shader.ts
+++ b/src/shaders/intersection-shader.ts
@@ -71,38 +71,41 @@ const fragmentShader = /* glsl */ `
                 center = vec4(center, 1.0) * t;
             }
 
-            // transform to clip space and discard if outside
+            // transform to world space (sphere/box modes test world-space containment)
             vec3 world = (matrix_model * vec4(center, 1.0)).xyz;
-            vec4 clip = matrix_viewProjection * vec4(world, 1.0);
-            vec3 ndc = clip.xyz / clip.w;
 
-            // skip offscreen fragments
-            if (!any(greaterThan(abs(ndc), vec3(1.0)))) {
-                if (mode == 0) {
-                    // select by mask
-                    ivec2 maskUV = ivec2((ndc.xy * vec2(0.5, -0.5) + 0.5) * mask_params);
-                    clr[i] = texelFetch(mask, maskUV, 0).a < 1.0 ? 0.0 : 1.0;
-                } else if (mode == 1) {
-                    // select by rect
-                    clr[i] = all(greaterThan(ndc.xy * vec2(1.0, -1.0), rect_params.xy)) && all(lessThan(ndc.xy * vec2(1.0, -1.0), rect_params.zw)) ? 1.0 : 0.0;
-                } else if (mode == 2) {
-                    // select by sphere
-                    clr[i] = length(world - sphere_params.xyz) < sphere_params.w ? 1.0 : 0.0;
-                } else if (mode == 3) {
-                    // select by box
-                    vec3 relativePosition = world - box_params.xyz;
-                    bool isInsideCube = true;
-                    if (relativePosition.x < -aabb_params.x || relativePosition.x > aabb_params.x) {
-                        isInsideCube = false;
+            if (mode == 0 || mode == 1) {
+                // screen-space modes: project to clip space and skip offscreen fragments
+                vec4 clip = matrix_viewProjection * vec4(world, 1.0);
+                vec3 ndc = clip.xyz / clip.w;
+
+                if (!any(greaterThan(abs(ndc), vec3(1.0)))) {
+                    if (mode == 0) {
+                        // select by mask
+                        ivec2 maskUV = ivec2((ndc.xy * vec2(0.5, -0.5) + 0.5) * mask_params);
+                        clr[i] = texelFetch(mask, maskUV, 0).a < 1.0 ? 0.0 : 1.0;
+                    } else {
+                        // select by rect
+                        clr[i] = all(greaterThan(ndc.xy * vec2(1.0, -1.0), rect_params.xy)) && all(lessThan(ndc.xy * vec2(1.0, -1.0), rect_params.zw)) ? 1.0 : 0.0;
                     }
-                    if (relativePosition.y < -aabb_params.y || relativePosition.y > aabb_params.y) {
-                        isInsideCube = false;
-                    }
-                    if (relativePosition.z < -aabb_params.z || relativePosition.z > aabb_params.z) {
-                        isInsideCube = false;
-                    }
-                    clr[i] = isInsideCube ? 1.0 : 0.0;
                 }
+            } else if (mode == 2) {
+                // select by sphere (world-space, independent of camera frustum)
+                clr[i] = length(world - sphere_params.xyz) < sphere_params.w ? 1.0 : 0.0;
+            } else if (mode == 3) {
+                // select by box (world-space, independent of camera frustum)
+                vec3 relativePosition = world - box_params.xyz;
+                bool isInsideCube = true;
+                if (relativePosition.x < -aabb_params.x || relativePosition.x > aabb_params.x) {
+                    isInsideCube = false;
+                }
+                if (relativePosition.y < -aabb_params.y || relativePosition.y > aabb_params.y) {
+                    isInsideCube = false;
+                }
+                if (relativePosition.z < -aabb_params.z || relativePosition.z > aabb_params.z) {
+                    isInsideCube = false;
+                }
+                clr[i] = isInsideCube ? 1.0 : 0.0;
             }
         }
 


### PR DESCRIPTION
## Summary

Restructure `src/shaders/intersection-shader.ts` so the NDC frustum-cull check only gates the screen-space selection modes. Sphere (mode 2) and box (mode 3) now evaluate their world-space predicate unconditionally, so splats inside a volume are selected even when the camera is pointed away from them.

## Why this matters

Issue #843 reports that Sphere and Box volume selection only catches splats whose projection sits inside the current camera view - rotate the camera away from the volume and clicking Add selects nothing. Maintainer @slimbuck confirmed on 2026-03-18: "omg you're right. i can't believe it." The bug is the unconditional `if (!any(greaterThan(abs(ndc), vec3(1.0))))` frustum cull that wraps every mode-specific predicate. That gate is correct for rect / mask / pixel-precise selection (modes 0 and 1) which operate in screen space, but it is wrong for sphere and box which test world-space containment.

## Implementation notes

- World position is still hoisted before the mode switch so all four modes can read it.
- NDC computation plus the `!any(greaterThan(abs(ndc), vec3(1.0)))` cull moved inside an `(mode == 0 || mode == 1)` branch.
- Sphere (mode 2) and box (mode 3) branches now run their world-space tests without the NDC gate.
- Shader uniforms, output channel layout, and the CPU dispatch path in `src/data-processor/intersect.ts` and `src/editor.ts` are unchanged.

## Testing

- `npm run lint` clean.
- `npx tsc --noEmit` clean.
- Walked the diff against the scenarios from the issue:
  - Sphere / box volume placed behind the camera: world-space predicate runs without the NDC gate, splats inside the volume select.
  - Rect / lasso / brush (modes 0 and 1): NDC gate still in place, off-screen splats are still rejected.
  - `select.byMask` (mode 0): mask sampling still requires valid NDC; behavior unchanged.

Fixes #843
