### PR TITLE
Fix camera not returning to pose when timeline has a single key

### DIFF
--- a/src/camera-poses.ts
+++ b/src/camera-poses.ts
@@ -237,6 +237,14 @@ class CameraAnimTrack implements AnimTrack {
                 pose.fov = result[6];
                 this.events.fire('camera.setPose', pose, 0);
             };
+        } else if (orderedPoses.length === 1) {
+            // a single key can't form a spline; hold its pose at every frame
+            const p = orderedPoses[0];
+            const pose = { position: p.position.clone(), target: p.target.clone(), fov: p.fov };
+
+            this.onTimelineChange = () => {
+                this.events.fire('camera.setPose', pose, 0);
+            };
         } else {
             this.onTimelineChange = null;
         }


### PR DESCRIPTION
## Summary

One item from #804: *"When defining only one frame, it is not possible to jump back to that position."*

With fewer than two keys, `rebuildSpline()` left the track's evaluate callback `null`, so scrubbing and prev/next-key navigation never re-applied the lone pose. A single key now holds its pose at every frame, consistent with how the spline drives the camera once two or more keys exist.

## Test Plan

- [x] Add a single keyframe, orbit the camera away, scrub the timeline (or Shift+prev) → camera returns to the keyed pose
- [x] Change total frames with one key → camera snaps once, remains controllable
- [x] Two or more keys → interpolation unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)