### PR TITLE
 Add "Show Dimensions" overlay for selected splat bound

### DIFF
--- a/src/editor.ts
+++ b/src/editor.ts
@@ -75,7 +75,7 @@ const registerEditorEvents = (events: Events, editHistory: EditHistory, scene: S
 
     [
         'camera.mode', 'camera.overlay', 'camera.splatSize', 'view.outlineSelection',
-        'view.centersUseGaussianColor', 'view.bands', 'camera.bound', 'camera.showPoses',
+        'view.centersUseGaussianColor', 'view.bands', 'camera.bound', 'camera.boundDimensions', 'camera.showPoses',
         'selection.changed', 'tool.coordSpace'
     ].forEach((eventName) => {
         events.on(eventName, () => {
@@ -154,6 +154,29 @@ const registerEditorEvents = (events: Events, editHistory: EditHistory, scene: S
 
     events.on('camera.toggleBound', () => {
         setBoundVisible(!events.invoke('camera.bound'));
+    });
+
+    // camera.boundDimensions
+
+    let boundDimensions = scene.config.show.boundDimensions;
+
+    const setBoundDimensionsVisible = (visible: boolean) => {
+        if (visible !== boundDimensions) {
+            boundDimensions = visible;
+            events.fire('camera.boundDimensions', boundDimensions);
+        }
+    };
+
+    events.function('camera.boundDimensions', () => {
+        return boundDimensions;
+    });
+
+    events.on('camera.setBoundDimensions', (value: boolean) => {
+        setBoundDimensionsVisible(value);
+    });
+
+    events.on('camera.toggleBoundDimensions', () => {
+        setBoundDimensionsVisible(!events.invoke('camera.boundDimensions'));
     });
 
     // camera.showPoses
@@ -756,6 +779,7 @@ const registerEditorEvents = (events: Events, editHistory: EditHistory, scene: S
             outlineSelection: events.invoke('view.outlineSelection'),
             showGrid: events.invoke('grid.visible'),
             showBound: events.invoke('camera.bound'),
+            showBoundDimensions: events.invoke('camera.boundDimensions'),
             showCameraPoses: events.invoke('camera.showPoses'),
             flySpeed: events.invoke('camera.flySpeed')
         };
@@ -771,6 +795,7 @@ const registerEditorEvents = (events: Events, editHistory: EditHistory, scene: S
         events.fire('view.setOutlineSelection', docView.outlineSelection);
         events.fire('grid.setVisible', docView.showGrid);
         events.fire('camera.setBound', docView.showBound);
+        events.fire('camera.setBoundDimensions', docView.showBoundDimensions ?? false);
         events.fire('camera.setShowPoses', docView.showCameraPoses ?? false);
         events.fire('camera.setFlySpeed', docView.flySpeed);
     });

--- a/src/main.ts
+++ b/src/main.ts
@@ -32,6 +32,7 @@ import { SphereSelection } from './tools/sphere-selection';
 import { ToolManager } from './tools/tool-manager';
 import { registerTrackManagerEvents } from './track-manager';
 import { registerTransformHandlerEvents } from './transform-handler';
+import { BoundDimensionsOverlay } from './ui/bound-dimensions-overlay';
 import { EditorUI } from './ui/editor';
 import { localizeInit } from './ui/localization';
 
@@ -240,6 +241,8 @@ const main = async () => {
     toolManager.register('rotate', new RotateTool(events, scene));
     toolManager.register('scale', new ScaleTool(events, scene));
     toolManager.register('measure', new MeasureTool(events, scene, editorUI.toolsContainer.dom, editorUI.canvasContainer));
+
+    const boundDimensionsOverlay = new BoundDimensionsOverlay(events, scene, editorUI.canvasContainer);
 
     editorUI.toolsContainer.dom.appendChild(maskCanvas);
 

--- a/src/scene-config.ts
+++ b/src/scene-config.ts
@@ -22,6 +22,7 @@ const sceneConfig = {
     show: {
         grid: true,
         bound: true,
+        boundDimensions: false,
         cameraPoses: false,
         shBands: 3
     },

--- a/src/ui/bound-dimensions-overlay.ts
+++ b/src/ui/bound-dimensions-overlay.ts
@@ -1,0 +1,187 @@
+import { Container } from '@playcanvas/pcui';
+import { Vec3 } from 'playcanvas';
+
+import { Events } from '../events';
+import { Scene } from '../scene';
+import { Splat } from '../splat';
+
+const corners = Array.from({ length: 8 }, () => new Vec3());
+const screenCorners = Array.from({ length: 8 }, () => new Vec3());
+const cornerInFront = new Array<boolean>(8);
+const screenBoundCenter = new Vec3();
+const worldBoundCenter = new Vec3();
+const tmpVec = new Vec3();
+
+// indices into the 8-corner array, ordered as (sx, sy, sz) where each s is 0 or 1
+// corner index = sx*4 + sy*2 + sz
+const cornerIndex = (sx: number, sy: number, sz: number) => sx * 4 + sy * 2 + sz;
+
+// for each axis, the 4 pairs of corner indices that form the parallel edges along that axis
+const axisEdges: number[][][] = [
+    // X edges: vary sx from 0->1, hold sy, sz constant
+    [
+        [cornerIndex(0, 0, 0), cornerIndex(1, 0, 0)],
+        [cornerIndex(0, 0, 1), cornerIndex(1, 0, 1)],
+        [cornerIndex(0, 1, 0), cornerIndex(1, 1, 0)],
+        [cornerIndex(0, 1, 1), cornerIndex(1, 1, 1)]
+    ],
+    // Y edges
+    [
+        [cornerIndex(0, 0, 0), cornerIndex(0, 1, 0)],
+        [cornerIndex(0, 0, 1), cornerIndex(0, 1, 1)],
+        [cornerIndex(1, 0, 0), cornerIndex(1, 1, 0)],
+        [cornerIndex(1, 0, 1), cornerIndex(1, 1, 1)]
+    ],
+    // Z edges
+    [
+        [cornerIndex(0, 0, 0), cornerIndex(0, 0, 1)],
+        [cornerIndex(0, 1, 0), cornerIndex(0, 1, 1)],
+        [cornerIndex(1, 0, 0), cornerIndex(1, 0, 1)],
+        [cornerIndex(1, 1, 0), cornerIndex(1, 1, 1)]
+    ]
+];
+
+class BoundDimensionsOverlay {
+    constructor(events: Events, scene: Scene, canvasContainer: Container) {
+        const ns = 'http://www.w3.org/2000/svg';
+        const svg = document.createElementNS(ns, 'svg');
+        svg.classList.add('tool-svg', 'bound-dimensions-svg', 'hidden');
+        svg.id = 'bound-dimensions-svg';
+        canvasContainer.dom.appendChild(svg);
+
+        const labels: SVGTextElement[] = [];
+        for (let i = 0; i < 3; i++) {
+            const text = document.createElementNS(ns, 'text') as SVGTextElement;
+            text.classList.add(['bound-dim-x', 'bound-dim-y', 'bound-dim-z'][i]);
+            text.setAttribute('text-anchor', 'middle');
+            text.setAttribute('dominant-baseline', 'middle');
+            svg.appendChild(text);
+            labels.push(text);
+        }
+
+        events.on('prerender', () => {
+            const selection = events.invoke('selection') as Splat;
+
+            if (!selection ||
+                !selection.visible ||
+                !events.invoke('camera.boundDimensions')) {
+                svg.classList.add('hidden');
+                return;
+            }
+
+            svg.classList.remove('hidden');
+
+            const width = canvasContainer.dom.clientWidth;
+            const height = canvasContainer.dom.clientHeight;
+            const camera = scene.camera;
+            const transform = selection.entity.getWorldTransform();
+            const bound = selection.localBound;
+            const { center, halfExtents } = bound;
+
+            // compute 8 world-space corners
+            for (let i = 0; i < 8; i++) {
+                const sx = (i >> 2) & 1;
+                const sy = (i >> 1) & 1;
+                const sz = i & 1;
+                const local = corners[i];
+                local.set(
+                    center.x + (sx ? 1 : -1) * halfExtents.x,
+                    center.y + (sy ? 1 : -1) * halfExtents.y,
+                    center.z + (sz ? 1 : -1) * halfExtents.z
+                );
+                transform.transformPoint(local, local);
+            }
+
+            // determine which corners are in front of the camera (for behind-camera culling)
+            const cameraPos = camera.mainCamera.getPosition();
+            const cameraFwd = camera.mainCamera.forward;
+            for (let i = 0; i < 8; i++) {
+                tmpVec.sub2(corners[i], cameraPos);
+                cornerInFront[i] = tmpVec.dot(cameraFwd) > 0;
+            }
+
+            // project all corners to screen
+            for (let i = 0; i < 8; i++) {
+                camera.worldToScreen(corners[i], screenCorners[i]);
+            }
+
+            // project bound center to screen (used to choose the outer-most edge)
+            transform.transformPoint(center, worldBoundCenter);
+            camera.worldToScreen(worldBoundCenter, screenBoundCenter);
+            const scx = screenBoundCenter.x * width;
+            const scy = screenBoundCenter.y * height;
+
+            for (let axis = 0; axis < 3; axis++) {
+                const edges = axisEdges[axis];
+                let bestEdge = -1;
+                let bestScore = -Infinity;
+
+                // pick the parallel edge on the outer silhouette: farthest screen-space distance
+                // from the projected box centroid. Ties are common in orthographic projection
+                // (opposite edges are exactly equidistant), so require a meaningful difference
+                // before swapping the chosen edge to avoid frame-to-frame flicker.
+                for (let e = 0; e < edges.length; e++) {
+                    const [a, b] = edges[e];
+                    if (!cornerInFront[a] || !cornerInFront[b]) continue;
+                    const mxe = (screenCorners[a].x + screenCorners[b].x) * 0.5 * width;
+                    const mye = (screenCorners[a].y + screenCorners[b].y) * 0.5 * height;
+                    const dxe = mxe - scx;
+                    const dye = mye - scy;
+                    const score = dxe * dxe + dye * dye;
+                    if (score > bestScore + 1) {
+                        bestScore = score;
+                        bestEdge = e;
+                    }
+                }
+
+                const text = labels[axis];
+
+                if (bestEdge < 0) {
+                    // no parallel edge has both endpoints in front of the camera
+                    text.setAttribute('visibility', 'hidden');
+                    continue;
+                }
+                text.setAttribute('visibility', 'visible');
+
+                const [a, b] = edges[bestEdge];
+                const sa = screenCorners[a];
+                const sb = screenCorners[b];
+
+                // world-space edge length
+                const length = corners[a].distance(corners[b]);
+
+                // screen-space endpoints in pixels
+                const x0 = sa.x * width;
+                const y0 = sa.y * height;
+                const x1 = sb.x * width;
+                const y1 = sb.y * height;
+
+                const mx = (x0 + x1) * 0.5;
+                const my = (y0 + y1) * 0.5;
+
+                let theta = Math.atan2(y1 - y0, x1 - x0);
+                // flip 180° to keep text upright
+                if (Math.cos(theta) < 0) {
+                    theta += Math.PI;
+                }
+
+                // perpendicular offset so the label sits outside the box
+                const perpX = -Math.sin(theta);
+                const perpY = Math.cos(theta);
+                const toCenterX = scx - mx;
+                const toCenterY = scy - my;
+                const dot = perpX * toCenterX + perpY * toCenterY;
+                const sign = dot > 0 ? -1 : 1;
+                const offsetPx = 10;
+                const ox = perpX * offsetPx * sign;
+                const oy = perpY * offsetPx * sign;
+
+                const thetaDeg = theta * 180 / Math.PI;
+                text.setAttribute('transform', `translate(${(mx + ox).toFixed(1)}, ${(my + oy).toFixed(1)}) rotate(${thetaDeg.toFixed(1)})`);
+                text.textContent = length.toFixed(2);
+            }
+        });
+    }
+}
+
+export { BoundDimensionsOverlay };

--- a/src/ui/scss/tool.scss
+++ b/src/ui/scss/tool.scss
@@ -45,6 +45,19 @@
         }
     }
 
+    &#bound-dimensions-svg {
+        pointer-events: none;
+
+        > text {
+            font-family: monospace;
+            font-size: 11px;
+            fill: white;
+            paint-order: stroke;
+            stroke: rgba(0, 0, 0, 0.7);
+            stroke-width: 3px;
+        }
+    }
+
     &#measure-tool-svg {
         >#measure-line-bottom {
             stroke: black;

--- a/src/ui/view-panel.ts
+++ b/src/ui/view-panel.ts
@@ -301,6 +301,26 @@ class ViewPanel extends Container {
         showBoundRow.append(showBoundLabel);
         showBoundRow.append(showBoundToggle);
 
+        // show dimensions
+
+        const showBoundDimensionsRow = new Container({
+            class: 'view-panel-row'
+        });
+
+        const showBoundDimensionsLabel = new Label({
+            text: localize('panel.view-options.show-bound-dimensions'),
+            class: 'view-panel-row-label'
+        });
+
+        const showBoundDimensionsToggle = new BooleanInput({
+            type: 'toggle',
+            class: 'view-panel-row-toggle',
+            value: false
+        });
+
+        showBoundDimensionsRow.append(showBoundDimensionsLabel);
+        showBoundDimensionsRow.append(showBoundDimensionsToggle);
+
         // show camera poses
 
         const showCameraPosesRow = new Container({
@@ -332,6 +352,7 @@ class ViewPanel extends Container {
         this.append(outlineSelectionRow);
         this.append(showGridRow);
         this.append(showBoundRow);
+        this.append(showBoundDimensionsRow);
         this.append(showCameraPosesRow);
 
         // handle panel visibility
@@ -430,6 +451,16 @@ class ViewPanel extends Container {
 
         showBoundToggle.on('change', () => {
             events.fire('camera.setBound', showBoundToggle.value);
+        });
+
+        // show dimensions
+
+        events.on('camera.boundDimensions', (visible: boolean) => {
+            showBoundDimensionsToggle.value = visible;
+        });
+
+        showBoundDimensionsToggle.on('change', () => {
+            events.fire('camera.setBoundDimensions', showBoundDimensionsToggle.value);
         });
 
         // show camera poses

--- a/static/locales/de.json
+++ b/static/locales/de.json
@@ -71,6 +71,7 @@
     "panel.view-options.outline-selection": "Umriss Selektion",
     "panel.view-options.show-grid": "Raster anzeigen",
     "panel.view-options.show-bound": "Objektbox anzeigen",
+    "panel.view-options.show-bound-dimensions": "Show Dimensions",
     "panel.view-options.show-camera-poses": "Kameras anzeigen",
     "panel.view-options.fly-speed": "Kamera Geschwindigkeit",
     "panel.view-options.tonemapping": "Tonemapping",

--- a/static/locales/de.json
+++ b/static/locales/de.json
@@ -71,7 +71,7 @@
     "panel.view-options.outline-selection": "Umriss Selektion",
     "panel.view-options.show-grid": "Raster anzeigen",
     "panel.view-options.show-bound": "Objektbox anzeigen",
-    "panel.view-options.show-bound-dimensions": "Show Dimensions",
+    "panel.view-options.show-bound-dimensions": "Abmessungen anzeigen",
     "panel.view-options.show-camera-poses": "Kameras anzeigen",
     "panel.view-options.fly-speed": "Kamera Geschwindigkeit",
     "panel.view-options.tonemapping": "Tonemapping",

--- a/static/locales/en.json
+++ b/static/locales/en.json
@@ -71,6 +71,7 @@
     "panel.view-options.outline-selection": "Outline Selection",
     "panel.view-options.show-grid": "Show Grid",
     "panel.view-options.show-bound": "Show Bound",
+    "panel.view-options.show-bound-dimensions": "Show Dimensions",
     "panel.view-options.show-camera-poses": "Show Cameras",
     "panel.view-options.fly-speed": "Fly Speed",
     "panel.view-options.tonemapping": "Tonemapping",

--- a/static/locales/es.json
+++ b/static/locales/es.json
@@ -71,7 +71,7 @@
     "panel.view-options.outline-selection": "Contorno de selección",
     "panel.view-options.show-grid": "Mostrar cuadrícula",
     "panel.view-options.show-bound": "Mostrar límites",
-    "panel.view-options.show-bound-dimensions": "Show Dimensions",
+    "panel.view-options.show-bound-dimensions": "Mostrar dimensiones",
     "panel.view-options.show-camera-poses": "Mostrar cámaras",
     "panel.view-options.fly-speed": "Velocidad de vuelo",
     "panel.view-options.tonemapping": "Mapeo de tonos",

--- a/static/locales/es.json
+++ b/static/locales/es.json
@@ -71,6 +71,7 @@
     "panel.view-options.outline-selection": "Contorno de selección",
     "panel.view-options.show-grid": "Mostrar cuadrícula",
     "panel.view-options.show-bound": "Mostrar límites",
+    "panel.view-options.show-bound-dimensions": "Show Dimensions",
     "panel.view-options.show-camera-poses": "Mostrar cámaras",
     "panel.view-options.fly-speed": "Velocidad de vuelo",
     "panel.view-options.tonemapping": "Mapeo de tonos",

--- a/static/locales/fr.json
+++ b/static/locales/fr.json
@@ -71,7 +71,7 @@
     "panel.view-options.outline-selection": "Contour de la sélection",
     "panel.view-options.show-grid": "Afficher la grille",
     "panel.view-options.show-bound": "Afficher limites",
-    "panel.view-options.show-bound-dimensions": "Show Dimensions",
+    "panel.view-options.show-bound-dimensions": "Afficher dimensions",
     "panel.view-options.show-camera-poses": "Afficher caméras",
     "panel.view-options.fly-speed": "Vitesse de vol",
     "panel.view-options.tonemapping": "Mappage tonal",

--- a/static/locales/fr.json
+++ b/static/locales/fr.json
@@ -71,6 +71,7 @@
     "panel.view-options.outline-selection": "Contour de la sélection",
     "panel.view-options.show-grid": "Afficher la grille",
     "panel.view-options.show-bound": "Afficher limites",
+    "panel.view-options.show-bound-dimensions": "Show Dimensions",
     "panel.view-options.show-camera-poses": "Afficher caméras",
     "panel.view-options.fly-speed": "Vitesse de vol",
     "panel.view-options.tonemapping": "Mappage tonal",

--- a/static/locales/ja.json
+++ b/static/locales/ja.json
@@ -71,6 +71,7 @@
     "panel.view-options.outline-selection": "選択のアウトライン",
     "panel.view-options.show-grid": "グリッド",
     "panel.view-options.show-bound": "バウンディングボックス",
+    "panel.view-options.show-bound-dimensions": "Show Dimensions",
     "panel.view-options.show-camera-poses": "カメラを表示",
     "panel.view-options.fly-speed": "カメラの移動速度",
     "panel.view-options.tonemapping": "トーンマッピング",

--- a/static/locales/ja.json
+++ b/static/locales/ja.json
@@ -71,7 +71,7 @@
     "panel.view-options.outline-selection": "選択のアウトライン",
     "panel.view-options.show-grid": "グリッド",
     "panel.view-options.show-bound": "バウンディングボックス",
-    "panel.view-options.show-bound-dimensions": "Show Dimensions",
+    "panel.view-options.show-bound-dimensions": "寸法を表示",
     "panel.view-options.show-camera-poses": "カメラを表示",
     "panel.view-options.fly-speed": "カメラの移動速度",
     "panel.view-options.tonemapping": "トーンマッピング",

--- a/static/locales/ko.json
+++ b/static/locales/ko.json
@@ -71,6 +71,7 @@
     "panel.view-options.outline-selection": "선택 윤곽선",
     "panel.view-options.show-grid": "그리드 표시",
     "panel.view-options.show-bound": "경계 표시",
+    "panel.view-options.show-bound-dimensions": "Show Dimensions",
     "panel.view-options.show-camera-poses": "카메라 표시",
     "panel.view-options.fly-speed": "카메라 이동 속도",
     "panel.view-options.tonemapping": "톤매핑",

--- a/static/locales/ko.json
+++ b/static/locales/ko.json
@@ -71,7 +71,7 @@
     "panel.view-options.outline-selection": "선택 윤곽선",
     "panel.view-options.show-grid": "그리드 표시",
     "panel.view-options.show-bound": "경계 표시",
-    "panel.view-options.show-bound-dimensions": "Show Dimensions",
+    "panel.view-options.show-bound-dimensions": "치수 표시",
     "panel.view-options.show-camera-poses": "카메라 표시",
     "panel.view-options.fly-speed": "카메라 이동 속도",
     "panel.view-options.tonemapping": "톤매핑",

--- a/static/locales/pt-BR.json
+++ b/static/locales/pt-BR.json
@@ -71,7 +71,7 @@
     "panel.view-options.outline-selection": "Contorno da Seleção",
     "panel.view-options.show-grid": "Mostrar Grade",
     "panel.view-options.show-bound": "Mostrar Limite",
-    "panel.view-options.show-bound-dimensions": "Show Dimensions",
+    "panel.view-options.show-bound-dimensions": "Mostrar Dimensões",
     "panel.view-options.show-camera-poses": "Mostrar Câmeras",
     "panel.view-options.fly-speed": "Velocidade de Voo",
     "panel.view-options.tonemapping": "Mapeamento de Tons",

--- a/static/locales/pt-BR.json
+++ b/static/locales/pt-BR.json
@@ -71,6 +71,7 @@
     "panel.view-options.outline-selection": "Contorno da Seleção",
     "panel.view-options.show-grid": "Mostrar Grade",
     "panel.view-options.show-bound": "Mostrar Limite",
+    "panel.view-options.show-bound-dimensions": "Show Dimensions",
     "panel.view-options.show-camera-poses": "Mostrar Câmeras",
     "panel.view-options.fly-speed": "Velocidade de Voo",
     "panel.view-options.tonemapping": "Mapeamento de Tons",

--- a/static/locales/ru.json
+++ b/static/locales/ru.json
@@ -71,7 +71,7 @@
     "panel.view-options.outline-selection": "Контур выделения",
     "panel.view-options.show-grid": "Показать сетку",
     "panel.view-options.show-bound": "Показать границы",
-    "panel.view-options.show-bound-dimensions": "Show Dimensions",
+    "panel.view-options.show-bound-dimensions": "Показать размеры",
     "panel.view-options.show-camera-poses": "Показать камеры",
     "panel.view-options.fly-speed": "Скорость полёта",
     "panel.view-options.tonemapping": "Тональная коррекция",

--- a/static/locales/ru.json
+++ b/static/locales/ru.json
@@ -71,6 +71,7 @@
     "panel.view-options.outline-selection": "Контур выделения",
     "panel.view-options.show-grid": "Показать сетку",
     "panel.view-options.show-bound": "Показать границы",
+    "panel.view-options.show-bound-dimensions": "Show Dimensions",
     "panel.view-options.show-camera-poses": "Показать камеры",
     "panel.view-options.fly-speed": "Скорость полёта",
     "panel.view-options.tonemapping": "Тональная коррекция",

--- a/static/locales/zh-CN.json
+++ b/static/locales/zh-CN.json
@@ -71,6 +71,7 @@
     "panel.view-options.outline-selection": "轮廓选择",
     "panel.view-options.show-grid": "显示网格",
     "panel.view-options.show-bound": "显示边界",
+    "panel.view-options.show-bound-dimensions": "Show Dimensions",
     "panel.view-options.show-camera-poses": "显示相机",
     "panel.view-options.fly-speed": "相机飞行速度",
     "panel.view-options.tonemapping": "色调映射",

--- a/static/locales/zh-CN.json
+++ b/static/locales/zh-CN.json
@@ -71,7 +71,7 @@
     "panel.view-options.outline-selection": "轮廓选择",
     "panel.view-options.show-grid": "显示网格",
     "panel.view-options.show-bound": "显示边界",
-    "panel.view-options.show-bound-dimensions": "Show Dimensions",
+    "panel.view-options.show-bound-dimensions": "显示尺寸",
     "panel.view-options.show-camera-poses": "显示相机",
     "panel.view-options.fly-speed": "相机飞行速度",
     "panel.view-options.tonemapping": "色调映射",


### PR DESCRIPTION
## Summary

Adds a new "Show Dimensions" toggle to the View panel that overlays the world-space length of each axis of the selected splat's bounding box directly on the 3D viewport. Each axis label is rendered as SVG text aligned with — and offset to the outside of — the corresponding outer-silhouette edge of the box, so users can read the X/Y/Z extents at a glance while orbiting.

## Implementation

- New [[src/ui/bound-dimensions-overlay.ts](https://claude.ai/epitaxy/src/ui/bound-dimensions-overlay.ts)](src/ui/bound-dimensions-overlay.ts) creates a single SVG attached to `canvasContainer.dom` with three `<text>` children (one per axis). Each frame on `prerender` it projects the 8 world-space corners of the splat's local bound, picks the outermost parallel edge per axis (farthest screen-space midpoint from the projected box centroid), and positions each label at that edge's midpoint, rotated to match its on-screen direction with a perpendicular offset that always points away from the box centre. Labels auto-flip 180° to stay upright.
- Behind-camera culling is done with a world-space dot product against the camera forward direction, so labels disappear cleanly when the box leaves the view frustum (rather than projecting to garbage screen coordinates).
- A 1-pixel² tie tolerance on the edge-selection score prevents frame-to-frame flicker in orthographic mode, where opposite parallel edges are exactly equidistant from the box centre.
- The "Show Dimensions" toggle is independent of "Show Bound" — users can show dimensions without the wireframe, or vice versa. State is wired through new `camera.boundDimensions` / `camera.setBoundDimensions` / `camera.toggleBoundDimensions` events in [[src/editor.ts](https://claude.ai/epitaxy/src/editor.ts)](src/editor.ts), defaults to `false` in [[src/scene-config.ts](https://claude.ai/epitaxy/src/scene-config.ts)](src/scene-config.ts), and round-trips via `docSerialize.view` / `docDeserialize.view`.
- Labels are styled in [[src/ui/scss/tool.scss](https://claude.ai/epitaxy/src/ui/scss/tool.scss)](src/ui/scss/tool.scss) with a black stroke halo (`paint-order: stroke`) so they remain legible against any background.
- Localized in all 9 locale files (`panel.view-options.show-bound-dimensions`).

## Test plan

- [ ] Load a splat, select it, toggle "Show Dimensions" on — three numeric labels appear, one per axis edge.
- [ ] Orbit the camera in perspective mode — labels track the outer silhouette edges and stay upright.
- [ ] Switch to orthographic mode — labels do not flicker between frames.
- [ ] Apply translate / rotate / non-uniform scale to the splat — displayed dimensions update and match the visible wireframe extents.
- [ ] Pan the splat partially / fully off-screen — labels hide cleanly per axis.
- [ ] Toggle "Show Bound" off while "Show Dimensions" is on — labels remain visible without the wireframe.
- [ ] Save and reload the document — toggle state persists.
- [ ] Verify the new toggle string renders correctly in each locale.