### PR TITLE
Use nice-number steps for timeline frame labels, add minor ticks

### DIFF
--- a/src/ui/scss/timeline-panel.scss
+++ b/src/ui/scss/timeline-panel.scss
@@ -98,6 +98,16 @@
             width: 100%;
             height: 100%;
 
+            > .time-tick {
+                position: absolute;
+                bottom: 1px;
+                width: 1px;
+                height: 5px;
+                transform: translate(-50%, 0);
+                background-color: $clr-disabled;
+                pointer-events: none;
+            }
+
             > .time-label {
                 position: absolute;
                 font-size: 12px;

--- a/src/ui/timeline-panel.ts
+++ b/src/ui/timeline-panel.ts
@@ -38,7 +38,7 @@ class Ticks extends Container {
             // 1/2/5 * 10^n series so labels land on round frame numbers
             const minStep = Math.max(1, numFrames / Math.max(1, Math.floor(width / 50)));
             const magnitude = 10 ** Math.floor(Math.log10(minStep));
-            const labelStep = [1, 2, 5, 10].map(m => m * magnitude).find(s => s >= minStep);
+            const labelStep = [1, 2, 5, 10].map(m => m * magnitude).find(s => s >= minStep) ?? 10 * magnitude;
 
             // subdivide labels with minor ticks (fifths, or halves for 1/2 steps)
             const tickStep = labelStep === 1 ? 0 : labelStep / (labelStep % 5 === 0 ? 5 : 2);

--- a/src/ui/timeline-panel.ts
+++ b/src/ui/timeline-panel.ts
@@ -33,8 +33,15 @@ class Ticks extends Container {
 
             const padding = 20;
             const width = this.dom.getBoundingClientRect().width - padding * 2;
-            const labelStep = Math.max(1, Math.floor(numFrames / Math.max(1, Math.floor(width / 50))));
-            const numLabels = Math.max(1, Math.ceil(numFrames / labelStep));
+
+            // round the smallest step that keeps labels ~50px apart up to the
+            // 1/2/5 * 10^n series so labels land on round frame numbers
+            const minStep = Math.max(1, numFrames / Math.max(1, Math.floor(width / 50)));
+            const magnitude = 10 ** Math.floor(Math.log10(minStep));
+            const labelStep = [1, 2, 5, 10].map(m => m * magnitude).find(s => s >= minStep);
+
+            // subdivide labels with minor ticks (fifths, or halves for 1/2 steps)
+            const tickStep = labelStep === 1 ? 0 : labelStep / (labelStep % 5 === 0 ? 5 : 2);
 
             const offsetFromFrame = (frame: number) => {
                 return padding + Math.floor(frame / (numFrames - 1) * width);
@@ -46,13 +53,25 @@ class Ticks extends Container {
 
             // timeline labels
 
-            for (let i = 0; i < numLabels; i++) {
-                const thisFrame = Math.floor(i * labelStep);
+            for (let frame = 0; frame < numFrames; frame += labelStep) {
                 const label = document.createElement('div');
                 label.classList.add('time-label');
-                label.style.left = `${offsetFromFrame(thisFrame)}px`;
-                label.textContent = thisFrame.toString();
+                label.style.left = `${offsetFromFrame(frame)}px`;
+                label.textContent = frame.toString();
                 workArea.dom.appendChild(label);
+            }
+
+            // minor ticks
+
+            if (tickStep > 0) {
+                for (let frame = tickStep; frame < numFrames; frame += tickStep) {
+                    if (frame % labelStep !== 0) {
+                        const tick = document.createElement('div');
+                        tick.classList.add('time-tick');
+                        tick.style.left = `${offsetFromFrame(frame)}px`;
+                        workArea.dom.appendChild(tick);
+                    }
+                }
             }
 
             // keys - get from active track


### PR DESCRIPTION
## Summary

One item from #804: *"Instead of the evenly spaced frame-numbers, I would like to see decimal-based framenumbers and show the intermediate steps with ticks."*

Frame labels were placed at an arbitrary width-derived interval, producing sequences like 0, 7, 14, 21… Round the interval up to the 1/2/5 × 10ⁿ series so labels land on round frame numbers, and render small unlabeled ticks between labels (fifths, or halves for steps of 1×/2×).

### Before

<img width="2560" height="144" alt="ticks-before" src="https://github.com/user-attachments/assets/6d247979-5531-4f72-a516-9c77eadb3efc" />

### After

<img width="2560" height="144" alt="ticks-after" src="https://github.com/user-attachments/assets/a3afa512-54e8-41bf-ac8c-4d3b3d90cbe3" />

## Test Plan

- [x] Frame counts 10 / 100 / 180 / 1000 / 10000 at several panel widths → labels land on 1/2/5×10ⁿ steps, ≥ ~50px apart
- [x] Minor ticks subdivide labels; none at step 1
- [x] Keys, cursor, scrubbing and drag interactions unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)