### PR TITLE
fix: clear error when WebGPU adapter is unavailable during Viewer/SOG export

### DIFF
--- a/src/file-handler.ts
+++ b/src/file-handler.ts
@@ -587,7 +587,7 @@ const initFileHandler = (scene: Scene, events: Events, dropTarget: HTMLElement) 
         } catch (error) {
             await events.invoke('showPopup', {
                 type: 'error',
-                header: i18n.t('popup.error-loading'),
+                header: i18n.t('popup.error-saving'),
                 message: `${error.message ?? error} while saving file`
             });
         } finally {

--- a/src/splat-serialize.ts
+++ b/src/splat-serialize.ts
@@ -1129,6 +1129,14 @@ const createGpuDevice = async (): Promise<WebgpuGraphicsDevice> => {
         throw new Error('WebGPU is not available in this browser');
     }
 
+    // Ensure a compatible WebGPU adapter exists before creating the device.
+    // Without this pre-flight, a null adapter causes the engine to read
+    // adapter.features on null, crashing with a confusing error during export.
+    const adapter = await navigator.gpu.requestAdapter();
+    if (!adapter) {
+        throw new Error('WebGPU is not available: no compatible GPU adapter was found. This export format requires WebGPU.');
+    }
+
     // Create a minimal canvas for the graphics device
     const canvas = document.createElement('canvas');
     canvas.width = 1024;

--- a/static/locales/en.json
+++ b/static/locales/en.json
@@ -127,6 +127,7 @@
     "popup.no": "No",
     "popup.error": "Error",
     "popup.error-loading": "Error Loading File",
+    "popup.error-saving": "Error Saving File",
     "popup.lcc-upload-warning": "For better publishing to superspl.at, upload your LCC file directly via the upload page.",
     "popup.export": "Export",
     "popup.copy-to-clipboard": "Copy Link to Clipboard",


### PR DESCRIPTION
## Summary

Exporting a scene to the Viewer App or SOG on a machine with no compatible WebGPU adapter now shows a clear, actionable error instead of a confusing "Cannot read properties of null (reading 'features')" crash shown under an "Error Loading File" header.

## Why this matters

As reported in #934, the Viewer/SOG export path builds a WebGPU device via `createGpuDevice` in `src/splat-serialize.ts`, which only guards against a missing `navigator.gpu`, not against `navigator.gpu.requestAdapter()` returning `null`. On systems with no compatible WebGPU adapter (common on older Linux/Chrome setups), the engine then reads `adapter.features` on a null adapter, producing the `reading 'features'` crash. This change adds an adapter pre-flight that throws a clear error before that null access is reached.

Separately, the export catch block in `src/file-handler.ts` labelled a save/export failure with the load-error header (`popup.error-loading`, "Error Loading File"), which is exactly what the maintainer found confusing in the issue thread. It now uses a new `popup.error-saving` ("Error Saving File") key. The genuine load-error uses elsewhere are left untouched, and the eight non-English locale files inherit the new key automatically through the existing `fallbackLng: 'en'` config.

## Testing

The repo has no unit-test framework, so verification is via the repo's own gates plus static reasoning about the null-adapter path:

- `npm run lint` passes clean.
- `npm run build` (type-checked rollup build) completes successfully.
- Happy path: with a working adapter, the added pre-flight `requestAdapter()` returns non-null and control proceeds unchanged into `graphicsDevice.createDevice()`.
- Bug path: with `navigator.gpu` present but `requestAdapter()` resolving `null`, `createGpuDevice` now throws "WebGPU is not available: no compatible GPU adapter was found" instead of the engine crash.
- The existing `if (!navigator.gpu)` guard is unchanged, so the no-WebGPU-at-all path still reports "WebGPU is not available in this browser".

Fixes #934
