### PR TITLE
Add Backspace to remove last point and Enter to close polygon select

### DIFF
--- a/src/editor.ts
+++ b/src/editor.ts
@@ -536,6 +536,10 @@ const registerEditorEvents = (events: Events, editHistory: EditHistory, scene: S
         if (events.invoke('tool.active') === 'measure') {
             return;
         }
+        // Don't delete gaussians while a polygon selection is in progress (backspace removes the last point instead)
+        if (events.invoke('polygonSelection.removeLastPoint')) {
+            return;
+        }
         selectedSplats().forEach((splat) => {
             editHistory.add(new DeleteSelectionOp(splat));
         });

--- a/src/tools/polygon-selection.ts
+++ b/src/tools/polygon-selection.ts
@@ -22,6 +22,7 @@ class PolygonSelection {
 
         let points: Point[] = [];
         let currentPoint: Point = null;
+        let active = false;
 
         const dist = (a: Point, b: Point) => {
             return Math.sqrt((a.x - b.x) ** 2 + (a.y - b.y) ** 2);
@@ -36,7 +37,7 @@ class PolygonSelection {
             polyline.setAttribute('stroke', isClosed() ? '#fa6' : '#f60');
         };
 
-        const commitSelection = async (e: MouseEvent) => {
+        const commitSelection = async (e: MouseEvent | KeyboardEvent) => {
             // initialize canvas
             if (canvas.width !== parent.clientWidth || canvas.height !== parent.clientHeight) {
                 canvas.width = parent.clientWidth;
@@ -109,23 +110,49 @@ class PolygonSelection {
             }
         };
 
+        const keydown = (e: KeyboardEvent) => {
+            // ignore when focus is elsewhere (input fields, modals, etc.)
+            if (e.target !== document.body) return;
+
+            if (e.key === 'Enter' && points.length > 2) {
+                e.preventDefault();
+                e.stopPropagation();
+                commitSelection(e);
+            }
+        };
+
+        // remove the last placed point, returning whether a point was removed
+        events.function('polygonSelection.removeLastPoint', () => {
+            if (active && points.length > 0) {
+                points.pop();
+                paint();
+                return true;
+            }
+            return false;
+        });
+
         this.activate = () => {
+            active = true;
             svg.classList.remove('hidden');
             parent.style.display = 'block';
             parent.addEventListener('pointerdown', pointerdown);
             parent.addEventListener('pointermove', pointermove);
             parent.addEventListener('pointerup', pointerup);
             parent.addEventListener('dblclick', dblclick);
+            // capture phase so enter commits the polygon before the shortcut handlers run
+            document.addEventListener('keydown', keydown, true);
         };
 
         this.deactivate = () => {
             // cancel active operation
+            active = false;
             svg.classList.add('hidden');
             parent.style.display = 'none';
             parent.removeEventListener('pointerdown', pointerdown);
             parent.removeEventListener('pointermove', pointermove);
             parent.removeEventListener('pointerup', pointerup);
             parent.removeEventListener('dblclick', dblclick);
+            document.removeEventListener('keydown', keydown, true);
             points = [];
             paint();
         };

--- a/src/tools/polygon-selection.ts
+++ b/src/tools/polygon-selection.ts
@@ -117,7 +117,10 @@ class PolygonSelection {
             if (e.key === 'Enter' && points.length > 2) {
                 e.preventDefault();
                 e.stopPropagation();
-                commitSelection(e);
+                // ignore held-key repeats so a single commit runs at a time
+                if (!e.repeat) {
+                    commitSelection(e);
+                }
             }
         };
 


### PR DESCRIPTION
Fixes #845

## What

While drawing a polygon selection:

- **Backspace / Delete** removes the most recently placed point, so a misplaced click no longer forces restarting the whole polygon.
- **Enter** closes and commits the polygon (requires 3+ points), joining the two existing completion methods (clicking the first point, double-click). Shift+Enter adds to the selection and Ctrl+Enter removes from it, same as the pointer-based modifiers.

This follows the convention of other popular apps: Photoshop''s Polygonal Lasso, GIMP''s Free Select, and Illustrator/Inkscape''s pen tools all use Backspace/Delete to remove the last anchor point, and Photoshop closes on Enter.

## How

- `polygon-selection.ts` registers a `polygonSelection.removeLastPoint` event function that pops the last point (returning whether it did), and adds a capture-phase `keydown` listener while the tool is active to handle Enter — capture so it consumes the key before the shortcut framework fires `track.addKey`.
- The `select.delete` handler in `editor.ts` first invokes `polygonSelection.removeLastPoint` and bails if a point was removed, mirroring the existing measure-tool guard. When no polygon is in progress, Backspace/Delete deletes the selected gaussians exactly as before — the common polygon-select-then-Delete workflow is preserved.
- Deletion is delegated through a single invoke (rather than the tool listening to `select.delete` itself) so that popping the final point can''t race the editor''s guard and delete the selection on the same keypress.

## Testing

Verified in the browser against the guitar sample scene:

- Backspace pops points one at a time down to zero, with all 90k splats selected, without deleting any gaussians.
- With no polygon in progress, Backspace/Delete still deletes the selected gaussians.
- Enter commits with 3+ points and selects the enclosed gaussians; Shift+Enter adds to an existing selection. Enter with fewer than 3 points does nothing and still reaches the timeline add-key shortcut.
- Existing completion paths (click first point, double-click) and the measure tool''s Backspace behavior are unchanged.
- `npm run lint` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)