### PR TITLE
Fix mouse-wheel zoom misclassification in camera controls

### DIFF
--- a/src/controllers.ts
+++ b/src/controllers.ts
@@ -224,51 +224,35 @@ class PointerController {
             }
         };
 
-        // Distinguish a physical mouse wheel from a trackpad two-finger
-        // scroll. A single wheel event is unreliable (Magic Mouse, hi-res
-        // mice, and macOS Shift-remapping all confuse per-event heuristics),
-        // so we classify on the first event of a burst and let the rest of
-        // the burst inherit that label. A burst is a run of wheel events
-        // separated by less than BURST_GAP_MS - trackpads stream at ~60Hz
-        // (~16ms), wheels emit one event per notch (typically >>50ms apart).
-        const BURST_GAP_MS = 80;
-        let lastWheelTime = -Infinity;
-        let burstIsWheel = false;
+        // A physical mouse wheel and a trackpad two-finger swipe are
+        // indistinguishable from their wheel-event deltas alone - every
+        // per-event heuristic (wheelDelta % 120, deltaMode, fractional or
+        // diagonal deltas) misfires on hi-res mice and in momentum tails
+        // (see issue #919). The one reliable trackpad signal the platform
+        // gives us is the macOS-synthesized pinch: a wheel event with
+        // ctrlKey set while the physical Ctrl key is *not* held. So we no
+        // longer classify the device and instead drive everything from
+        // modifier keys, treating a bare scroll as zoom regardless of device:
+        //
+        // | Input                       | Action |
+        // |-----------------------------|--------|
+        // | Bare scroll (wheel / swipe) | zoom   |
+        // | Pinch (synthetic Ctrl)      | zoom   |
+        // | Physical Ctrl + scroll      | orbit  |
+        // | Shift + scroll              | pan    |
 
