### PR TITLE
Add loop toggle to the editor timeline

### DIFF
--- a/src/camera-poses.ts
+++ b/src/camera-poses.ts
@@ -45,6 +45,10 @@ class CameraAnimTrack implements AnimTrack {
             this.rebuildSpline();
         });
 
+        events.on('timeline.loop', () => {
+            this.rebuildSpline();
+        });
+
         // Clear track when scene is cleared
         events.on('scene.clear', () => {
             this.clear();
@@ -211,6 +215,7 @@ class CameraAnimTrack implements AnimTrack {
     private rebuildSpline(): void {
         const duration = this.events.invoke('timeline.frames');
         const smoothness = this.events.invoke('timeline.smoothness');
+        const loop = this.events.invoke('timeline.loop');
 
         const orderedPoses = this.poses.slice()
         .filter(a => a.frame < duration)
@@ -226,7 +231,11 @@ class CameraAnimTrack implements AnimTrack {
         }
 
         if (orderedPoses.length > 1) {
-            const spline = CubicSpline.fromPointsLooping(duration, times, points, smoothness);
+            // when not looping the spline clamps, holding the first/last pose
+            // beyond the outer keys instead of wrapping the end into the start
+            const spline = loop ?
+                CubicSpline.fromPointsLooping(duration, times, points, smoothness) :
+                CubicSpline.fromPoints(times, points, smoothness);
             const result: number[] = [];
             const pose = { position: new Vec3(), target: new Vec3(), fov: 0 };
 

--- a/src/timeline.ts
+++ b/src/timeline.ts
@@ -11,6 +11,7 @@ const registerTimelineEvents = (events: Events) => {
     let frames = 180;
     let frameRate = 30;
     let smoothness = 1;
+    let loop = true;
 
     // frames
 
@@ -61,6 +62,23 @@ const registerTimelineEvents = (events: Events) => {
 
     events.on('timeline.setSmoothness', (value: number) => {
         setSmoothness(value);
+    });
+
+    // loop
+
+    const setLoop = (value: boolean) => {
+        if (value !== loop) {
+            loop = value;
+            events.fire('timeline.loop', loop);
+        }
+    };
+
+    events.function('timeline.loop', () => {
+        return loop;
+    });
+
+    events.on('timeline.setLoop', (value: boolean) => {
+        setLoop(value);
     });
 
     // current frame
@@ -176,7 +194,8 @@ const registerTimelineEvents = (events: Events) => {
             frames,
             frameRate,
             frame,
-            smoothness
+            smoothness,
+            loop
         };
     });
 
@@ -186,12 +205,14 @@ const registerTimelineEvents = (events: Events) => {
         frameRate = data.frameRate ?? 30;
         frame = data.frame ?? 0;
         smoothness = data.smoothness ?? 1;
+        loop = data.loop ?? true;
 
         // Fire events to update UI (always fire to ensure rebuild)
         events.fire('timeline.frames', frames);
         events.fire('timeline.frameRate', frameRate);
         events.fire('timeline.frame', frame);
         events.fire('timeline.smoothness', smoothness);
+        events.fire('timeline.loop', loop);
     });
 };
 

--- a/src/ui/scss/timeline-panel.scss
+++ b/src/ui/scss/timeline-panel.scss
@@ -74,7 +74,32 @@
                 }
 
                 > #loop {
-                    margin: 0 4px;
+                    font-family: pc-icon;
+                    font-weight: bold;
+                    font-size: 13px;
+
+                    width: 36px;
+                    height: 24px;
+                    margin: 0;
+                    padding: 0;
+                    flex-grow: 0;
+                    flex-shrink: 0;
+
+                    border-radius: 4px;
+
+                    text-align: center;
+                    line-height: 24px;
+
+                    &:hover {
+                        color: #ff9900;
+                        cursor: pointer;
+                        box-shadow: none;
+                        border-color: #ff990088;
+                    }
+
+                    &.active {
+                        color: $clr-hilight;
+                    }
                 }
             }
         }

--- a/src/ui/scss/timeline-panel.scss
+++ b/src/ui/scss/timeline-panel.scss
@@ -72,6 +72,10 @@
                     margin: 0;
                     width: 60px;
                 }
+
+                > #loop {
+                    margin: 0 4px;
+                }
             }
         }
     }

