### PR TITLE
Fix dead mouse-wheel zoom in fly mode with orthographic projection

### DIFF
--- a/src/controllers.ts
+++ b/src/controllers.ts
@@ -274,8 +274,9 @@ class PointerController {
                     pan(event.offsetX, event.offsetY, deltaX, deltaY);
                 } else if (camera.ortho) {
                     // moving forward/backward has no visual effect in ortho
-                    // (ortho height derives from distance), so zoom instead
-                    zoom(wheelDelta * -0.002);
+                    // (ortho height derives from distance), so zoom instead,
+                    // with the same pinch/scroll factors as the orbit path
+                    zoom(isPinch ? deltaY * -0.02 : wheelDelta * -0.002);
                 } else {
                     // Bare scroll / pinch: move focal point forward/backward
                     const factor = camera.flySpeed * 0.01;

--- a/src/controllers.ts
+++ b/src/controllers.ts
@@ -272,6 +272,10 @@ class PointerController {
                     look(deltaX, deltaY);
                 } else if (event.shiftKey) {
                     pan(event.offsetX, event.offsetY, deltaX, deltaY);
+                } else if (camera.ortho) {
+                    // moving forward/backward has no visual effect in ortho
+                    // (ortho height derives from distance), so zoom instead
+                    zoom(wheelDelta * -0.002);
                 } else {
                     // Bare scroll / pinch: move focal point forward/backward
                     const factor = camera.flySpeed * 0.01;


### PR DESCRIPTION
## Summary

Bug from #804: *"When in fly-mode and switching to orthogonal projection, the mouse-wheel zoom doesn't work."*

In fly mode a bare wheel scroll moves the focal point along the camera Z axis. Under orthographic projection that has no visual effect, because ortho height derives solely from the camera distance — so the wheel appeared dead. Route the bare wheel to distance zoom when ortho is active, matching orbit-mode behavior. Fly + perspective is untouched.

This is also an alternative resolution to #761 ("disable fly mode when switching to ortho") that keeps fly mode usable in ortho instead of removing it — happy to switch approach if disabling is preferred.

Touch pinch in fly mode has the same ortho deadness (`controllers.ts` `ontouchmove`); can follow up with the same pattern if wanted.

## Test Plan

Getting into the fly + ortho state (the only state this PR changes) is easy to miss:
- Ortho has no dedicated toggle — click an axis ball on the **view cube** (top right) to enter it.
- The view cube does **not** change control mode; enter fly with **V** or by pressing a fly key (W/A/S/D).
- Rotating the camera (orbit drag, or look-drag in fly) intentionally returns to perspective (`Camera.setAzimElev`), so don't rotate mid-test or you'll silently leave ortho.

Steps:
- [x] Click a view cube axis (→ ortho), press **V** (→ fly), bare wheel scroll → view zooms. On main the wheel does nothing here.
- [x] Left-drag to look around (returns to perspective by design) → wheel resumes flying forward/backward
- [x] Orbit mode wheel zoom unchanged, in both perspective and ortho

🤖 Generated with [Claude Code](https://claude.com/claude-code)