### PR TITLE
Add "Generate LODs" option to publish dialog

### DIFF
--- a/src/publish.ts
+++ b/src/publish.ts
@@ -67,6 +67,7 @@ type PublishSettings = {
     overwriteHash?: string;
     overrideModel?: boolean;
     overrideAnimation?: boolean;
+    autoLods: boolean;
 };
 
 const origin = location.origin;
@@ -247,6 +248,8 @@ class PublishWriter implements Writer {
 
             const completeJson = await completeResult.json();
 
+            const publishFormat = publishSettings.autoLods ? 'ssog' : 'sog';
+
             const doPublish = () => fetch(`${user.apiServer}/splats/publish`, {
                 method: 'POST',
                 body: JSON.stringify({
@@ -256,7 +259,7 @@ class PublishWriter implements Writer {
                     listed: publishSettings.listed,
                     settings: publishSettings.experienceSettings,
                     sourceFormat: 'ply',
-                    publishFormat: 'sog'
+                    publishFormat
                 }),
                 headers: {
                     'Authorization': `Bearer ${user.token}`,
@@ -270,7 +273,7 @@ class PublishWriter implements Writer {
                     s3Key: startJson.key,
                     settings: publishSettings.experienceSettings,
                     sourceFormat: 'ply',
-                    publishFormat: 'sog'
+                    publishFormat
                 }),
                 headers: {
                     'Authorization': `Bearer ${user.token}`,

--- a/src/publish.ts
+++ b/src/publish.ts
@@ -67,7 +67,7 @@ type PublishSettings = {
     overwriteHash?: string;
     overrideModel?: boolean;
     overrideAnimation?: boolean;
-    autoLods: boolean;
+    generateLods: boolean;
 };
 
 const origin = location.origin;
@@ -248,7 +248,7 @@ class PublishWriter implements Writer {
 
             const completeJson = await completeResult.json();
 
-            const publishFormat = publishSettings.autoLods ? 'ssog' : 'sog';
+            const publishFormat = publishSettings.generateLods ? 'ssog' : 'sog';
 
             const doPublish = () => fetch(`${user.apiServer}/splats/publish`, {
                 method: 'POST',

--- a/src/ui/publish-settings-dialog.ts
+++ b/src/ui/publish-settings-dialog.ts
@@ -123,7 +123,7 @@ class PublishSettingsDialog extends Container {
 
         // auto LODs
 
-        const autoLodsLabel = new Label({ class: 'label', text: localize('popup.publish.auto-lods') });
+        const autoLodsLabel = new Label({ class: 'label', text: localize('popup.publish.generate-lods') });
         const autoLodsToggle = new BooleanInput({ class: 'boolean', type: 'toggle', value: false });
         const autoLodsRow = new Container({ class: 'row' });
         autoLodsRow.append(autoLodsLabel);

--- a/src/ui/publish-settings-dialog.ts
+++ b/src/ui/publish-settings-dialog.ts
@@ -121,13 +121,13 @@ class PublishSettingsDialog extends Container {
         colorRow.append(colorLabel);
         colorRow.append(colorPicker);
 
-        // auto LODs
+        // generate LODs
 
-        const autoLodsLabel = new Label({ class: 'label', text: localize('popup.publish.generate-lods') });
-        const autoLodsToggle = new BooleanInput({ class: 'boolean', type: 'toggle', value: false });
-        const autoLodsRow = new Container({ class: 'row' });
-        autoLodsRow.append(autoLodsLabel);
-        autoLodsRow.append(autoLodsToggle);
+        const generateLodsLabel = new Label({ class: 'label', text: localize('popup.publish.generate-lods') });
+        const generateLodsToggle = new BooleanInput({ class: 'boolean', type: 'toggle', value: false });
+        const generateLodsRow = new Container({ class: 'row' });
+        generateLodsRow.append(generateLodsLabel);
+        generateLodsRow.append(generateLodsToggle);
 
         // fov
 
@@ -155,7 +155,7 @@ class PublishSettingsDialog extends Container {
         content.append(fovRow);
         content.append(animationRow);
         content.append(loopRow);
-        content.append(autoLodsRow);
+        content.append(generateLodsRow);
 
         // footer
 
@@ -217,8 +217,8 @@ class PublishSettingsDialog extends Container {
             animationRow.hidden = !isNew;
             overrideModelRow.hidden = isNew;
             overrideAnimationRow.hidden = isNew;
-            // autoLods only matters when a model is uploaded — hide when republishing animation-only
-            autoLodsRow.hidden = !isNew && !modelOn;
+            // generateLods only matters when a model is uploaded — hide when republishing animation-only
+            generateLodsRow.hidden = !isNew && !modelOn;
 
             if (isNew) {
                 animationToggle.enabled = hasPosesState;
@@ -279,7 +279,7 @@ class PublishSettingsDialog extends Container {
             loopSelect.value = 'repeat';
             colorPicker.value = [bgClr.r, bgClr.g, bgClr.b];
             fovSlider.value = events.invoke('camera.fov');
-            autoLodsToggle.value = totalSplats >= 1_000_000 && isLargeScene;
+            generateLodsToggle.value = totalSplats >= 1_000_000 && isLargeScene;
 
             updateLayout();
         };
@@ -393,7 +393,7 @@ class PublishSettingsDialog extends Container {
                         overwriteHash: selectedScene?.hash,
                         overrideModel: isNew || overrideModelToggle.value,
                         overrideAnimation: !isNew && overrideAnimationToggle.value,
-                        autoLods: autoLodsToggle.value
+                        generateLods: generateLodsToggle.value
                     });
                 };
             }).finally(() => {

--- a/src/ui/publish-settings-dialog.ts
+++ b/src/ui/publish-settings-dialog.ts
@@ -217,6 +217,8 @@ class PublishSettingsDialog extends Container {
             animationRow.hidden = !isNew;
             overrideModelRow.hidden = isNew;
             overrideAnimationRow.hidden = isNew;
+            // autoLods only matters when a model is uploaded — hide when republishing animation-only
+            autoLodsRow.hidden = !isNew && !modelOn;
 
             if (isNew) {
                 animationToggle.enabled = hasPosesState;
@@ -245,7 +247,7 @@ class PublishSettingsDialog extends Container {
             const filename = splats[0].filename;
             const dot = splats[0].filename.lastIndexOf('.');
             const bgClr = events.invoke('bgClr');
-            const totalSplats = splats.reduce((sum: number, s: any) => sum + (s.splatData?.numSplats ?? 0), 0);
+            const totalSplats = splats.reduce((sum: number, s: any) => sum + (s.numSplats ?? 0), 0);
 
             // union scene bounds to decide LOD default for large scenes
             const sceneMin = [Infinity, Infinity, Infinity];

--- a/src/ui/publish-settings-dialog.ts
+++ b/src/ui/publish-settings-dialog.ts
@@ -121,6 +121,14 @@ class PublishSettingsDialog extends Container {
         colorRow.append(colorLabel);
         colorRow.append(colorPicker);
 
+        // auto LODs
+
+        const autoLodsLabel = new Label({ class: 'label', text: 'Auto generate LODs' });
+        const autoLodsToggle = new BooleanInput({ class: 'boolean', type: 'toggle', value: false });
+        const autoLodsRow = new Container({ class: 'row' });
+        autoLodsRow.append(autoLodsLabel);
+        autoLodsRow.append(autoLodsToggle);
+
         // fov
 
         const fovLabel = new Label({ class: 'label', text: localize('popup.export.fov') });
@@ -147,6 +155,7 @@ class PublishSettingsDialog extends Container {
         content.append(fovRow);
         content.append(animationRow);
         content.append(loopRow);
+        content.append(autoLodsRow);
 
         // footer
 
@@ -236,6 +245,24 @@ class PublishSettingsDialog extends Container {
             const filename = splats[0].filename;
             const dot = splats[0].filename.lastIndexOf('.');
             const bgClr = events.invoke('bgClr');
+            const totalSplats = splats.reduce((sum: number, s: any) => sum + (s.splatData?.numSplats ?? 0), 0);
+
+            // union scene bounds to decide LOD default for large scenes
+            const sceneMin = [Infinity, Infinity, Infinity];
+            const sceneMax = [-Infinity, -Infinity, -Infinity];
+            for (const s of splats) {
+                const bound = s.worldBound;
+                if (!bound) continue;
+                const { center, halfExtents } = bound;
+                const c = [center.x, center.y, center.z];
+                const h = [halfExtents.x, halfExtents.y, halfExtents.z];
+                for (let i = 0; i < 3; i++) {
+                    sceneMin[i] = Math.min(sceneMin[i], c[i] - h[i]);
+                    sceneMax[i] = Math.max(sceneMax[i], c[i] + h[i]);
+                }
+            }
+            const largeAxes = [0, 1, 2].filter(i => sceneMax[i] - sceneMin[i] > 16).length;
+            const isLargeScene = largeAxes >= 2;
 
             overwriteSelect.options = [{
                 v: '0', t: localize('popup.publish.new-scene')
@@ -250,6 +277,7 @@ class PublishSettingsDialog extends Container {
             loopSelect.value = 'repeat';
             colorPicker.value = [bgClr.r, bgClr.g, bgClr.b];
             fovSlider.value = events.invoke('camera.fov');
+            autoLodsToggle.value = totalSplats >= 1_000_000 && isLargeScene;
 
             updateLayout();
         };
@@ -362,7 +390,8 @@ class PublishSettingsDialog extends Container {
                         overwriteId: selectedScene?.id,
                         overwriteHash: selectedScene?.hash,
                         overrideModel: isNew || overrideModelToggle.value,
-                        overrideAnimation: !isNew && overrideAnimationToggle.value
+                        overrideAnimation: !isNew && overrideAnimationToggle.value,
+                        autoLods: autoLodsToggle.value
                     });
                 };
             }).finally(() => {

--- a/src/ui/publish-settings-dialog.ts
+++ b/src/ui/publish-settings-dialog.ts
@@ -123,7 +123,7 @@ class PublishSettingsDialog extends Container {
 
         // auto LODs
 
-        const autoLodsLabel = new Label({ class: 'label', text: 'Auto generate LODs' });
+        const autoLodsLabel = new Label({ class: 'label', text: localize('popup.publish.auto-lods') });
         const autoLodsToggle = new BooleanInput({ class: 'boolean', type: 'toggle', value: false });
         const autoLodsRow = new Container({ class: 'row' });
         autoLodsRow.append(autoLodsLabel);

--- a/static/locales/de.json
+++ b/static/locales/de.json
@@ -235,6 +235,7 @@
     "popup.publish.new-scene": "Neue Szene",
     "popup.publish.override-model": "Modell überschreiben",
     "popup.publish.override-animation": "Animation überschreiben",
+    "popup.publish.auto-lods": "LODs erzeugen",
     "cursor.click-to-copy": "Klicken zum Kopieren",
     "cursor.copied": "Kopiert!",
     "doc.reset": "Szene Zurücksetzen",

--- a/static/locales/de.json
+++ b/static/locales/de.json
@@ -235,7 +235,7 @@
     "popup.publish.new-scene": "Neue Szene",
     "popup.publish.override-model": "Modell überschreiben",
     "popup.publish.override-animation": "Animation überschreiben",
-    "popup.publish.auto-lods": "LODs erzeugen",
+    "popup.publish.generate-lods": "LODs erzeugen",
     "cursor.click-to-copy": "Klicken zum Kopieren",
     "cursor.copied": "Kopiert!",
     "doc.reset": "Szene Zurücksetzen",

--- a/static/locales/en.json
+++ b/static/locales/en.json
@@ -235,7 +235,7 @@
     "popup.publish.new-scene": "New Scene",
     "popup.publish.override-model": "Override Model",
     "popup.publish.override-animation": "Override Animation",
-    "popup.publish.auto-lods": "Generate LODs",
+    "popup.publish.generate-lods": "Generate LODs",
     "cursor.click-to-copy": "Click to Copy",
     "cursor.copied": "Copied!",
     "doc.reset": "Reset Scene",

--- a/static/locales/en.json
+++ b/static/locales/en.json
@@ -235,6 +235,7 @@
     "popup.publish.new-scene": "New Scene",
     "popup.publish.override-model": "Override Model",
     "popup.publish.override-animation": "Override Animation",
+    "popup.publish.auto-lods": "Generate LODs",
     "cursor.click-to-copy": "Click to Copy",
     "cursor.copied": "Copied!",
     "doc.reset": "Reset Scene",

--- a/static/locales/es.json
+++ b/static/locales/es.json
@@ -235,7 +235,7 @@
     "popup.publish.new-scene": "Nueva escena",
     "popup.publish.override-model": "Reemplazar modelo",
     "popup.publish.override-animation": "Reemplazar animación",
-    "popup.publish.auto-lods": "Generar LOD",
+    "popup.publish.generate-lods": "Generar LOD",
     "cursor.click-to-copy": "Haga clic para copiar",
     "cursor.copied": "¡Copiado!",
     "doc.reset": "Restablecer escena",

--- a/static/locales/es.json
+++ b/static/locales/es.json
@@ -235,6 +235,7 @@
     "popup.publish.new-scene": "Nueva escena",
     "popup.publish.override-model": "Reemplazar modelo",
     "popup.publish.override-animation": "Reemplazar animación",
+    "popup.publish.auto-lods": "Generar LOD",
     "cursor.click-to-copy": "Haga clic para copiar",
     "cursor.copied": "¡Copiado!",
     "doc.reset": "Restablecer escena",

--- a/static/locales/fr.json
+++ b/static/locales/fr.json
@@ -235,6 +235,7 @@
     "popup.publish.new-scene": "Nouvelle scène",
     "popup.publish.override-model": "Remplacer le modèle",
     "popup.publish.override-animation": "Remplacer l'animation",
+    "popup.publish.auto-lods": "Générer les LOD",
     "cursor.click-to-copy": "Cliquez pour copier",
     "cursor.copied": "Copié!",
     "doc.reset": "Réinitialiser la Scène",

--- a/static/locales/fr.json
+++ b/static/locales/fr.json
@@ -235,7 +235,7 @@
     "popup.publish.new-scene": "Nouvelle scène",
     "popup.publish.override-model": "Remplacer le modèle",
     "popup.publish.override-animation": "Remplacer l'animation",
-    "popup.publish.auto-lods": "Générer les LOD",
+    "popup.publish.generate-lods": "Générer les LOD",
     "cursor.click-to-copy": "Cliquez pour copier",
     "cursor.copied": "Copié!",
     "doc.reset": "Réinitialiser la Scène",

--- a/static/locales/ja.json
+++ b/static/locales/ja.json
@@ -235,6 +235,7 @@
     "popup.publish.new-scene": "新規シーンを作成",
     "popup.publish.override-model": "モデルを上書き",
     "popup.publish.override-animation": "アニメーションを上書き",
+    "popup.publish.auto-lods": "LODを生成",
     "cursor.click-to-copy": "クリックしてコピー",
     "cursor.copied": "コピーしました！",
     "doc.reset": "シーンをリセット",

--- a/static/locales/ja.json
+++ b/static/locales/ja.json
@@ -235,7 +235,7 @@
     "popup.publish.new-scene": "新規シーンを作成",
     "popup.publish.override-model": "モデルを上書き",
     "popup.publish.override-animation": "アニメーションを上書き",
-    "popup.publish.auto-lods": "LODを生成",
+    "popup.publish.generate-lods": "LODを生成",
     "cursor.click-to-copy": "クリックしてコピー",
     "cursor.copied": "コピーしました！",
     "doc.reset": "シーンをリセット",

--- a/static/locales/ko.json
+++ b/static/locales/ko.json
@@ -235,7 +235,7 @@
     "popup.publish.new-scene": "새 장면",
     "popup.publish.override-model": "모델 덮어쓰기",
     "popup.publish.override-animation": "애니메이션 덮어쓰기",
-    "popup.publish.auto-lods": "LOD 생성",
+    "popup.publish.generate-lods": "LOD 생성",
     "cursor.click-to-copy": "클릭하여 복사",
     "cursor.copied": "복사됨!",
     "doc.reset": "장면 재설정",

--- a/static/locales/ko.json
+++ b/static/locales/ko.json
@@ -235,6 +235,7 @@
     "popup.publish.new-scene": "새 장면",
     "popup.publish.override-model": "모델 덮어쓰기",
     "popup.publish.override-animation": "애니메이션 덮어쓰기",
+    "popup.publish.auto-lods": "LOD 생성",
     "cursor.click-to-copy": "클릭하여 복사",
     "cursor.copied": "복사됨!",
     "doc.reset": "장면 재설정",

--- a/static/locales/pt-BR.json
+++ b/static/locales/pt-BR.json
@@ -235,7 +235,7 @@
     "popup.publish.new-scene": "Nova Cena",
     "popup.publish.override-model": "Substituir Modelo",
     "popup.publish.override-animation": "Substituir Animação",
-    "popup.publish.auto-lods": "Gerar LODs",
+    "popup.publish.generate-lods": "Gerar LODs",
     "cursor.click-to-copy": "Clique para Copiar",
     "cursor.copied": "Copiado!",
     "doc.reset": "Reiniciar a Cena",

--- a/static/locales/pt-BR.json
+++ b/static/locales/pt-BR.json
@@ -235,6 +235,7 @@
     "popup.publish.new-scene": "Nova Cena",
     "popup.publish.override-model": "Substituir Modelo",
     "popup.publish.override-animation": "Substituir Animação",
+    "popup.publish.auto-lods": "Gerar LODs",
     "cursor.click-to-copy": "Clique para Copiar",
     "cursor.copied": "Copiado!",
     "doc.reset": "Reiniciar a Cena",

--- a/static/locales/ru.json
+++ b/static/locales/ru.json
@@ -235,6 +235,7 @@
     "popup.publish.new-scene": "Новая сцена",
     "popup.publish.override-model": "Заменить модель",
     "popup.publish.override-animation": "Заменить анимацию",
+    "popup.publish.auto-lods": "Создавать LOD",
     "cursor.click-to-copy": "Нажмите, чтобы скопировать",
     "cursor.copied": "Скопировано!",
     "doc.reset": "Сбросить сцену",

--- a/static/locales/ru.json
+++ b/static/locales/ru.json
@@ -235,7 +235,7 @@
     "popup.publish.new-scene": "Новая сцена",
     "popup.publish.override-model": "Заменить модель",
     "popup.publish.override-animation": "Заменить анимацию",
-    "popup.publish.auto-lods": "Создавать LOD",
+    "popup.publish.generate-lods": "Создавать LOD",
     "cursor.click-to-copy": "Нажмите, чтобы скопировать",
     "cursor.copied": "Скопировано!",
     "doc.reset": "Сбросить сцену",

--- a/static/locales/zh-CN.json
+++ b/static/locales/zh-CN.json
@@ -235,7 +235,7 @@
     "popup.publish.new-scene": "新场景",
     "popup.publish.override-model": "覆盖模型",
     "popup.publish.override-animation": "覆盖动画",
-    "popup.publish.auto-lods": "生成 LOD",
+    "popup.publish.generate-lods": "生成 LOD",
     "cursor.click-to-copy": "点击复制",
     "cursor.copied": "已复制!",
     "doc.reset": "重置场景",

--- a/static/locales/zh-CN.json
+++ b/static/locales/zh-CN.json
@@ -235,6 +235,7 @@
     "popup.publish.new-scene": "新场景",
     "popup.publish.override-model": "覆盖模型",
     "popup.publish.override-animation": "覆盖动画",
+    "popup.publish.auto-lods": "生成 LOD",
     "cursor.click-to-copy": "点击复制",
     "cursor.copied": "已复制!",
     "doc.reset": "重置场景",


### PR DESCRIPTION
## Summary
Adds a user-facing "Generate LODs" toggle to the publish settings dialog. When enabled, the publish request sends `publishFormat: 'ssog'` instead of `'sog'`, telling the server pipeline to decimate the PLY into LOD chunks (streaming SOG) rather than producing a single SOG.
The toggle is visible in both new-scene and republish flows and defaults to ON when both:
- the scene contains ≥ 1,000,000 splats, and
- the unioned scene world-bound exceeds 16 m on at least 2 axes.
Otherwise it defaults to OFF, preserving today's single-SOG behavior.
**Changes:**
- `src/publish.ts`: extended `PublishSettings` with `generateLods`; both `doPublish` and `doRepublish` payloads now derive `publishFormat` from it.
- `src/ui/publish-settings-dialog.ts`: new `BooleanInput` row, default computed from splat count + world-bound extents, threaded into the resolved `PublishSettings`. The row is hidden when republishing animation-only (no model upload).
- `static/locales/*.json`: added `popup.publish.generate-lods` for all 9 supported languages.
**Test plan:**
- [ ] Load a small PLY (<1M splats or compact bounds) → toggle defaults OFF; publish → `publishFormat: "sog"` in request.
- [ ] Load a large outdoor PLY (≥1M splats and ≥2 axes >16 m) → toggle defaults ON; publish → `publishFormat: "ssog"`.
- [ ] Republish an existing scene with the toggle on → `PUT /splats/:id/republish` body carries `publishFormat: "ssog"`.
- [ ] Toggle off on a large scene before publishing → request still sends `"sog"`.
- [ ] Republish animation-only (Override Model off) → `Generate LODs` row is hidden.
- [ ] Switch UI language → label renders the localized string.