### PR TITLE
Fix stale selection mode comment in intersection shader

### DIFF
--- a/src/shaders/intersection-shader.ts
+++ b/src/shaders/intersection-shader.ts
@@ -16,7 +16,7 @@ const fragmentShader = /* glsl */ `
 
     uniform uvec2 output_params;                    // output width, height
 
-    // 0: mask, 1: rect, 2: sphere
+    // 0: mask, 1: rect, 2: sphere, 3: box
     uniform int mode;
 
     // mask params


### PR DESCRIPTION
## What

One-line comment fix in `src/shaders/intersection-shader.ts`: the `mode` uniform comment listed only `0: mask, 1: rect, 2: sphere` — box (mode 3) was added in #472 without updating it.

## Why

Follow-up spotted while reviewing/verifying #904 (the fix for #843). Comment-only, no behavior change — the compiled shader is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)