-        const classifyWheel = (event: WheelEvent) => {
-            // Firefox: physical wheels report line/page mode; trackpads report
-            // pixel mode. Firefox doesn't expose wheelDelta* so this is the
-            // only reliable signal on Firefox.
-            if (event.deltaMode !== WheelEvent.DOM_DELTA_PIXEL) {
-                return true;
-            }
-            // Chrome / Safari: the non-standard wheelDelta{X,Y} properties
-            // preserve the raw wheel-tick value (always multiples of ±120 per
-            // notch) regardless of macOS scroll smoothing applied to
-            // delta{X,Y}. Trackpads and Magic Mouse emit arbitrary values
-            // that are essentially never aligned to 120.
-            const e = event as WheelEvent & { wheelDeltaX?: number, wheelDeltaY?: number };
-            if (typeof e.wheelDeltaY === 'number' && e.wheelDeltaY !== 0) {
-                return e.wheelDeltaY % 120 === 0;
-            }
-            if (typeof e.wheelDeltaX === 'number' && e.wheelDeltaX !== 0) {
-                return e.wheelDeltaX % 120 === 0;
-            }
-            // Last-resort fallback for browsers without wheelDelta*.
-            const { deltaX, deltaY } = event;
-            if (deltaX !== 0 && deltaY !== 0) {
-                return false;
-            }
-            return Number.isInteger(deltaX) && Number.isInteger(deltaY);
+        // Track the physical Ctrl key so we can tell a real Ctrl+scroll
+        // (orbit) from a macOS pinch (zoom). Listeners live on window so they
+        // fire regardless of which element currently has focus.
+        let ctrlDown = false;
+        const keydown = (event: KeyboardEvent) => {
+            if (event.key === 'Control') ctrlDown = true;
+        };
+        const keyup = (event: KeyboardEvent) => {
+            if (event.key === 'Control') ctrlDown = false;
         };
 
         const wheel = (event: WheelEvent) => {
-            const now = performance.now();
-            if (now - lastWheelTime > BURST_GAP_MS) {
-                burstIsWheel = classifyWheel(event);
-            }
-            lastWheelTime = now;
-
             const { deltaX, deltaY } = event;
 
             // Some browsers (notably Safari/Firefox on macOS) remap a vertical
@@ -278,22 +262,33 @@ class PointerController {
             // zoom / fly movement.
             const wheelDelta = event.shiftKey && deltaY === 0 ? deltaX : deltaY;
 
+            // Synthetic Ctrl (macOS/Magic Mouse pinch) or Cmd: fine zoom.
+            // Physical Ctrl held down: orbit.
+            const isPinch = (event.ctrlKey && !ctrlDown) || event.metaKey;
+            const isOrbit = event.ctrlKey && ctrlDown;
+
             if (camera.controlMode === 'fly') {
-                // Fly mode: wheel moves forward/backward by moving focal point
-                const factor = camera.flySpeed * 0.01;
-                const worldTransform = camera.mainCamera.getWorldTransform();
-                const zAxis = worldTransform.getZ();
-                moveVec.copy(zAxis).mulScalar(wheelDelta * factor);
-                const p = camera.focalPoint.add(moveVec);
-                camera.setFocalPoint(p);
-            } else if (burstIsWheel) {
-                zoom(wheelDelta * -0.002);
-            } else if (event.ctrlKey || event.metaKey) {
-                zoom(deltaY * -0.02);
+                if (isOrbit) {
+                    look(deltaX, deltaY);
+                } else if (event.shiftKey) {
+                    pan(event.offsetX, event.offsetY, deltaX, deltaY);
+                } else {
+                    // Bare scroll / pinch: move focal point forward/backward
+                    const factor = camera.flySpeed * 0.01;
+                    const worldTransform = camera.mainCamera.getWorldTransform();
+                    const zAxis = worldTransform.getZ();
+                    moveVec.copy(zAxis).mulScalar(wheelDelta * factor);
+                    const p = camera.focalPoint.add(moveVec);
+                    camera.setFocalPoint(p);
+                }
+            } else if (isOrbit) {
+                orbit(deltaX, deltaY);
             } else if (event.shiftKey) {
                 pan(event.offsetX, event.offsetY, deltaX, deltaY);
+            } else if (isPinch) {
+                zoom(deltaY * -0.02);
             } else {
-                orbit(deltaX, deltaY);
+                zoom(wheelDelta * -0.002);
             }
 
             event.preventDefault();
@@ -334,6 +329,7 @@ class PointerController {
             flyUp = false;
             fastDown = false;
             slowDown = false;
+            ctrlDown = false;
         };
 
         // Helper to switch to fly mode when a fly key is pressed
@@ -450,8 +446,15 @@ class PointerController {
         wrap(target, 'dblclick', dblclick);
         wrap(window, 'blur', clearAllKeys);
 
+        // Registered directly (not via wrap) so physical-Ctrl tracking
+        // doesn't fire camera.controller on every keystroke.
+        window.addEventListener('keydown', keydown);
+        window.addEventListener('keyup', keyup);
+
         this.destroy = () => {
             destroy?.();
+            window.removeEventListener('keydown', keydown);
+            window.removeEventListener('keyup', keyup);
             events.off('camera.fly.forward', onFlyForward);
             events.off('camera.fly.backward', onFlyBackward);
             events.off('camera.fly.left', onFlyLeft);

--- a/src/controllers.ts
+++ b/src/controllers.ts
@@ -447,14 +447,18 @@ class PointerController {
         wrap(window, 'blur', clearAllKeys);
 
         // Registered directly (not via wrap) so physical-Ctrl tracking
-        // doesn't fire camera.controller on every keystroke.
-        window.addEventListener('keydown', keydown);
-        window.addEventListener('keyup', keyup);
+        // doesn't fire camera.controller on every keystroke. Capture phase
+        // ensures we see Ctrl keydown/keyup even when a focused UI element
+        // (dialogs, popups) calls stopPropagation() on key events - otherwise
+        // ctrlDown could go stale and a real Ctrl+wheel would be misread as a
+        // synthetic-Ctrl pinch.
+        window.addEventListener('keydown', keydown, { capture: true });
+        window.addEventListener('keyup', keyup, { capture: true });
 
         this.destroy = () => {
             destroy?.();
-            window.removeEventListener('keydown', keydown);
-            window.removeEventListener('keyup', keyup);
+            window.removeEventListener('keydown', keydown, { capture: true });
+            window.removeEventListener('keyup', keyup, { capture: true });
             events.off('camera.fly.forward', onFlyForward);
             events.off('camera.fly.backward', onFlyBackward);
             events.off('camera.fly.left', onFlyLeft);


### PR DESCRIPTION
## Summary

Replaces the stateful, burst-based device classifier in the camera controller's wheel handler with a modifier-key-only model, mirroring the approach already shipped in supersplat-viewer. The previous classifier tried to distinguish a physical mouse wheel from a trackpad two-finger swipe using per-event heuristics (`wheelDelta % 120`, `deltaMode`, fractional/diagonal deltas), but hi-res mice emit smooth deltas that are indistinguishable from a trackpad. On the reporter's Logitech G502 X (Windows 11), a bare wheel was misclassified as a trackpad ~95% of the time and fell through to the `orbit` branch instead of zooming. The same misfire was reported on Windows Edge.

## Root cause

A bare wheel event and a bare trackpad swipe carry no reliable signal that tells them apart — every delta-based heuristic misfires on some hardware or in momentum tails. The old code's `else` fallback was `orbit(deltaX, deltaY)`, so any wheel that failed the "is this a mouse?" check orbited.

## Approach

The one trackpad signal the platform reliably provides is the macOS/Magic-Mouse pinch: a wheel event with `ctrlKey` set while the physical Ctrl key is *not* held (synthetic Ctrl). So we stop classifying the device entirely and drive everything from modifier keys, treating a bare scroll as zoom regardless of input device.

To tell a synthetic-Ctrl pinch from a user physically holding Ctrl while scrolling, we track the physical Ctrl key with `keydown`/`keyup` listeners on `window` (cleared on blur and on destroy). These are registered directly rather than through the `wrap` helper, so Ctrl tracking does not fire `camera.controller` on every keystroke.

## Input mapping: old vs new

### Orbit mode

| Input | Old | New |
|---|---|---|
| Mouse wheel (classified as wheel) | zoom | zoom |
| Trackpad two-finger swipe (classified as trackpad) | **orbit** | **zoom** |
| Hi-res mouse wheel misclassified as trackpad | **orbit** (bug) | **zoom** (fixed) |
| Pinch (synthetic Ctrl) | zoom | zoom |
| Cmd + scroll | zoom | zoom |
| Physical Ctrl + scroll | zoom | **orbit** |
| Shift + scroll | pan | pan |

### Fly mode

| Input | Old | New |
|---|---|---|
| Bare scroll / pinch | dolly along view Z | dolly along view Z |
| Physical Ctrl + scroll | dolly along view Z | **look** |
| Shift + scroll | dolly along view Z | **pan** |

The Shift-remap workaround (reading `deltaX` when macOS maps a Shift+wheel to `deltaY === 0`) is preserved.

## Trade-off

A bare macOS trackpad two-finger swipe now zooms instead of orbiting; trackpad orbit moves to Ctrl + swipe. This is unavoidable — a bare wheel and a bare swipe are physically indistinguishable, so fixing mouse-wheel zoom necessarily changes bare-swipe behavior. This matches the resolution already adopted in supersplat-viewer and the tension noted by the maintainer in the issue thread.

## Test plan

Verified at runtime by dispatching synthetic wheel events against the live editor canvas and reading camera state before/after:

- [x] Bare wheel → distance changes, azim/elevation unchanged (zoom)
- [x] Synthetic-Ctrl pinch (ctrlKey, no physical Ctrl) → zoom
- [x] Physical Ctrl held + scroll → azim/elevation change (orbit)
- [x] Shift + scroll → focal point moves (pan)
- [x] Ctrl keyup resets tracking → a subsequent ctrlKey wheel is treated as pinch/zoom again
- [x] `tsc --noEmit` and `eslint` clean, no console errors