--- a/src/ui/timeline-panel.ts
+++ b/src/ui/timeline-panel.ts
@@ -391,7 +391,7 @@ class TimelinePanel extends Container {
 
         const loop = new Button({
             id: 'loop',
-            text: '\uE113'
+            text: '\uE128'
         });
 
         loop.on('click', () => {

--- a/src/ui/timeline-panel.ts
+++ b/src/ui/timeline-panel.ts
@@ -1,4 +1,4 @@
-import { Button, Container, NumericInput, SelectInput } from '@playcanvas/pcui';
+import { BooleanInput, Button, Container, NumericInput, SelectInput } from '@playcanvas/pcui';
 
 import { Events } from '../events';
 import { ShortcutManager } from '../shortcut-manager';
@@ -318,12 +318,29 @@ class TimelinePanel extends Container {
             smoothness.value = smoothnessIn;
         });
 
+        // loop
+
+        const loop = new BooleanInput({
+            type: 'toggle',
+            id: 'loop',
+            value: true
+        });
+
+        loop.on('change', (value: boolean) => {
+            events.fire('timeline.setLoop', value);
+        });
+
+        events.on('timeline.loop', (loopIn: boolean) => {
+            loop.value = loopIn;
+        });
+
         const settingsControls = new Container({
             id: 'settings-controls'
         });
         settingsControls.append(speed);
         settingsControls.append(frames);
         settingsControls.append(smoothness);
+        settingsControls.append(loop);
 
         // append control groups
 
@@ -459,6 +476,7 @@ class TimelinePanel extends Container {
         tooltips.register(speed, () => i18n.t('tooltip.timeline.frame-rate'), 'top');
         tooltips.register(frames, () => i18n.t('tooltip.timeline.total-frames'), 'top');
         tooltips.register(smoothness, () => i18n.t('tooltip.timeline.smoothness'), 'top');
+        tooltips.register(loop, () => i18n.t('tooltip.timeline.loop'), 'top');
     }
 }
 

--- a/src/ui/timeline-panel.ts
+++ b/src/ui/timeline-panel.ts
@@ -1,4 +1,4 @@
-import { BooleanInput, Button, Container, Element, NumericInput, SelectInput } from '@playcanvas/pcui';
+import { Button, Container, Element, NumericInput, SelectInput } from '@playcanvas/pcui';
 
 import { Events } from '../events';
 import { ShortcutManager } from '../shortcut-manager';
@@ -389,19 +389,22 @@ class TimelinePanel extends Container {
 
         // loop
 
-        const loop = new BooleanInput({
-            type: 'toggle',
+        const loop = new Button({
             id: 'loop',
-            value: true
+            text: '\uE113'
         });
 
-        loop.on('change', (value: boolean) => {
-            events.fire('timeline.setLoop', value);
+        loop.on('click', () => {
+            events.fire('timeline.setLoop', !events.invoke('timeline.loop'));
         });
 
         events.on('timeline.loop', (loopIn: boolean) => {
-            loop.value = loopIn;
+            loop.class[loopIn ? 'add' : 'remove']('active');
         });
+
+        if (events.invoke('timeline.loop')) {
+            loop.class.add('active');
+        }
 
         const settingsControls = new Container({
             id: 'settings-controls'

--- a/static/locales/de.json
+++ b/static/locales/de.json
@@ -290,6 +290,7 @@
     "tooltip.timeline.frame-rate": "Bildrate",
     "tooltip.timeline.total-frames": "Gesamtanzahl der Frames",
     "tooltip.timeline.smoothness": "Weichheit",
+    "tooltip.timeline.loop": "Animation wiederholen",
     "tooltip.scene.solo": "Auswahl solo anzeigen",
     "status-bar.splats": "Splats",
     "status-bar.selected": "Ausgewählt",

--- a/static/locales/en.json
+++ b/static/locales/en.json
@@ -290,6 +290,7 @@
     "tooltip.timeline.frame-rate": "Frame Rate",
     "tooltip.timeline.total-frames": "Total Frames",
     "tooltip.timeline.smoothness": "Smoothness",
+    "tooltip.timeline.loop": "Loop Animation",
     "tooltip.scene.solo": "Solo Selected",
     "status-bar.splats": "Splats",
     "status-bar.selected": "Selected",

--- a/static/locales/es.json
+++ b/static/locales/es.json
@@ -290,6 +290,7 @@
     "tooltip.timeline.frame-rate": "Velocidad de fotogramas",
     "tooltip.timeline.total-frames": "Fotogramas totales",
     "tooltip.timeline.smoothness": "Suavidad",
+    "tooltip.timeline.loop": "Animación en bucle",
     "tooltip.scene.solo": "Solo seleccionado",
     "status-bar.splats": "Splats",
     "status-bar.selected": "Seleccionados",

--- a/static/locales/fr.json
+++ b/static/locales/fr.json
@@ -290,6 +290,7 @@
     "tooltip.timeline.frame-rate": "Fréquence d'image",
     "tooltip.timeline.total-frames": "Nombre total de frames",
     "tooltip.timeline.smoothness": "Douceur",
+    "tooltip.timeline.loop": "Animation en boucle",
     "tooltip.scene.solo": "Solo sélectionné",
     "status-bar.splats": "Splats",
     "status-bar.selected": "Sélectionnés",

--- a/static/locales/ja.json
+++ b/static/locales/ja.json
@@ -290,6 +290,7 @@
     "tooltip.timeline.frame-rate": "フレームレート",
     "tooltip.timeline.total-frames": "総フレーム数",
     "tooltip.timeline.smoothness": "スムーズさ",
+    "tooltip.timeline.loop": "アニメーションをループ",
     "tooltip.scene.solo": "選択をソロ表示",
     "status-bar.splats": "スプラット",
     "status-bar.selected": "選択済み",

--- a/static/locales/ko.json
+++ b/static/locales/ko.json
@@ -290,6 +290,7 @@
     "tooltip.timeline.frame-rate": "프레임 속도",
     "tooltip.timeline.total-frames": "총 프레임 수",
     "tooltip.timeline.smoothness": "부드러움",
+    "tooltip.timeline.loop": "애니메이션 루프",
     "tooltip.scene.solo": "선택 항목 솔로",
     "status-bar.splats": "스플랫",
     "status-bar.selected": "선택됨",

--- a/static/locales/pt-BR.json
+++ b/static/locales/pt-BR.json
@@ -290,6 +290,7 @@
     "tooltip.timeline.frame-rate": "Taxa de Quadros",
     "tooltip.timeline.total-frames": "Total de Quadros",
     "tooltip.timeline.smoothness": "Suavidade",
+    "tooltip.timeline.loop": "Repetir Animação",
     "tooltip.scene.solo": "Solo selecionado",
     "status-bar.splats": "Splats",
     "status-bar.selected": "Selecionados",

--- a/static/locales/ru.json
+++ b/static/locales/ru.json
@@ -290,6 +290,7 @@
     "tooltip.timeline.frame-rate": "Частота кадров",
     "tooltip.timeline.total-frames": "Всего кадров",
     "tooltip.timeline.smoothness": "Плавность",
+    "tooltip.timeline.loop": "Зациклить анимацию",
     "tooltip.scene.solo": "Соло выбранного",
     "status-bar.splats": "Сплаты",
     "status-bar.selected": "Выбрано",

--- a/static/locales/zh-CN.json
+++ b/static/locales/zh-CN.json
@@ -290,6 +290,7 @@
     "tooltip.timeline.frame-rate": "帧率",
     "tooltip.timeline.total-frames": "总帧数",
     "tooltip.timeline.smoothness": "平滑度",
+    "tooltip.timeline.loop": "循环动画",
     "tooltip.scene.solo": "独显所选",
     "status-bar.splats": "高斯点",
     "status-bar.selected": "已选择",


### PR DESCRIPTION
## Summary

One item from #804: *"For some applications (especially rendering video) it is a pain, that the end of the animation is connected to the beginning."*

The editor always built a looping spline, smoothing the end of the animation back into the first keyframe — which distorts the path near the ends when rendering non-looping video. This adds a loop toggle to the timeline settings (default on, preserving current behavior). When off, the spline clamps instead of wrapping, so the camera holds the first/last keyframe pose beyond the outer keys.

- State persists in document serialization (`.ssproj` round-trips)
- Tooltip localized in all 9 locales
- Complements the viewer-side loop modes added in #831

<img width="549" height="253" alt="image" src="https://github.com/user-attachments/assets/d4f5f1a8-0e0b-4445-a7fc-d92f5a5d6ed5" />

## Test Plan

- [x] Three keys, loop off → scrubbing past the last key holds its pose (no curve back toward key 0)
- [x] Loop on → end wraps smoothly into the start (current behavior)
- [x] Save and reload a document → toggle state persists
- [x] Video render with loop off no longer bends toward the start near the final frames

🤖 Generated with [Claude Code](https://claude.com/claude-code)