### PR TITLE
Fix LCC import filter showing *.com and *.exe on Windows

### DIFF
--- a/src/file-handler.ts
+++ b/src/file-handler.ts
@@ -54,8 +54,7 @@ const filePickerTypes: { [key: string]: FilePickerAcceptType } = {
     'lcc': {
         description: 'LCC Scene',
         accept: {
-            'application/json': ['.lcc'],
-            'application/octet-stream': ['.bin']
+            'application/x-lcc': ['.lcc', '.bin']
         }
     },
     'splat': {
@@ -102,8 +101,7 @@ const allImportTypes = {
         'application/ply': ['.ply'],
         'application/x-gaussian-splat': ['.json', '.sog', '.splat', '.ksplat', '.spz'],
         'image/webp': ['.webp'],
-        'application/json': ['.lcc'],
-        'application/octet-stream': ['.bin'],
+        'application/x-lcc': ['.lcc', '.bin'],
         'text/plain': ['.txt']
     }
 };


### PR DESCRIPTION
## Problem

On Windows, File > Import shows the file type filter:

> LCC Scene (*.lcc, *.bin, *.json, *.com, *.exe)

The `.json`, `.com` and `.exe` entries are wrong (and look alarming).

## Cause

The LCC entry passed to `showOpenFilePicker` used standard MIME types:

```ts
accept: {
    'application/json': ['.lcc'],
    'application/octet-stream': ['.bin']
}
```

Chromium expands each MIME type in `accept` to its known extensions *in addition to* the explicitly listed ones, and it hard-codes `application/octet-stream → .com, .exe, .bin` (and `application/json → .json`). Every other format in `file-handler.ts` avoids this by using custom MIME types (`application/x-gaussian-splat`, `application/ply`).

## Fix

Use a custom `application/x-lcc` MIME type for `.lcc`/`.bin` in both the `LCC Scene` filter and the combined `Supported Files` filter. The filter now reads **LCC Scene (*.lcc, *.bin)**, and `Supported Files` no longer lists `*.com`/`*.exe` (`.json` still appears there via the SOG entry, as intended).

The MIME keys are only used to build the picker filter — import dispatch is by filename — so no loading behavior changes.

## Verification

- Stubbed `window.showOpenFilePicker` in the running app and triggered File > Import: the picker receives `LCC Scene → { "application/x-lcc": [".lcc", ".bin"] }` and the cleaned-up `Supported Files` map.
- `npm run lint` and build pass; no console errors on load.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
