### PR TITLE
Add ctrl+click on a timeline key to overwrite it with the current view

### DIFF
--- a/src/ui/scss/timeline-panel.scss
+++ b/src/ui/scss/timeline-panel.scss
@@ -138,16 +138,18 @@
                     pointer-events: auto;
                 }
 
+                // declared before dragging/copying so those cursors win
+                // during a ctrl+drag
+                &.stamping {
+                    cursor: crosshair;
+                }
+
                 &.dragging {
                     cursor: ew-resize;
                 }
 
                 &.copying {
                     cursor: copy;
-                }
-
-                &.stamping {
-                    cursor: crosshair;
                 }
             }
         }

--- a/src/ui/scss/timeline-panel.scss
+++ b/src/ui/scss/timeline-panel.scss
@@ -135,6 +135,10 @@
                 &.copying {
                     cursor: copy;
                 }
+
+                &.stamping {
+                    cursor: crosshair;
+                }
             }
         }
     }

--- a/src/ui/timeline-panel.ts
+++ b/src/ui/timeline-panel.ts
@@ -232,6 +232,8 @@ class Ticks extends Container {
         window.addEventListener('keyup', onCtrlUp);
 
         this.on('destroy', () => {
+            keyElements.forEach(el => el.destroy());
+            keyElements = [];
             window.removeEventListener('keydown', onCtrlDown);
             window.removeEventListener('keyup', onCtrlUp);
         });

--- a/src/ui/timeline-panel.ts
+++ b/src/ui/timeline-panel.ts
@@ -63,6 +63,7 @@ class Ticks extends Container {
                 label.classList.add('time-label', 'key');
                 label.style.left = `${offsetFromFrame(keyFrame)}px`;
                 label.dataset.frame = keyFrame.toString();
+                label.title = i18n.t('tooltip.timeline.key');
                 let dragging = false;
                 let copying = false;
                 let clone: HTMLElement = null;
@@ -96,6 +97,9 @@ class Ticks extends Container {
                         } else {
                             label.style.left = `${offsetFromFrame(toFrame)}px`;
                         }
+                    } else {
+                        // hint that ctrl+click overwrites the key with the current pose
+                        label.classList.toggle('stamping', event.ctrlKey);
                     }
                 });
 
