### PR TITLE
Fix mousewheel scrolling breaking over rows in the keyboard shortcuts popup

### DIFF
--- a/src/ui/scss/style.scss
+++ b/src/ui/scss/style.scss
@@ -30,9 +30,7 @@
     user-select: none;
 }
 
-// viewport only - on '*' this hits overflow:hidden elements (e.g. pcui-label),
-// which are scroll containers, so wheel events die there instead of chaining
-// up to the nearest scrollable ancestor
+// not on '*' - that breaks wheel scrolling over overflow:hidden elements (e.g. pcui labels)
 html {
     height: 100%;
     overscroll-behavior: none;

--- a/src/ui/scss/style.scss
+++ b/src/ui/scss/style.scss
@@ -28,11 +28,14 @@
 * {
     font-size: 12px;
     user-select: none;
-    overscroll-behavior: none;
 }
 
+// viewport only - on '*' this hits overflow:hidden elements (e.g. pcui-label),
+// which are scroll containers, so wheel events die there instead of chaining
+// up to the nearest scrollable ancestor
 html {
     height: 100%;
+    overscroll-behavior: none;
 }
 
 body {
@@ -43,6 +46,7 @@ body {
     background-color: black;
     overflow: hidden;
     touch-action: none;
+    overscroll-behavior: none;
 }
 
 #app-container {


### PR DESCRIPTION
## Bug

Repro:
1. Open **Help > Keyboard Shortcuts**
2. Scroll the panel with the mousewheel — works
3. Hover a shortcut row (it highlights) — the mousewheel now does nothing

## Root cause

`overscroll-behavior: none` is applied to **every element** via the universal `*` selector (added in #274 to stop touchpad overscroll/back-navigation gestures).

PCUI styles every `Label` with `overflow: hidden`, which makes labels *scroll containers*. `overscroll-behavior: none` on a scroll container prevents scroll chaining past it — so a wheel event targeting a label is consumed by the label instead of chaining up to the scrollable `#content`. The key/action labels cover virtually the entire shortcut row, so wheel input dies anywhere over a row.

It only *looks* hover-triggered: Chrome latches the scroll target when a wheel gesture starts, so a gesture begun over the padding or a category header keeps scrolling even as rows pass under the cursor — but the next gesture begun over a row goes nowhere.

## Fix

Scope `overscroll-behavior: none` to `html`/`body` instead of `*`. The viewport is all #274 needed: `body` is `overflow: hidden`, so no scroll can chain past it, and the viewport still refuses overscroll/navigation gestures.

This also fixes the same latent issue in every other scrollable region where labels sit under the cursor (export popup, publish dialog, scene manager list, etc.).

## Notes for reviewers

Verified in the running app: row labels now compute `overscroll-behavior: auto` (while remaining `overflow: hidden`), and `html`/`body` still compute `none`, so the touchpad-gesture fix from #274 is preserved. Manual check: wheel over a highlighted row now scrolls the panel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)