### PR TITLE
Fix empty HTML/SOG export by forcing splat-transform's worker pool inline

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -1,4 +1,4 @@
-import { WebPCodec } from '@playcanvas/splat-transform';
+import { WebPCodec, WorkerQueue } from '@playcanvas/splat-transform';
 import { Color, createGraphicsDevice } from 'playcanvas';
 
 import { registerCameraPosesEvents } from './camera-poses';
@@ -98,6 +98,12 @@ const main = async () => {
 
     // Configure WebP WASM for SOG format (used for both reading and writing)
     WebPCodec.wasmUrl = new URL('static/lib/webp/webp.wasm', document.baseURI).toString();
+
+    // Run SOG writing inline rather than in worker threads. We don't ship
+    // splat-transform's worker.mjs, so leaving the pool enabled makes it try to
+    // spawn a worker that 404s; under SOG's parallel task load it then hangs
+    // instead of falling back, producing an empty export.
+    WorkerQueue.maxWorkers = 0;
 
     // register events that only need the events object (before UI is created)
     registerTimelineEvents(events);


### PR DESCRIPTION
## Problem

After updating to `@playcanvas/splat-transform@2.7.1` and `playcanvas@2.20.2` (#929), HTML and ZIP viewer export stopped working: the output file and its `.crswap` temp were created on disk but **0 bytes were written**, with no error dialog. Plain SOG export was affected too, since all three share the same write path.

## Root cause

splat-transform 2.6.0 ("Parallelize SOG writing with a cross-platform worker pool") rewired `writeSog` to offload `runQuantize1d` / `runEncodeWebp` onto a `WorkerQueue`. Our 2.5.1 → 2.7.1 bump crossed that change (`writeHtml` itself is unchanged between the two versions).

In the published build the pool is **not** inline by default (`WorkerQueue.isInline` is `false`). We never configure it for our browser bundle — `main.ts` only sets `WebPCodec.wasmUrl` — so the pool tries to spawn `new URL('./worker.mjs', import.meta.url)`, which resolves next to our bundle and 404s (we don't ship that worker). A single failed-worker task falls back to inline correctly, but under the **parallel** task load that real SOG writing generates, the pool hangs instead of falling back — so `writeSog` never completes and nothing is written.

## Fix

Force SOG writing to run inline (the pre-2.6.0 behavior), alongside the existing `WebPCodec` config in `main.ts`:

```ts
import { WebPCodec, WorkerQueue } from '@playcanvas/splat-transform';
...
WorkerQueue.maxWorkers = 0;
```

With the pool disabled, no worker spawn is attempted and writes run on the calling thread, exactly as in 2.5.1.

## Verification

- `tsc --noEmit` passes.
- Reproduced the hang directly against the installed 2.7.1: 16 parallel quantize tasks with an unreachable worker hang before the change, and complete inline (16/16) with `maxWorkers = 0`.

## Notes / follow-ups

- Trade-off: SOG writing in the editor is serial again (no worker parallelism). To restore it later, ship splat-transform's `worker.mjs` as a static asset and set `WorkerQueue.workerUrl` to it.
- Latent splat-transform bug (out of scope here): `WorkerQueue` hangs under parallel load when workers can't spawn, rather than degrading to inline. Forcing inline sidesteps it, but it would bite any browser consumer that enables the pool without shipping the worker.