### PR TITLE
Use splat hashes for editor overwrite and publish flows

### DIFF
--- a/src/publish.ts
+++ b/src/publish.ts
@@ -44,7 +44,6 @@ type User = {
 };
 
 type Scene = {
-    id: string;
     hash: string;
     title: string;
     description: string;
@@ -63,7 +62,6 @@ type PublishSettings = {
     listed: boolean;
     serializeSettings: SerializeSettings;
     experienceSettings: ExperienceSettings;
-    overwriteId?: string;
     overwriteHash?: string;
     overrideModel?: boolean;
     overrideAnimation?: boolean;
@@ -97,8 +95,8 @@ const fetchSceneList = async (user: User) => {
     return (await response.json()).result as Scene[];
 };
 
-const fetchSceneSettings = async (user: User, sceneId: string): Promise<ExperienceSettings> => {
-    const response = await fetch(`${user.apiServer}/splats/${sceneId}/settings`, {
+const fetchSceneSettings = async (user: User, sceneHash: string): Promise<ExperienceSettings> => {
+    const response = await fetch(`${user.apiServer}/splats/${sceneHash}/settings`, {
         method: 'GET',
         headers: {
             'Authorization': `Bearer ${user.token}`
@@ -110,8 +108,8 @@ const fetchSceneSettings = async (user: User, sceneId: string): Promise<Experien
     return await response.json() as ExperienceSettings;
 };
 
-const updateSceneSettings = async (user: User, sceneId: string, settings: ExperienceSettings) => {
-    const response = await fetch(`${user.apiServer}/splats/${sceneId}/settings`, {
+const updateSceneSettings = async (user: User, sceneHash: string, settings: ExperienceSettings) => {
+    const response = await fetch(`${user.apiServer}/splats/${sceneHash}/settings`, {
         method: 'PUT',
         body: JSON.stringify(settings),
         headers: {
@@ -267,7 +265,7 @@ class PublishWriter implements Writer {
                 }
             });
 
-            const doRepublish = () => fetch(`${user.apiServer}/splats/${publishSettings.overwriteId}/republish`, {
+            const doRepublish = () => fetch(`${user.apiServer}/splats/${publishSettings.overwriteHash}/republish`, {
                 method: 'PUT',
                 body: JSON.stringify({
                     s3Key: startJson.key,
@@ -281,7 +279,7 @@ class PublishWriter implements Writer {
                 }
             });
 
-            const publishResponse = await (publishSettings.overwriteId ? doRepublish() : doPublish());
+            const publishResponse = await (publishSettings.overwriteHash ? doRepublish() : doPublish());
 
             if (!publishResponse.ok) {
                 let msg;
@@ -326,7 +324,7 @@ const registerPublishEvents = (events: Events) => {
                 setTimeout(resolve, 10);
             });
 
-            const { overwriteId, overwriteHash, overrideAnimation } = publishSettings;
+            const { overwriteHash, overrideAnimation } = publishSettings;
             const overrideModel = publishSettings.overrideModel ?? true;
 
             const mergeAnimation = (target: ExperienceSettings, source: ExperienceSettings) => {
@@ -334,15 +332,15 @@ const registerPublishEvents = (events: Events) => {
                 target.startMode = source.startMode;
             };
 
-            if (overwriteId && !overrideModel) {
+            if (overwriteHash && !overrideModel) {
                 if (!overrideAnimation) {
                     throw new Error('No overrides selected');
                 }
 
                 // animation-only update: fetch existing settings, merge animation, PUT settings
-                const existingSettings = await fetchSceneSettings(publishSettings.user, overwriteId);
+                const existingSettings = await fetchSceneSettings(publishSettings.user, overwriteHash);
                 mergeAnimation(existingSettings, publishSettings.experienceSettings);
-                await updateSceneSettings(publishSettings.user, overwriteId, existingSettings);
+                await updateSceneSettings(publishSettings.user, overwriteHash, existingSettings);
 
                 await events.invoke('showPopup', {
                     type: 'info',
@@ -352,9 +350,9 @@ const registerPublishEvents = (events: Events) => {
                 });
             } else {
                 // new scene or model override: upload PLY and publish/republish
-                if (overwriteId) {
+                if (overwriteHash) {
                     // republishing with model override: merge with existing settings
-                    const existingSettings = await fetchSceneSettings(publishSettings.user, overwriteId);
+                    const existingSettings = await fetchSceneSettings(publishSettings.user, overwriteHash);
                     if (overrideAnimation) {
                         mergeAnimation(existingSettings, publishSettings.experienceSettings);
                     }

--- a/src/ui/publish-settings-dialog.ts
+++ b/src/ui/publish-settings-dialog.ts
@@ -389,7 +389,6 @@ class PublishSettingsDialog extends Container {
                         listed: false,
                         serializeSettings,
                         experienceSettings,
-                        overwriteId: selectedScene?.id,
                         overwriteHash: selectedScene?.hash,
                         overrideModel: isNew || overrideModelToggle.value,
                         overrideAnimation: !isNew && overrideAnimationToggle.value,


### PR DESCRIPTION
## Summary
- Remove editor reliance on internal splat ids for overwrite, settings, and republish flows
- Use `hash` consistently when loading existing scene settings and republishing
- Stop passing `overwriteId` through the publish settings dialog

## Testing
- `npm run lint` passed
- `npm run build` passed