@@ -115,7 +119,11 @@ class Ticks extends Container {
 
                         label.releasePointerCapture(event.pointerId);
 
-                        if (fromFrame !== toFrame && toFrame >= 0) {
+                        if (event.ctrlKey && (toFrame < 0 || toFrame === fromFrame)) {
+                            // ctrl+click without dragging: overwrite this key
+                            // with the current camera pose
+                            events.fire('track.addKey', fromFrame);
+                        } else if (fromFrame !== toFrame && toFrame >= 0) {
                             if (copying) {
                                 events.fire('track.copyKey', fromFrame, toFrame);
                             } else {

--- a/src/ui/timeline-panel.ts
+++ b/src/ui/timeline-panel.ts
@@ -228,14 +228,19 @@ class Ticks extends Container {
             if (event.key === 'Control') updateStamping(false);
         };
 
+        // ctrl released while the window is unfocused never fires keyup
+        const onBlur = () => updateStamping(false);
+
         window.addEventListener('keydown', onCtrlDown);
         window.addEventListener('keyup', onCtrlUp);
+        window.addEventListener('blur', onBlur);
 
         this.on('destroy', () => {
             keyElements.forEach(el => el.destroy());
             keyElements = [];
             window.removeEventListener('keydown', onCtrlDown);
             window.removeEventListener('keyup', onCtrlUp);
+            window.removeEventListener('blur', onBlur);
         });
 
         // rebuild the timeline on dom resize

--- a/src/ui/timeline-panel.ts
+++ b/src/ui/timeline-panel.ts
@@ -220,12 +220,20 @@ class Ticks extends Container {
             if (down && hovered) hovered.classList.add('stamping');
         };
 
-        window.addEventListener('keydown', (event: KeyboardEvent) => {
-            if (event.key === 'Control') updateStamping(true);
-        });
+        const onCtrlDown = (event: KeyboardEvent) => {
+            if (event.key === 'Control' && !event.repeat) updateStamping(true);
+        };
 
-        window.addEventListener('keyup', (event: KeyboardEvent) => {
+        const onCtrlUp = (event: KeyboardEvent) => {
             if (event.key === 'Control') updateStamping(false);
+        };
+
+        window.addEventListener('keydown', onCtrlDown);
+        window.addEventListener('keyup', onCtrlUp);
+
+        this.on('destroy', () => {
+            window.removeEventListener('keydown', onCtrlDown);
+            window.removeEventListener('keyup', onCtrlUp);
         });
 
         // rebuild the timeline on dom resize

--- a/src/ui/timeline-panel.ts
+++ b/src/ui/timeline-panel.ts
@@ -1,4 +1,4 @@
-import { Button, Container, NumericInput, SelectInput } from '@playcanvas/pcui';
+import { Button, Container, Element, NumericInput, SelectInput } from '@playcanvas/pcui';
 
 import { Events } from '../events';
 import { ShortcutManager } from '../shortcut-manager';
@@ -23,9 +23,15 @@ class Ticks extends Container {
         let frameFromOffset: (offset: number) => number;
         let moveCursor: (frame: number) => void;
 
+        // pcui wrappers around key markers, kept so their tooltips unregister
+        // (via the destroy event) when the timeline is rebuilt
+        let keyElements: Element[] = [];
+
         // rebuild the timeline
         const rebuild = () => {
             // clear existing labels
+            keyElements.forEach(el => el.destroy());
+            keyElements = [];
             workArea.dom.innerHTML = '';
 
             const numFrames = events.invoke('timeline.frames');
@@ -82,7 +88,10 @@ class Ticks extends Container {
                 label.classList.add('time-label', 'key');
                 label.style.left = `${offsetFromFrame(keyFrame)}px`;
                 label.dataset.frame = keyFrame.toString();
-                label.title = i18n.t('tooltip.timeline.key');
+
+                const wrapper = new Element({ dom: label });
+                tooltips.register(wrapper, () => i18n.t('tooltip.timeline.key'), 'top');
+                keyElements.push(wrapper);
                 let dragging = false;
                 let copying = false;
                 let clone: HTMLElement = null;

--- a/src/ui/timeline-panel.ts
+++ b/src/ui/timeline-panel.ts
@@ -201,6 +201,24 @@ class Ticks extends Container {
             }
         });
 
+        // update the stamp cursor hint when ctrl changes while already
+        // hovering a key (pointermove alone misses a stationary pointer)
+        const updateStamping = (down: boolean) => {
+            const hovered = workArea.dom.querySelector('.key:hover');
+            workArea.dom.querySelectorAll('.key.stamping').forEach((el) => {
+                if (!down || el !== hovered) el.classList.remove('stamping');
+            });
+            if (down && hovered) hovered.classList.add('stamping');
+        };
+
+        window.addEventListener('keydown', (event: KeyboardEvent) => {
+            if (event.key === 'Control') updateStamping(true);
+        });
+
+        window.addEventListener('keyup', (event: KeyboardEvent) => {
+            if (event.key === 'Control') updateStamping(false);
+        });
+
         // rebuild the timeline on dom resize
         new ResizeObserver(() => rebuild()).observe(workArea.dom);
 

--- a/static/locales/de.json
+++ b/static/locales/de.json
@@ -287,6 +287,7 @@
     "tooltip.timeline.play": "Abspielen/Stoppen",
     "tooltip.timeline.add-key": "Key hinzufügen",
     "tooltip.timeline.remove-key": "Key entfernen",
+    "tooltip.timeline.key": "Ziehen zum Verschieben. Umschalt+Ziehen zum Kopieren. Strg+Klick übernimmt die aktuelle Ansicht.",
     "tooltip.timeline.frame-rate": "Bildrate",
     "tooltip.timeline.total-frames": "Gesamtanzahl der Frames",
     "tooltip.timeline.smoothness": "Weichheit",

--- a/static/locales/en.json
+++ b/static/locales/en.json
@@ -287,6 +287,7 @@
     "tooltip.timeline.play": "Play/Stop",
     "tooltip.timeline.add-key": "Add Key",
     "tooltip.timeline.remove-key": "Remove Key",
+    "tooltip.timeline.key": "Drag to move. Shift+drag to copy. Ctrl+click to set to current view.",
     "tooltip.timeline.frame-rate": "Frame Rate",
     "tooltip.timeline.total-frames": "Total Frames",
     "tooltip.timeline.smoothness": "Smoothness",

--- a/static/locales/es.json
+++ b/static/locales/es.json
@@ -287,6 +287,7 @@
     "tooltip.timeline.play": "Reproducir/Detener",
     "tooltip.timeline.add-key": "Añadir clave",
     "tooltip.timeline.remove-key": "Eliminar clave",
+    "tooltip.timeline.key": "Arrastra para mover. Mayús+arrastrar para copiar. Ctrl+clic para fijar la vista actual.",
     "tooltip.timeline.frame-rate": "Velocidad de fotogramas",
     "tooltip.timeline.total-frames": "Fotogramas totales",
     "tooltip.timeline.smoothness": "Suavidad",

--- a/static/locales/fr.json
+++ b/static/locales/fr.json
@@ -287,6 +287,7 @@
     "tooltip.timeline.play": "Jouer/Arrêter",
     "tooltip.timeline.add-key": "Ajouter une clé",
     "tooltip.timeline.remove-key": "Supprimer une clé",
+    "tooltip.timeline.key": "Glisser pour déplacer. Maj+glisser pour copier. Ctrl+clic pour reprendre la vue actuelle.",
     "tooltip.timeline.frame-rate": "Fréquence d'image",
     "tooltip.timeline.total-frames": "Nombre total de frames",
     "tooltip.timeline.smoothness": "Douceur",

--- a/static/locales/ja.json
+++ b/static/locales/ja.json
@@ -287,6 +287,7 @@
     "tooltip.timeline.play": "再生/停止",
     "tooltip.timeline.add-key": "キーフレームを追加",
     "tooltip.timeline.remove-key": "キーフレームを削除",
+    "tooltip.timeline.key": "ドラッグで移動。Shift+ドラッグでコピー。Ctrl+クリックで現在のビューを設定。",
     "tooltip.timeline.frame-rate": "フレームレート",
     "tooltip.timeline.total-frames": "総フレーム数",
     "tooltip.timeline.smoothness": "スムーズさ",

--- a/static/locales/ko.json
+++ b/static/locales/ko.json
@@ -287,6 +287,7 @@
     "tooltip.timeline.play": "재생/정지",
     "tooltip.timeline.add-key": "키 추가",
     "tooltip.timeline.remove-key": "키 제거",
+    "tooltip.timeline.key": "드래그하여 이동. Shift+드래그로 복사. Ctrl+클릭으로 현재 뷰 설정.",
     "tooltip.timeline.frame-rate": "프레임 속도",
     "tooltip.timeline.total-frames": "총 프레임 수",
     "tooltip.timeline.smoothness": "부드러움",

--- a/static/locales/pt-BR.json
+++ b/static/locales/pt-BR.json
@@ -287,6 +287,7 @@
     "tooltip.timeline.play": "Tocar/Parar",
     "tooltip.timeline.add-key": "Adicionar Quadro",
     "tooltip.timeline.remove-key": "Remover Quadro",
+    "tooltip.timeline.key": "Arraste para mover. Shift+arrastar para copiar. Ctrl+clique para definir a visão atual.",
     "tooltip.timeline.frame-rate": "Taxa de Quadros",
     "tooltip.timeline.total-frames": "Total de Quadros",
     "tooltip.timeline.smoothness": "Suavidade",

--- a/static/locales/ru.json
+++ b/static/locales/ru.json
@@ -287,6 +287,7 @@
     "tooltip.timeline.play": "Воспроизвести/Остановить",
     "tooltip.timeline.add-key": "Добавить ключ",
     "tooltip.timeline.remove-key": "Удалить ключ",
+    "tooltip.timeline.key": "Перетащите для перемещения. Shift+перетаскивание — копировать. Ctrl+клик — задать текущий вид.",
     "tooltip.timeline.frame-rate": "Частота кадров",
     "tooltip.timeline.total-frames": "Всего кадров",
     "tooltip.timeline.smoothness": "Плавность",

--- a/static/locales/zh-CN.json
+++ b/static/locales/zh-CN.json
@@ -287,6 +287,7 @@
     "tooltip.timeline.play": "播放/停止",
     "tooltip.timeline.add-key": "添加关键帧",
     "tooltip.timeline.remove-key": "删除关键帧",
+    "tooltip.timeline.key": "拖动以移动。Shift+拖动复制。Ctrl+点击设为当前视图。",
     "tooltip.timeline.frame-rate": "帧率",
     "tooltip.timeline.total-frames": "总帧数",
     "tooltip.timeline.smoothness": "平滑度",


### PR DESCRIPTION
## Summary

One item from #804: *"Sometimes you want to have the same position that you have in the current frame also in another frame. But if you select the other frame the camera jumps there."*

Re-posing an existing keyframe required scrubbing to it first, which jumps the camera to the old pose and destroys the newly composed shot. Ctrl+click on a key marker now overwrites that key with the current camera pose in place — the playhead does not move. It reuses the existing `track.addKey` path, so snapshot undo/redo works unchanged.

- Crosshair cursor when hovering a key with Ctrl held (tracked via pointermove and window-level Control keydown/keyup, so it also updates under a stationary pointer)
- Key markers register with the shared `Tooltips` system (wrapped in a pcui `Element`, unregistered on rebuild via `destroy`), describing the three gestures: drag to move, Shift+drag to copy, Ctrl+click to overwrite — localized in all 9 locales
- Ctrl+drag to a different frame still moves the key; Shift+drag copy unchanged

## Test Plan

- [x] Compose a shot at any frame, Ctrl+click an existing key → key updated to current view, playhead stays put
- [x] Undo restores the key's previous pose; redo re-applies
- [x] Hover a key → shared-style tooltip appears above it; hold Ctrl while hovering (moving or stationary) → crosshair cursor
- [x] Plain click, drag-move and Shift+drag copy behave as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)