### PR TITLE
Add SplatEstate PRD and technical build plan

### DIFF
--- a/docs/splatestate/01-prd.md
+++ b/docs/splatestate/01-prd.md
@@ -1,0 +1,301 @@
+# 01 — Product Requirements Document (PRD)
+
+## 1. Product summary
+
+**SplatEstate turns property footage into a photorealistic browser-based virtual tour.**
+
+A real-estate agent records a property using a 360 camera, a normal phone video, or a photo set. They upload the media to the SplatEstate web platform. The platform:
+
+1. Validates and analyzes the footage.
+2. Extracts and quality-filters frames.
+3. Reconstructs camera poses (Structure-from-Motion).
+4. Trains a 3D Gaussian Splat of the property.
+5. Applies AI cleanup and enhancement (masking, artifact removal, exposure harmonization, privacy blur).
+6. Compresses and packages the result for the web.
+7. Returns a polished, shareable browser tour link with agent branding and lead capture.
+
+Buyers open the link on any device, walk around the property, look around freely, and contact the agent or request a viewing — without downloading anything.
+
+**Homepage headline:** "Turn a property video into a photorealistic 3D walkthrough."
+
+**Subheading:** "Upload a 360 video, phone video, or photo set of your listing and get a shareable virtual tour link for buyers, viewings, and property marketing."
+
+### What SplatEstate is
+
+- A photorealistic virtual tour generator.
+- An AI-enhanced property walkthrough.
+- A real-estate marketing tool.
+- A shareable, embeddable, browser-based 3D listing experience.
+
+### What SplatEstate is NOT (positioning guardrails)
+
+- Not a CAD model generator.
+- Not a measurement-grade scanner.
+- Not a full Matterport clone.
+- Not an architectural survey tool.
+- Not an interior design tool.
+- Not a game engine.
+
+Every marketing page, onboarding screen, and tour footer reflects this: *"Tours are visual marketing assets, not measurement-grade scans."*
+
+## 2. Target users
+
+### Primary customer
+
+**Independent real-estate agents and small agencies (1–20 agents).**
+
+- Technically non-expert; they need "film → upload → link."
+- Price-sensitive: Matterport-style services (€150–400/scan or hardware + subscription) are too expensive or inconvenient for most listings.
+- Motivated by: winning listings (premium presentation in pitch meetings), filtering low-intent buyers, and reducing wasted physical viewings.
+
+### Secondary customers
+
+- Airbnb / short-term rental hosts (tour as booking conversion asset).
+- Property managers (remote tenant screening, move-in/move-out records — marketing angle only).
+- Renovation companies (before/after showcases).
+- Hotels and event venues (venue previews).
+- Student-housing companies (remote international leasing).
+- Commercial property brokers (office/retail space marketing).
+
+### Buyer persona (end-viewer, not the paying customer)
+
+Property buyers/renters who open a shared link. They demand: instant load, intuitive navigation on phone and desktop, and an obvious way to contact the agent. They are the reason viewer performance and mobile support are non-negotiable.
+
+## 3. Problem statement
+
+Real-estate agents waste time and money on low-quality leads and unnecessary viewings:
+
+1. **Static photos undersell and mislead.** Photos hide layout, flow, and proportion. Buyers show up, feel deceived by wide-angle shots, and walk away — a wasted viewing for everyone.
+2. **Professional 3D scanning is expensive and inconvenient.** Dedicated scanning services or Matterport hardware require scheduling, capital cost, per-scan fees, and vendor lock-in. Most independent agents skip it entirely.
+3. **Video walkthroughs are passive.** A YouTube walkthrough doesn't let the buyer look where *they* want to look.
+4. **Agents need to differentiate.** In listing pitches, agents who offer "an immersive 3D tour with every listing" win mandates against agents with photos only.
+
+The gap: **a fast, affordable, self-serve way to turn footage the agent can capture in 10 minutes into a premium interactive presentation.**
+
+## 4. Value proposition
+
+| For | Value |
+|---|---|
+| Agents | Premium listing presentation from a 10-minute capture, at a fraction of scanning-service cost; pre-qualified buyers; leads captured inside the tour. |
+| Agencies | Consistent branded tour experience across all agents; team management; analytics on listing engagement. |
+| Buyers | Explore the property honestly before committing travel time; view on any device. |
+| Sellers/landlords | Their property is presented at its best, truthfully, to more qualified buyers. |
+
+**Differentiators vs. incumbents:**
+
+- No proprietary hardware requirement (any consumer 360 camera, later any phone).
+- Photorealism from Gaussian Splatting exceeds stitched-panorama "dollhouse" tours in visual continuity — free movement, not point-hopping between fixed panoramas.
+- AI cleanup layer produces polished results from imperfect amateur captures.
+- Built entirely on a permissive open-source stack → structural cost advantage and no per-scan license fees.
+
+## 5. Feature list (full product)
+
+### Product modules
+
+1. **Authentication** — email/password + OAuth (Google), email verification, password reset, sessions/JWT, 2FA (later).
+2. **Agency account** — agency profile, logo, brand colors, contact details, custom slug.
+3. **User roles** — Owner, Agent, Editor, internal Admin (see [02-user-flows-ux.md](./02-user-flows-ux.md#user-roles)).
+4. **Property projects** — create, list, organize, archive, delete property tours; per-project metadata (address, price, listing URL, description).
+5. **Upload module** — resumable multipart upload for large files (multi-GB 360 video), upload validation, progress UI.
+6. **Capture guidance** — in-product instructions per capture type, checklists, example footage, pre-upload self-check.
+7. **Processing queue** — asynchronous jobs, status/progress visible to the user, retries, failure reasons in plain language.
+8. **Reconstruction pipeline** — frame extraction → quality filter → SfM → Gaussian Splat training → export ([04-pipeline.md](./04-pipeline.md)).
+9. **AI cleanup/enhancement pipeline** — masking, artifact reduction, exposure harmonization, privacy blur, quality scoring ([04-pipeline.md](./04-pipeline.md#ai-enhancement-layer)).
+10. **Review/editor screen** — SuperSplat-derived web editor: preview, crop bounds, delete floaters, labels, hotspots, starting view, cover image.
+11. **Buyer-facing viewer** — SuperSplat-Viewer-derived tour player: walk/orbit, room labels, hotspots, branding, CTA, lead form ([02-user-flows-ux.md](./02-user-flows-ux.md#screen-v1--public-tour-viewer)).
+12. **Publishing/sharing** — private draft / unlisted link / public page / password-protected / embed-only.
+13. **Lead capture** — in-tour contact form, viewing request, notifications, lead inbox.
+14. **Dashboard** — projects overview, processing status, recent leads, usage.
+15. **Billing/credits** — subscriptions + processing-credit add-ons (Stripe).
+16. **Admin/logs** — internal ops console: job logs, retry, failure inspection, abuse handling.
+17. **Analytics** — tour views, visitors, time-in-tour, room heatmap, CTA clicks, lead conversion, device/geo/referrer.
+18. **Privacy/delete/export controls** — project deletion, original-media deletion, data export, consent management.
+
+### MVP feature checklist (Phase 2 exit)
+
+1. User accounts
+2. Agency profile
+3. Property project creation
+4. Large media upload (resumable)
+5. 360 video upload (primary capture path)
+6. Frame extraction
+7. SfM / camera-pose reconstruction
+8. Gaussian Splat training
+9. AI cleanup / quality + masking checks (baseline)
+10. Web optimization/compression
+11. Preview page
+12. Basic editing (crop, delete splats, rename)
+13. Room labels
+14. Navigation points/hotspots
+15. Public/private share link
+16. Buyer-facing viewer (desktop + mobile)
+17. Agent branding
+18. Lead capture form
+19. Admin dashboard for failed jobs/logs
+20. Basic billing or credit logic
+
+## 6. MVP scope
+
+**Platform:** Web only. No mobile app in MVP.
+
+**Primary capture workflow:** **360-camera video upload.** Rationale:
+
+- Complete room coverage in a single pass → far fewer failed reconstructions.
+- One continuous walking path is natural with a 360 camera on a pole.
+- Better demo quality for interiors; strongest visual results.
+- Easier to instruct: "hold it above your head and walk slowly" beats teaching photogrammetry-style phone technique.
+
+**Secondary inputs (present in MVP but labeled):**
+
+- Normal phone video — labeled **Experimental**. Expectation-setting copy + stricter quality gate.
+- Photo folder upload — labeled **Advanced / Professional**. For users who already know photogrammetry capture.
+
+**Quality bar for MVP:** A well-captured 2–4 room apartment produces a tour rated "Good" or better by the internal quality score, loads in < 10 s on a mid-range phone over 4G, and is navigable at ≥ 30 fps on that device.
+
+## 7. Non-goals (explicitly out of MVP, most out of v1 entirely)
+
+- Full mobile capture app (Phase 6).
+- Perfect floorplans.
+- Accurate measurements of any kind.
+- CAD/BIM export.
+- Full native VR app (WebXR "nice to have" later; native never in v1).
+- Automatic renovation / virtual staging / furniture replacement.
+- Full Matterport clone (dollhouse view, measurement tools, schema exports).
+- Multi-floor automatic alignment (manual per-floor projects instead).
+- Real-time reconstruction preview during capture.
+- Advanced object removal that could misrepresent the property (see AI ethics rule).
+- Marketplace/community features.
+
+## 8. Monetization plan
+
+### Model: hybrid subscription + processing credits
+
+Processing cost is real (GPU minutes per tour), so pure flat subscription is margin-dangerous and pure pay-per-tour kills habit formation. Hybrid:
+
+| Plan | Price (launch hypothesis) | Included | Notes |
+|---|---|---|---|
+| **Free trial** | €0 | 1 tour, watermarked, 30-day hosting | Card-free; the demo IS the funnel |
+| **Starter** | €39/mo | 3 tours/mo, standard queue, SplatEstate badge | Solo agents, low volume |
+| **Pro** | €99/mo | 10 tours/mo, no watermark, agent branding, priority queue, analytics | Core plan; most revenue |
+| **Agency** | €249/mo | 30 tours/mo, 5 seats, agency branding, white-label option, priority processing, lead routing | Small agencies |
+| **Credits add-on** | €12–15/tour credit, volume discounts | Extra tours beyond plan | Also sold to trial users |
+
+Tours = processing credits. 1 credit = 1 standard processing run (re-runs after failure are free; re-runs after re-capture cost a credit). Hosting included while subscribed; published tours grandfathered 90 days after churn, then archived (originals retained per retention policy).
+
+### Upsells (Phase 4+)
+
+- **Professional cleanup** (€49–99/tour): human editor polishes the splat (floater removal, cropping, hotspot placement) — human-in-the-loop as a product.
+- **White-label domain** (tours.agencyname.com).
+- **Agency landing pages** (branded portfolio of all published tours).
+- **Lead capture premium** (SMS/WhatsApp instant alerts, lead routing rules, calendar-scheduling integration).
+- **CRM integration** (webhooks first; then HubSpot/Pipedrive/propertybase connectors).
+- **Priority GPU processing** (jump the queue; results in ~1 hour).
+- **Done-for-you scanning service** (partner operator network; SplatEstate takes a margin).
+- **Custom branding** (fully unbranded viewer, custom loading screen).
+- **Analytics package** (per-room heatmaps, buyer engagement reports, listing-portal attribution).
+
+### Unit economics guardrail
+
+Target: GPU + storage + egress cost per tour ≤ 20% of per-tour revenue. Levers: frame-count caps, training-iteration budget per plan tier, spot GPU instances, SOG compression (10–20× smaller than raw PLY) to control egress, mobile quality tiers.
+
+## 9. Risk analysis and mitigations
+
+| # | Risk | Likelihood | Impact | Mitigation |
+|---|---|---|---|---|
+| 1 | **Failed captures** — amateur footage doesn't reconstruct | High | High (refunds, churn, reputation) | 360-first strategy; strict in-product capture guidance; pre-processing quality gate that rejects bad uploads *before* burning GPU time with specific recapture instructions ("video moved too fast", "hallway transition failed"); quality score with honest labels; failed-job credits refunded automatically |
+| 2 | **Processing cost blowout** | Medium | High | Credit system; frame sampling caps (≤ 600 training frames MVP); iteration budgets per tier; spot GPUs with checkpoint/resume; queue depth limits on free tier; per-job cost telemetry from day one |
+| 3 | **Viewer too heavy for buyer devices** | Medium | High (buyers are the product demo) | SOG compressed format via splat-transform; mobile quality variant (reduced splat count); progressive loading + cover-image-first; fallback still-image gallery; hard QA gate on file size (< 30 MB mobile / < 80 MB desktop target) and load time |
+| 4 | **License risk** — non-commercial 3DGS code contamination | Medium | Severe (rebuild or legal exposure) | Production stack restricted to the approved inventory ([03-architecture.md](./03-architecture.md#license-inventory)); CI dependency-license scanning; explicit ban on Inria `graphdeco-inria/gaussian-splatting` and its `diff-gaussian-rasterization` in any production dependency tree; legal review before launch; experimental repos quarantined to research environment ([08-personal-testing.md](./08-personal-testing.md)) |
+| 5 | **AI misrepresentation** — cleanup crosses into deception | Low–Medium | Severe (legal liability, trust) | AI limited to capture artifacts, privacy items, tripod/operator removal, exposure; never structural edits; user confirmation step lists every automated removal; disclaimers in viewer footer; audit log of all AI edits per tour |
+| 6 | **Privacy breach / GDPR violation** | Low | Severe | Private by default; signed URLs; deletion pipeline that actually deletes (originals, frames, masks, splats, backups within SLA); face/document/plate detection with blur offering; no training on user data without opt-in; consent checkbox at upload; DPA + records of processing |
+| 7 | **Reconstruction quality plateau** — splats look "good demo, bad product" on hard properties (mirrors, glass, white walls) | Medium | Medium | Quality score honesty ("Needs review" / "Recapture recommended"); capture guidance about mirrors/glass; fallback panorama mode for failed rooms (Phase 5); manage expectations in marketing (real footage in demos, not cherry-picked) |
+| 8 | **Single-founder/small-team pipeline complexity** | High | Medium | Buy-don't-build for non-core (auth provider optional, Stripe billing, managed Postgres); the AWS open-source 3D reconstruction toolbox guidance as architecture reference; Phase 1 is a hardcoded pipeline before any SaaS chrome |
+| 9 | **GPU supply/pricing volatility** | Medium | Medium | Provider-agnostic worker container (plain Docker + queue pull model) runs on RunPod, Lambda, CoreWeave, or AWS interchangeably |
+| 10 | **Incumbent response** (Matterport/Zillow adds splat tours) | Medium | Medium | Move fast on the low end; win on price, self-serve simplicity, and open embedding; agent relationships + lead-capture lock-in |
+
+## 10. Roadmap
+
+### Phase 1 — Technical proof (no SaaS)
+
+Upload one 360 video → extract frames → COLMAP → Nerfstudio Splatfacto/gsplat → export → view in SuperSplat Viewer. Manual scripts, one GPU box. **Exit criterion: 3 different real apartments produce walkable tours you'd show an agent.**
+
+### Phase 2 — MVP SaaS
+
+Auth, agency profile, project dashboard, resumable upload, processing queue with status, automated pipeline, basic editor (labels/hotspots/crop), publish link, buyer viewer (desktop+mobile), lead form, basic admin, credit logic. **Exit: MVP acceptance criteria below all pass with a stranger's footage.**
+
+### Phase 3 — AI enhancement
+
+Frame quality scoring, blur/exposure/shake filtering, duplicate removal, person/tripod/private-object segmentation (SAM2 + detector), mask-aware training, thumbnail generation, tour quality score with plain-language reasons.
+
+### Phase 4 — Real-estate polish
+
+Agent branding suite, room labels UX, hotspot navigation graph, guided tour path ("best room order"), embed code, analytics dashboard, mobile performance tier, listing-text generation.
+
+### Phase 5 — Advanced cleanup
+
+3D inpainting (Inpaint360GS-class, license-verified), automated floating-artifact removal, seamless compositing, exposure harmonization across rooms, privacy blur/remove in 3D, "professional cleanup" human-review upsell.
+
+### Phase 6 — Capture apps
+
+iOS/Android guided capture with real-time quality meter, ARKit/LiDAR assist, direct upload. (Evaluate `brush`/WebGPU on-device paths here.)
+
+### Phase 7 — Agency/business growth
+
+Team accounts at scale, white-label, CRM integrations, property-portal integrations (Idealista/Rightmove/Zillow embed partnerships), public API, bulk processing, partner scanning network.
+
+## 11. MVP acceptance criteria
+
+The MVP ships when **all** of the following pass end-to-end with real (non-team) user footage:
+
+1. User can create an account.
+2. User can create an agency profile.
+3. User can create a property project.
+4. User can upload a 360 video (≥ 4 GB file, resumable, survives a connection drop).
+5. System extracts frames.
+6. System reconstructs camera poses.
+7. System trains a Gaussian Splat.
+8. System applies baseline AI cleanup — at minimum: frame quality filtering, quality/masking checks, and a quality score with reasons.
+9. System exports a browser-viewable tour.
+10. User can preview the tour.
+11. User can add room labels and hotspots.
+12. User can publish and unpublish.
+13. Buyer can open the link on desktop **and** mobile (mid-range Android over 4G loads in < 10 s and navigates at ≥ 30 fps).
+14. Buyer can submit a lead.
+15. Agent sees the lead (dashboard + email notification).
+16. Failed jobs show a clear, human-readable reason and a recapture suggestion.
+17. Admin can inspect logs and retry jobs.
+
+## 12. First 30/60/90-day implementation plan
+
+### Days 1–30 — Prove the pipeline (Phase 1)
+
+- **Week 1:** Buy/borrow a 360 camera (e.g., Insta360 X4/X5). Rent one GPU box (RTX 4090 / L4-class). Set up Nerfstudio + gsplat + COLMAP + FFmpeg in a Docker image. Capture apartment #1.
+- **Week 2:** Build the frame-extraction script: FFmpeg equirectangular → perspective crops (v360 filter, 6–8 virtual pinhole views per frame), controlled FPS. Run COLMAP → Splatfacto → export PLY. Get *anything* walkable.
+- **Week 3:** Iterate on quality: frame sampling rates, COLMAP settings (sequential matcher for video), Splatfacto config, OpenSfM spherical-model comparison for the same footage. Pipe exports through splat-transform → SOG. View in SuperSplat Viewer (this repo's sibling). Establish the capture protocol doc from what actually works.
+- **Week 4:** Capture 3 different real properties (small apartment, larger unit with hallway, one hard case with mirrors). Document per-property GPU minutes and cost. Write the go/no-go quality memo. **Deliverable: 3 demo tour links + a repeatable `make tour INPUT=video.mp4` pipeline + cost-per-tour number.**
+
+### Days 31–60 — Wrap it in a product (Phase 2 core)
+
+- **Week 5:** Repo scaffolding: monorepo (web app, API, worker). Postgres schema v1 ([05-database-schema.md](./05-database-schema.md)). Auth + agency + projects CRUD.
+- **Week 6:** Resumable multipart upload to S3-compatible storage; upload validation; job queue (see [03-architecture.md](./03-architecture.md#processing-queue-design)); worker pulls job, runs Phase-1 pipeline in container, streams logs/status back.
+- **Week 7:** Processing status UI with stages and progress; failure reasons; retry. Viewer packaging: SOG + `viewer_config` JSON → hosted tour page on SuperSplat Viewer base.
+- **Week 8:** Editor v1 (SuperSplat fork embedded: crop bounds, delete floaters, save) + labels/hotspots + cover image + publish/unpublish + share link. **Deliverable: a stranger can self-serve from signup to shared tour.**
+
+### Days 61–90 — Make it sellable (Phase 2 finish + Phase 3 start)
+
+- **Week 9:** Buyer viewer polish: loading screen, cover fallback, branding, CTA, lead form, mobile QA. Lead inbox + email notifications.
+- **Week 10:** Billing: Stripe subscriptions + credits; free trial with watermark; usage metering. Admin console: job list, logs, retry, account suspend.
+- **Week 11:** AI layer v1: blur/exposure/duplicate frame filtering in the pipeline; person/tripod detection + SAM2 masking on flagged frames; quality score with reasons surfaced to the user.
+- **Week 12:** Private beta with 5–10 real agents. Instrument everything (per-stage timings, failure taxonomy, viewer load times). Fix the top 5 failure modes. **Deliverable: 10 external tours processed, ≥ 70% success rate on guided 360 captures, first paying customer conversation.**
+
+## 13. Clear recommendation: what to build first
+
+**Build the pipeline before the platform. Specifically, in this order:**
+
+1. **Week 1–4: The `video → tour link` pipeline as scripts** (Phase 1). Everything else is worthless if this doesn't produce impressive tours from realistic amateur captures. This is also where all the risk lives — retire it first.
+2. **The quality gate second.** Before any dashboard exists, build the pre-flight analyzer (frame quality, coverage, motion speed) — it protects GPU spend and user trust, and its failure messages are the product's most important copy.
+3. **The viewer third.** Fork/adapt SuperSplat Viewer with branding + lead CTA. The buyer-facing link is the demo that sells the product; it must be excellent on mobile before the SaaS chrome exists.
+4. **Then the SaaS shell** (auth → upload → queue → status → publish), which is well-understood commodity work.
+5. **AI enhancement last within MVP** — start with the cheap, high-yield pieces (frame filtering, tripod masking) and defer 3D inpainting entirely.
+
+**Deliberately do NOT start with:** the mobile app, the editor's advanced tooling, floorplans, analytics, or CRM integrations. None of them matter until the core loop (film → upload → beautiful tour → lead) is reliably impressive.

--- a/docs/splatestate/02-user-flows-ux.md
+++ b/docs/splatestate/02-user-flows-ux.md
@@ -1,0 +1,161 @@
+# 02 — User Roles, User Flows, and UX Screens
+
+## User roles
+
+| Role | Scope | Permissions |
+|---|---|---|
+| **Owner** | Agency | Manage agency profile & branding; manage billing & plan; invite/remove members; change member roles; view/edit **all** agency projects and leads; delete agency |
+| **Agent** | Own projects | Create/edit/delete own projects; upload media; run processing; edit own tours; publish/unpublish; view own leads; view own analytics |
+| **Editor** | Assigned projects | Edit tours (labels, hotspots, crop, cover, starting view); cannot upload new projects, publish, manage billing, or see leads unless granted |
+| **Admin** (internal SplatEstate staff) | Platform | View processing logs; retry/cancel jobs; inspect failures; impersonate-for-support (audited); suspend accounts; handle abuse/privacy reports; manage feature flags |
+
+Role enforcement is server-side per-endpoint (see [06-api.md](./06-api.md)) via agency membership + role checks; Admin is a separate staff flag, never grantable through the public API.
+
+## Main user flow (happy path)
+
+1. Agent signs up (email or Google).
+2. Agent creates agency profile (name, logo, colors, contact info).
+3. Agent creates a new property project (title, address, optional price/listing URL).
+4. Agent chooses capture type: **360 video** (recommended) / phone video (experimental) / photo set (advanced).
+5. Platform shows capture instructions for the chosen type (checklist + example clip). Agent confirms "I've read the capture guide."
+6. Agent uploads the 360 video (resumable multipart; progress bar; can close the tab).
+7. Platform validates the upload (container/codec/duration/resolution; equirectangular detection) and shows a pre-flight result.
+8. Platform extracts frames (FFmpeg).
+9. Platform runs frame quality analysis (blur, exposure, shake, duplicates, dynamic objects).
+10. Bad frames are removed or downweighted; masks generated where needed.
+11. Platform runs SfM — COLMAP primary; GLOMAP/global mapper, OpenSfM (spherical), HLOC as fallbacks.
+12. Platform trains the Gaussian Splat (Nerfstudio Splatfacto + gsplat, mask-aware).
+13. Platform runs AI cleanup: artifact reduction, boundary cropping, exposure harmonization, quality scoring.
+14. Platform optimizes for web (splat-transform → SOG; mobile variant).
+15. Platform creates the preview tour and notifies the agent (email + dashboard).
+16. Agent reviews the tour in the editor.
+17. Agent adds room labels and hotspots (AI suggestions pre-populated, Phase 3+).
+18. Agent sets cover image, starting view, description, price/location, and CTA.
+19. Agent publishes (unlisted link / public page / password / embed).
+20. Buyer opens the link on any device.
+21. Buyer explores the property (walk, look, jump to rooms via labels/hotspots).
+22. Buyer submits a lead / viewing request.
+23. Agent receives the lead (email + dashboard inbox) and follows up.
+
+Throughout steps 8–15 the agent sees a live status page: current stage, percent, elapsed time, and — on failure — a plain-language reason plus recapture guidance.
+
+## Failure flow
+
+1. A pipeline stage fails or the quality gate rejects the input.
+2. Job is marked `failed` with a machine `failure_code` and human `failure_reason` (e.g., "Video moved too fast — SfM could only register 34% of frames. Re-record walking at half speed, pausing 2 seconds in each doorway.").
+3. Agent gets an email + dashboard alert with the reason and a link to the relevant capture-guide section.
+4. Credit for the failed run is auto-refunded.
+5. Agent can: re-upload new footage to the same project, retry (if failure was transient/infrastructure), or contact support.
+6. Admin sees the failure in the ops console with full logs and artifacts for diagnosis.
+
+## Additional flows
+
+- **Invite flow:** Owner → Settings → Members → invite by email + role → invitee accepts → lands in agency dashboard.
+- **Lead follow-up flow:** email notification → lead inbox → mark contacted/qualified/closed → (later) push to CRM.
+- **Deletion flow (GDPR):** Agent deletes project → confirmation listing exactly what is destroyed (original media, frames, masks, splats, published tour, analytics) → soft-delete 7-day grace → hard purge job → audit record retained.
+- **Trial-to-paid flow:** trial tour is watermarked + capped at 30-day hosting → upgrade prompt on publish screen and at day 25 → upgrading removes watermark retroactively.
+
+## UX screen inventory
+
+### Marketing / public
+
+| ID | Screen | Key elements |
+|---|---|---|
+| P1 | Landing page | Headline + subheading (see PRD), embedded live demo tour, pricing, "what it is / isn't" honesty section |
+| P2 | Demo tour | Full buyer viewer with sample property |
+| P3 | Pricing | Plan table, credits explainer, FAQ |
+| V1 | **Public tour viewer** | See detailed spec below |
+
+### App — agent-facing
+
+| ID | Screen | Key elements |
+|---|---|---|
+| A1 | Sign up / Log in | Email+password, Google OAuth, consent checkboxes (ToS, upload-rights confirmation) |
+| A2 | Onboarding | Agency setup wizard: name, logo, brand color, phone/WhatsApp, slug |
+| A3 | Dashboard | Project cards (thumbnail, status chip, views, leads), "New tour" CTA, credits remaining, recent leads strip |
+| A4 | New project | Title, address, capture-type picker with recommendation badges |
+| A5 | Capture guide | Per-type checklist, dos/don'ts with example clips, "common failures" gallery, confirm-and-continue |
+| A6 | Upload | Drag-drop, multi-GB resumable progress, pre-flight validation results, consent checkbox ("I have permission to upload and publish this property media") |
+| A7 | Processing status | Stage timeline (Ingest → Frames → Quality → Poses → Training → Cleanup → Optimize → Package → QA), live progress, ETA, cancel button, failure panel with reason + recapture link |
+| A8 | Tour editor | Embedded SuperSplat-derived editor: 3D preview, crop-bounds tool, splat-delete brush, undo; side panel: rename, labels list, hotspots list, starting-view "set from current camera", cover-image capture, description/price/listing URL fields |
+| A9 | Publish panel | Privacy mode selector (draft/unlisted/public/password/embed-only), share-link copy, embed-code copy, QR code, watermark notice on trial |
+| A10 | Leads inbox | Lead list with status (new/contacted/qualified/closed), lead detail, per-project filter |
+| A11 | Analytics | Views, uniques, avg time, room engagement, CTA clicks, device split, geo, referrers; per-project and agency-wide |
+| A12 | Agency settings | Profile, branding, members & roles, invitations |
+| A13 | Billing | Current plan, usage meter, credit balance, buy credits, invoices, upgrade/downgrade |
+| A14 | Account settings | Profile, password, notification prefs, data export, delete account |
+
+### App — internal admin
+
+| ID | Screen | Key elements |
+|---|---|---|
+| X1 | Jobs console | All jobs filterable by status/stage/agency; failure taxonomy counts |
+| X2 | Job detail | Full stage logs, artifacts (sample frames, SfM stats, training curves), retry/cancel, cost telemetry |
+| X3 | Accounts | Search, plan info, suspend/reinstate, audited support-impersonation |
+| X4 | Abuse/privacy reports | Report queue from viewer "report" link, takedown actions |
+
+### Screen V1 — Public tour viewer (buyer-facing) — detailed requirements
+
+Built on **playcanvas/supersplat-viewer** (MIT) with a SplatEstate overlay layer.
+
+**Must have (MVP):**
+
+- Browser-based 3D tour; desktop (mouse/keyboard: WASD + orbit) and mobile (touch: drag-look, pinch, tap-to-move / joystick) support.
+- Loading screen with progress bar and agency branding.
+- Cover-image-first render: cover shows instantly while the splat streams.
+- Room labels (floating, tappable → camera flies to room's saved viewpoint).
+- Hotspots/navigation points (curated camera positions forming the tour path; "next room" affordance).
+- Agent/agency branding: logo, name, photo, brand color.
+- Contact CTA: persistent button → lead form (name, email, phone, message, preferred contact method, optional desired viewing date/time).
+- WhatsApp / phone quick-contact buttons (agency-configurable).
+- "Schedule viewing" button (same form with date/time emphasized; calendar integration later).
+- Fullscreen mode; share button (native share sheet on mobile, copy-link on desktop).
+- Watermark on trial-plan tours.
+- Footer disclaimer: "Visual marketing asset — not a measurement-grade scan."
+
+**Should have:**
+
+- Optional property details panel (price, address, description, listing URL).
+- Optional photo-gallery fallback (also serves as the no-WebGL/ancient-device fallback).
+- Embed mode: minimal chrome, `postMessage` resize, no external navigation.
+- Guided auto-tour: camera animates along the hotspot path until the user interacts (SuperSplat's timeline/camera-pose system is the base for this).
+
+**Performance budget:** initial interactive < 10 s on 4G mid-range Android; mobile asset ≤ ~30 MB (SOG), desktop ≤ ~80 MB; ≥ 30 fps mobile / 60 fps desktop; graceful WebGPU→WebGL fallback per PlayCanvas engine support.
+
+## Capture guidance content (shipped in-product, screen A5)
+
+### 360 camera (recommended)
+
+- Walk **slowly** — half your normal pace.
+- Keep the camera vertical, on a pole/selfie stick above head height.
+- Keep the camera stable; no swinging.
+- Turn **all** lights on; open curtains for even light.
+- Open all doors before you start.
+- Nobody else in the scene; avoid pets.
+- No fast turns — rotate your path, not the camera.
+- Don't stand closer than ~1 m to walls.
+- Cover room corners; walk a loop in each room, not just the center.
+- Take doorway transitions slowly: pause ~2 s on each side of every doorway.
+- Avoid mirrors where possible (walk past them, don't face them).
+- Record extra coverage in hallways and doorways — these are where reconstructions break.
+- One continuous take for the whole property if possible.
+- Target: roughly 1–2 minutes per room; 5–10 minutes total for an apartment.
+
+### Phone video (experimental)
+
+- Landscape orientation, 4K if available, highest stabilization.
+- Move slowly; avoid motion blur (well-lit rooms only).
+- Capture each room from multiple angles/heights — not one pan from the doorway.
+- Keep exposure locked/stable if the camera app allows.
+- No fast pans; rotate ≤ 90° over 4+ seconds.
+- Avoid featureless content: don't film blank walls filling the frame; keep furniture/edges in view.
+- Overlap: every part of the room should appear in several seconds of footage from different positions.
+
+### Photo sets (advanced/professional)
+
+- Many overlapping photos (60–80% overlap between neighbors).
+- Cover all rooms including transitions between them (shoot *through* doorways from both sides).
+- Consistent exposure (manual/locked); consistent white balance.
+- No huge positional gaps; move in small steps, shoot ring patterns per room.
+- Same camera/lens throughout; no zoom changes mid-set.
+- Recommended: 150–400 photos for a typical apartment.

--- a/docs/splatestate/03-architecture.md
+++ b/docs/splatestate/03-architecture.md
@@ -1,0 +1,198 @@
+# 03 — System Architecture, Open-Source Stack, Queue Design, Cloud/GPU Plan
+
+## High-level architecture
+
+```
+                                   ┌────────────────────────────────────────────────┐
+                                   │                    CDN                         │
+                                   │  (tour assets: SOG splats, thumbnails, viewer) │
+                                   └───────▲────────────────────────────▲───────────┘
+                                           │                            │
+┌──────────────┐   HTTPS   ┌───────────────┴───────────┐    ┌───────────┴───────────┐
+│ Agent browser │◄────────►│  Web app (Next.js)        │    │ Buyer browser         │
+│ (dashboard,   │          │  - dashboard, editor      │    │ (tour viewer,         │
+│  editor)      │          │  - SuperSplat fork embed  │    │  supersplat-viewer    │
+└──────┬───────┘           └───────────────┬───────────┘    │  fork + lead form)    │
+       │ multipart upload                  │ REST/JSON      └───────────┬───────────┘
+       │ (presigned URLs)                  ▼                            │ public API
+       │                    ┌──────────────────────────┐               │ (tour data,
+       └───────────────────►│  API service (FastAPI)   │◄──────────────┘  leads,
+                            │  - auth, RBAC            │                  analytics)
+┌──────────────────┐        │  - projects/uploads      │
+│ Object storage   │◄──────►│  - jobs orchestration    │────► Stripe (billing)
+│ (S3-compatible)  │        │  - leads, analytics      │────► Email (SES/Resend)
+│ originals/frames/│        └────────┬─────────────────┘
+│ masks/splats/    │                 │
+│ tours            │        ┌────────▼─────────────────┐
+└──────▲───────────┘        │ PostgreSQL 16            │
+       │                    │ (system of record)       │
+       │                    └────────┬─────────────────┘
+       │                             │ job rows (queue)
+       │                    ┌────────▼─────────────────┐
+       │                    │ Queue: Postgres-backed   │
+       │                    │ job table + Valkey       │
+       │                    │ pub/sub for progress     │
+       │                    └────────┬─────────────────┘
+       │                             │ pull (HTTPS, outbound-only)
+       │            ┌────────────────┼──────────────────────┐
+       │            ▼                ▼                      ▼
+       │   ┌────────────────┐ ┌────────────────┐  ┌────────────────┐
+       └───┤ CPU workers    │ │ GPU workers    │  │ AI workers     │
+           │ ffmpeg ingest, │ │ COLMAP (GPU),  │  │ SAM2 masking,  │
+           │ frame extract, │ │ Splatfacto/    │  │ detection,     │
+           │ quality filter,│ │ gsplat training│  │ scoring        │
+           │ splat-transform│ │                │  │ (GPU, smaller) │
+           └────────────────┘ └────────────────┘  └────────────────┘
+             (autoscaled container fleet; provider-agnostic Docker images)
+```
+
+Reference architecture: **aws-solutions-library-samples/guidance-for-open-source-3d-reconstruction-toolbox-for-gaussian-splats-on-aws** — we follow its shape (media in S3 → orchestrated GPU pipeline with COLMAP/GLOMAP + Nerfstudio/gsplat → web-ready outputs) while keeping the implementation cloud-portable.
+
+## Tech stack (all permissive-license)
+
+| Layer | Choice | License | Why |
+|---|---|---|---|
+| Web app | Next.js + React + TypeScript | MIT | Dashboard, editor shell, marketing pages, SSR public tour pages (SEO for public listings) |
+| Editor | **This repo** — fork of playcanvas/supersplat | MIT | Crop, floater deletion, camera poses, publish prep; already ships timeline/camera-pose tooling reusable for guided tours |
+| Buyer viewer | Fork of playcanvas/supersplat-viewer (+ playcanvas/engine) | MIT | Proven SOG playback, mobile support; we add branding/lead overlay |
+| API | Python FastAPI + Pydantic + SQLAlchemy | MIT | One language across API and ML pipeline; async; OpenAPI for free |
+| DB | PostgreSQL 16 | PostgreSQL (permissive) | System of record + job queue (`FOR UPDATE SKIP LOCKED`) |
+| Cache/pub-sub | **Valkey** | BSD-3-Clause | Redis-compatible; chosen over Redis ≥ 7.4 which moved to RSALv2/SSPLv1 (not permissive) |
+| Object storage | S3 / any S3-compatible (MinIO for dev, AGPL — dev-only, unmodified use; or SeaweedFS Apache-2.0) | — | Originals, frames, masks, splats, tour bundles |
+| Queue/workers | Postgres job table + custom pull workers (Python) | — | See queue design below; avoids Celery+Redis license/ops coupling; Celery (BSD) acceptable alternative |
+| Media | FFmpeg — **LGPL build** (disable `--enable-gpl`, no x264/x265; use openh264 BSD or hosted transcode for H.264 encode; decode is fine) | LGPL-2.1 | Frame extraction, v360 reprojection, thumbnails, validation |
+| Billing | Stripe SDK | MIT | Subscriptions + credits |
+| Email | SES/Resend/Postmark SDK | MIT/Apache | Notifications, leads |
+| Infra as code | OpenTofu / Terraform-compatible | MPL-2.0 | Cloud portability |
+| Observability | OpenTelemetry + Grafana stack (Grafana/Loki are AGPL — SaaS-internal use is fine, or use managed Grafana Cloud; Prometheus/OTel Apache-2.0) | Apache-2.0 core | Per-stage pipeline telemetry is a day-one requirement |
+
+## Open-source repo usage plan
+
+### Tier 1 — production core
+
+| Repo | License | Role in SplatEstate |
+|---|---|---|
+| nerfstudio-project/**nerfstudio** | Apache-2.0 | Training framework; `ns-process-data` conventions; **Splatfacto** is the production method |
+| nerfstudio-project/**gsplat** | Apache-2.0 | Gaussian rasterization/training backend (the license-safe alternative to Inria's non-commercial rasterizer); also exposes compression/pruning utilities |
+| colmap/**colmap** | BSD (New BSD) | Primary SfM: feature extraction, sequential matching (video), sparse reconstruction, undistortion |
+| colmap/**glomap** | BSD-3-Clause | Global mapper for faster SfM on large frame sets; if standalone repo is deprecated, use COLMAP's equivalent global mapper |
+| mapillary/**OpenSfM** | BSD-2-Clause | Fallback SfM with native **spherical/equirectangular camera model** — key for 360 workflows where perspective-crop + COLMAP underperforms |
+| cvg/**Hierarchical-Localization (HLOC)** | Apache-2.0 | Robust learned feature matching (SuperPoint+LightGlue-class, license-check each model) as SfM rescue path for low-texture scenes |
+| playcanvas/**supersplat** | MIT | **This repo.** Agent-facing editor: crop bounds, splat deletion, camera poses/timeline, SOG export |
+| playcanvas/**supersplat-viewer** | MIT | Buyer-facing tour viewer base |
+| playcanvas/**splat-transform** | MIT | CLI conversion/compression: PLY → SOG, filtering, LOD prep, transforms |
+| playcanvas/**engine** | MIT | Underlying 3D engine; custom viewer interactions (hotspot nav, guided path, collision-ish constraints) |
+| facebookresearch/**sam2** | Apache-2.0 (code) — **verify checkpoint license before prod** | Segmentation for masks: people, tripod/operator, pets, private objects, mirrors |
+| **FFmpeg** | LGPL-2.1 (LGPL-safe build) | Ingest, validation, frame extraction, v360 equirect→perspective, thumbnails |
+
+### Tier 2 — reference & roadmap (not in MVP runtime)
+
+| Repo | License | Planned use |
+|---|---|---|
+| aws-solutions-library-samples/guidance-for-open-source-3d-reconstruction-toolbox-for-gaussian-splats-on-aws | (sample code — review terms) | Architecture reference only |
+| ArthurBrussee/**brush** | Apache-2.0 | Future WebGPU/on-device training path (Phase 6 capture apps) |
+| KevinXu02/**splatfacto-w** | Apache-2.0 | "In the wild" appearance/lighting variation handling — Phase 5 candidate for mixed-lighting captures |
+| nerficg-project/**faster-gaussian-splatting** | Apache-2.0 | Training speed optimization candidate |
+| inuex35/**splat_one** | Apache-2.0 | GUI workflow inspiration only |
+| wanmeihuali/**taichi_3d_gaussian_splatting** | Apache-2.0 | Alternative implementation for testing/learning |
+| joeyan/**gaussian_splatting** | MIT | Reference implementation; prefer gsplat in prod |
+| AndrewBoessen/**3DGS** | MIT | Minimal C++/CUDA learning reference |
+| nvpro-samples/**vk_gaussian_splatting** | Apache-2.0 | Native/Vulkan viewer reference (future native apps) |
+| InternLandMark/**FlashGS** | MIT | Future large-scene rendering optimization |
+| 3dv-casia/**MGSfM** | BSD-3-Clause | Future multi-camera/360-rig reconstruction |
+| facebookresearch/**map-anything** | Apache-2.0 variant — **verify exact terms** | Future metric depth/pose assistance |
+| dfki-av/**Inpaint360GS** | Apache-2.0 — **verify model/data deps** | Phase 5: object-aware 3D inpainting for 360 scenes |
+| U2Net-style background removal (permissive forks only) | verify per-repo | Optional masking preprocessing |
+
+### Explicitly banned from production
+
+- `graphdeco-inria/gaussian-splatting` and its `diff-gaussian-rasterization` / `simple-knn` submodules (Inria/MPI **non-commercial research license**) — including *any transitive dependency* that vendors them. This is the single most common license contamination vector in the splat ecosystem: many research repos (MonoGS, GaussianRoom, many "XX-GS" papers) depend on it.
+- Any repo with no LICENSE file.
+- Forks of non-commercial research repos regardless of what the fork's LICENSE claims.
+- AGPL components in shipped/linked code paths (internal ops tooling exempted case-by-case).
+- Apple sample-code derivatives unless terms are individually reviewed.
+- Model weights whose terms are unclear, even when repo code is permissive (weights and code are licensed separately — check both).
+
+### License inventory (process)
+
+- `THIRD_PARTY_LICENSES.md` generated in CI (e.g., pip-licenses + license-checker) on every build; build **fails** on GPL/AGPL/unknown/noncommercial in production dependency trees.
+- Every new dependency requires a PR checklist entry: license of code, license of any weights/data, licenses of transitive deps.
+- Quarantine rule: experimental repos ([08-personal-testing.md](./08-personal-testing.md)) live only in a separate research environment/repo, never imported by production code.
+- Full legal review of the inventory before public launch.
+
+## Processing queue design
+
+**Choice: Postgres-backed job queue with pull workers.** No message broker to operate; jobs are transactional with the rest of the system of record; `SELECT ... FOR UPDATE SKIP LOCKED` gives safe concurrent dequeue. Valkey is used only for ephemeral progress pub/sub to the status UI.
+
+### Job model
+
+- A `processing_job` row per pipeline run, plus child `job_stages` (see [05-database-schema.md](./05-database-schema.md)). Stages: `ingest → frames → quality → sfm → train → cleanup → optimize → package → qa`.
+- Workers are **stage-typed**: `cpu` (ingest/frames/quality/optimize/package), `gpu-train` (sfm/train), `gpu-ai` (masking/cleanup/scoring). A job flows across worker types; the queue matches `stage → required worker class`.
+- Dequeue: worker polls `POST /internal/jobs/claim {worker_class, capabilities}` → API runs `UPDATE ... WHERE id = (SELECT id FROM processing_jobs WHERE status='queued' AND worker_class=$1 ORDER BY priority DESC, created_at LIMIT 1 FOR UPDATE SKIP LOCKED) RETURNING ...`.
+- **Pull model, outbound-only workers**: GPU boxes on RunPod/Lambda need no inbound ports; they claim work, download inputs via presigned URLs, upload outputs via presigned URLs, and POST progress/heartbeats. This is what makes the fleet provider-agnostic.
+
+### Reliability semantics
+
+- **Heartbeats**: worker heartbeats every 30 s; a job with no heartbeat for 5 min is marked `stalled` and re-queued (attempt count +1).
+- **Retries**: infrastructure failures (OOM, spot preemption, download error) auto-retry up to 3× with backoff, resuming from the last completed stage (stage outputs are persisted to object storage as checkpoints). Content failures (SfM can't register frames) do **not** retry — they fail fast with a `failure_code` + human reason.
+- **Idempotency**: every stage writes to a deterministic object-storage prefix (`projects/{id}/jobs/{job_id}/{stage}/`); re-running a stage overwrites cleanly.
+- **Priority**: integer priority — Agency/priority-credit jobs > Pro > Starter > trial. Per-plan concurrent-job caps prevent queue monopolization.
+- **Cancellation**: user cancel sets `cancel_requested`; workers check between sub-steps and at checkpoint boundaries.
+- **Progress**: workers POST `{stage, pct, message}`; API relays via Valkey pub/sub → SSE/WebSocket to the status page; also persisted to `processing_logs`.
+- **Dead-letter**: jobs exceeding max attempts land in `failed` with full logs; visible in admin console X1/X2 with one-click retry.
+- **Cost telemetry**: each stage records worker class, GPU type, wall-clock seconds, and estimated cost — aggregated per job/plan for unit-economics tracking (PRD risk #2).
+
+## Cloud/GPU infrastructure plan
+
+### Principles
+
+1. **Provider-agnostic GPU fleet.** Workers are plain Docker images (CUDA base) that pull jobs over HTTPS. They run identically on RunPod, Lambda Cloud, CoreWeave, Vast.ai (with vetting), or AWS g5/g6.
+2. **Control plane on boring managed infra.** API + Postgres + web app on a mainstream cloud (e.g., AWS: ECS/Fargate + RDS + S3 + CloudFront; or Hetzner + managed PG for cost). The control plane never needs a GPU.
+3. **Egress is a first-class cost.** Tour assets served via CDN with long cache lifetimes; SOG compression keeps per-tour delivery ~20–40 MB.
+
+### GPU sizing (MVP)
+
+| Workload | GPU | Est. time per tour (apartment, ~300–600 frames) |
+|---|---|---|
+| COLMAP (GPU SIFT + matching) | L4 / RTX 4090 / A10G class, 24 GB | 10–30 min sequential matcher |
+| Splatfacto training (30k iters) | same | 20–45 min |
+| SAM2 masking + detection | same (or smaller) | 5–15 min |
+| CPU stages (ffmpeg, transform, package) | CPU-only nodes | 5–10 min |
+
+Working planning number: **~1–1.5 GPU-hours per tour**, ≈ $0.5–1.5 on spot/community pricing, $2–5 on on-demand cloud — comfortably inside the ≤ 20%-of-revenue guardrail at €12–15/credit.
+
+### Scaling model
+
+- **Phase 1:** one rented GPU box, jobs run manually.
+- **Phase 2 (MVP):** 1–2 always-on GPU workers on RunPod/Lambda + autoscaler script that watches queue depth and starts/stops instances via provider API. Spot/community instances with stage checkpointing (retry semantics above absorb preemption).
+- **Phase 4+:** scheduled capacity for business hours per market; burst to on-demand; optionally AWS Batch/ECS-GPU if consolidating onto AWS (per the AWS guidance sample).
+
+### Environments
+
+- `dev` (docker-compose: Postgres, Valkey, MinIO, one local worker; small test datasets)
+- `staging` (full pipeline on 1 GPU, synthetic + fixture properties, license scan gate)
+- `prod` (as above; separate storage buckets, keys, and DB; no research code)
+
+### Storage layout (S3)
+
+```
+s3://splatestate-media/                # private bucket, signed URLs only
+  agencies/{agency_id}/branding/...
+  projects/{project_id}/
+    uploads/{upload_id}/original.*     # immutable original
+    jobs/{job_id}/
+      frames/{frame_id}.jpg            # extracted frames
+      frames_lowres/...                # analysis proxies
+      masks/{frame_id}.png
+      sfm/{colmap|opensfm}/...         # poses, sparse model
+      train/checkpoints/...            # resumable checkpoints (TTL 7d)
+      splat/raw.ply                    # training export
+      splat/cleaned.ply
+s3://splatestate-tours/                # CDN-fronted; public objects only for published tours
+  tours/{tour_slug}/
+    scene.sog / scene-mobile.sog
+    viewer-config.json                 # served via API for private tours
+    cover.jpg / thumb.jpg
+```
+
+Private tours are never in the public bucket: viewer fetches short-lived signed URLs through the API after access check (unlisted-token / password / auth).

--- a/docs/splatestate/04-pipeline.md
+++ b/docs/splatestate/04-pipeline.md
@@ -1,0 +1,151 @@
+# 04 — Reconstruction Pipeline & AI Enhancement Plan
+
+## Pipeline overview
+
+Ten stages, each checkpointed to object storage, each with pass/fail criteria and cost telemetry. Stage names match the queue design in [03-architecture.md](./03-architecture.md#processing-queue-design).
+
+```
+ingest → frames → quality → sfm → train → cleanup → optimize → package → qa → publish(user)
+```
+
+## Stage 1 — Media ingest (`ingest`, CPU)
+
+- Persist original upload (immutable; never modified or deleted by the pipeline).
+- Extract metadata: container, codec, resolution, duration, fps, bitrate, GPS/EXIF (stripped from published outputs), camera model hints.
+- Detect media type: 360 equirectangular video (2:1 aspect + metadata heuristics + user declaration), flat video, photo set.
+- Validate: decodable, duration 1–30 min (video), resolution ≥ 1080p flat / ≥ 4K equirect recommended, photo count 50–1000.
+- Generate preview thumbnail + short proxy clip for the dashboard.
+- **Fail fast** with actionable copy on invalid input ("This looks like a flat video but the project is set to 360 — change capture type or re-upload").
+
+## Stage 2 — Frame extraction (`frames`, CPU)
+
+- FFmpeg extracts frames at controlled rate: adaptive 1–3 fps targeting **300–600 candidate frames** (hard cap enforced for cost).
+- **360 path:** equirectangular frames are reprojected via FFmpeg `v360` into 6–8 virtual pinhole cameras per frame position (yaw ring at eye level + up/down as needed, ~90° FOV, shared intrinsics). Each virtual view becomes an SfM/training image with known relative rotations (used as priors where the SfM backend supports rig constraints).
+  - Alternative path (A/B tested in Phase 1): keep equirect frames and use **OpenSfM's spherical camera model** end-to-end, then convert poses for training.
+- Low-res proxies (480p) generated for all analysis steps — full-res touched only by SfM/training.
+- Frame metadata rows written (`frames` table): index, timestamp, source region (for 360 crops), paths, sharpness/exposure placeholders.
+
+## Stage 3 — Frame quality filtering (`quality`, CPU + light GPU)
+
+The pre-flight gate that protects GPU spend and reconstruction quality. All detectors run on proxies.
+
+| Check | Method (permissive-license) | Action |
+|---|---|---|
+| Blur / motion blur | Variance of Laplacian + Tenengrad (OpenCV, Apache-2.0) with per-video adaptive threshold | Drop frame if sharpest-in-window alternative exists |
+| Over/under-exposure | Histogram clipping %, mean luma bounds | Drop or downweight; feed exposure stats to harmonization |
+| Camera shake | Optical-flow magnitude between neighbors (OpenCV) | Drop spikes; if sustained → capture-quality warning |
+| Duplicates/redundancy | Perceptual hash + flow < ε | Keep 1 of N; reduces training set bloat |
+| Dynamic objects | Lightweight detector (see AI layer) on people/pets/vehicles | Mask (preferred) or drop frame if subject dominates |
+| Coverage/gap analysis | Frame timeline + (post-SfM) trajectory gaps | Warnings: "not enough coverage in one area" |
+
+**Gate decision:** if < 60% of candidate frames survive, or coverage heuristics fail, the job stops here with `failure_code=capture_quality`, a plain-language reason, and recapture guidance — **before** any GPU training spend. Credit auto-refunded.
+
+## Stage 4 — SfM / pose estimation (`sfm`, GPU)
+
+Escalation ladder (each step only if the previous fails registration thresholds):
+
+1. **COLMAP** (BSD): GPU SIFT, **sequential matcher** (video ordering prior) + loop detection via vocabulary tree; incremental mapper.
+2. **GLOMAP / COLMAP global mapper** (BSD-3): global SfM for speed on large frame sets or when incremental drifts.
+3. **OpenSfM** (BSD-2): spherical camera model directly on equirect frames — primary fallback for 360 footage.
+4. **HLOC** (Apache-2.0): learned features + matching for low-texture/repetitive interiors (verify each model checkpoint license; SuperPoint weights are non-commercial — use license-safe alternatives such as ALIKED/DISK + LightGlue, each individually verified).
+
+**Pass criteria:** ≥ 70% frames registered, single connected component covering the trajectory, reprojection error within bounds. Partial registration (one connected room cluster) can proceed with a "partial coverage" warning; disconnected components → fail with "the hallway transition failed — re-record moving slowly between rooms."
+
+Outputs: camera poses, sparse points, undistorted images — converted to Nerfstudio dataset format.
+
+## Stage 5 — Gaussian Splat training (`train`, GPU)
+
+- **Nerfstudio Splatfacto** (Apache-2.0) on the **gsplat** backend (Apache-2.0). No Inria rasterizer anywhere in the tree.
+- Mask-aware: per-frame masks from the AI layer are passed so masked pixels don't supervise training (people/tripod/mirror regions contribute no gradient).
+- Iteration budget by plan tier (e.g., 15k trial / 30k standard); densification caps to bound splat count (~1.5–3 M before optimization).
+- Checkpoint every 5k iters to object storage (spot-preemption resume).
+- Anti-aliased/absgrad options per gsplat for quality; config frozen per "pipeline version" recorded on the job for reproducibility.
+- Export: PLY with training stats (final losses, PSNR on held-out frames, gaussian count).
+- Phase 5 candidate: **splatfacto-w** (Apache-2.0) for captures with strong appearance/lighting variation.
+
+## Stage 6 — AI cleanup / compositing (`cleanup`, GPU) {#ai-enhancement-layer}
+
+### The AI enhancement layer — scope and framing
+
+Framed in-product as **"tour cleanup, artifact reduction, visual enhancement, and presentation polish"** — never "perfect reconstruction."
+
+**Ethics rule (enforced, not aspirational):** AI may remove *capture artifacts* (tripod, operator, passers-by, floaters, noise) and *privacy items* (faces, plates, documents, personal photos), and may correct *capture-induced* exposure/color problems. AI must never fake renovations, remove permanent defects or damage, alter room dimensions/geometry, or add content that isn't there. Every automated removal is listed to the user at review time and recorded in the audit log.
+
+### 6a. Dynamic object detection & segmentation
+
+- Detector (permissive: e.g., RT-DETR/RF-DETR-class under Apache-2.0 — verify weights; **not** Ultralytics YOLO, which is AGPL) finds: people, pets, moving cars (through windows), TVs with changing content, photographer/camera/tripod (self-capture signature at nadir in 360 footage), mirrors and problematic reflective surfaces.
+- **SAM2** (Apache-2.0 code; verify checkpoint terms) converts detections to precise masks and **propagates them across video frames** (SAM2's video mode is exactly this use case).
+- 360 nadir/tripod handling: fixed nadir mask for pole/hand region is applied always — the cheapest, highest-yield cleanup in the whole product.
+- Masks stored per frame (`masks` table + PNG in object storage), consumed by training (Stage 5) and privacy review.
+
+### 6b. Privacy detection
+
+- Face detection; license plates (through windows); personal documents/mail; family photos on walls; screens with personal content.
+- Output: flagged regions per frame → agent review screen offers blur/remove before publishing; GDPR-relevant categories default to **blur-on** with opt-out. (2D blur baked into training images MVP; 3D-aware removal Phase 5.)
+
+### 6c. Splat-space cleanup (post-training)
+
+- **Floater removal:** statistical outlier pruning (splats with low opacity contribution / far from the sparse-point support / isolated in space), plus visibility-based pruning from training-camera coverage — gsplat pruning utilities + custom pass.
+- **Boundary cropping:** auto-compute tight scene bounds from the camera trajectory + point density; crop noisy periphery (through-window "sky garbage", mirror ghosts beyond walls). Manual refinement in the SuperSplat-fork editor.
+- **Floor/wall denoise:** detect planar regions from sparse points; flatten/remove stray splats hovering off major planes (conservative thresholds — never re-shape actual geometry).
+- **Hole & gap management:** ray-coverage analysis marks weakly-reconstructed zones; small holes → hidden by navigation constraints (viewpoints never enter them); large holes → "recapture recommended for {area}" in the quality report; optional fallback still images for weak rooms in the tour UI. Never pretend a missing room exists.
+- **Mirror handling:** masked in training (6a); residual mirror-ghost splats behind wall planes removed by the plane pass.
+
+### 6d. Color & exposure harmonization
+
+- Per-frame exposure normalization before training (stats from Stage 3): gentle gain/curve matching toward the sequence median — bounded corrections only.
+- White-balance harmonization across rooms (bounded), preserving genuinely warm/cool lighting character.
+- Dark-room lift with a realism ceiling: improve legibility, never "showroom-fake" brightness.
+- All corrections logged with before/after params; "original exposure" toggle in review.
+
+### 6e. 3D inpainting (Phase 5, not MVP)
+
+- Candidate: **dfki-av/Inpaint360GS** (Apache-2.0 — verify model/data dependencies) for object-aware 3D inpainting of removed tripods/objects in 360 scenes.
+- MVP behavior instead: masking during training (usually leaves a soft plausible fill from other views) + manual cleanup in the editor + honest gaps where fill is impossible.
+
+### 6f. Tour presentation AI (Phase 3–4)
+
+- Room classification per trajectory cluster (kitchen/bath/bedroom via an image classifier on representative frames) → **suggested room labels**.
+- Suggested hotspots: viewpoint selection maximizing coverage/aesthetics per room; suggested "best room order" for the guided path (entrance → living → kitchen → bedrooms → bath → outdoor).
+- Best starting view: high coverage + high sharpness + doorway-facing heuristic; cover thumbnail rendered from it.
+- Listing copy generation (property summary, listing text, social teaser) from room labels + agent-supplied facts — clearly editable drafts, agent owns final text.
+
+### 6g. Quality scoring
+
+Composite score → label: **Excellent / Good / Usable / Needs review / Failed — recapture recommended.**
+
+Inputs: % frames surviving quality gate; SfM registration rate & trajectory connectivity; training PSNR/SSIM on held-out frames; splat count & floater ratio; coverage-hole area; per-room coverage.
+
+Every non-Excellent label ships **reasons in plain language**, e.g.: "Video moved too fast." / "Scene is too dark." / "Too many reflective surfaces." / "Camera path has gaps." / "Not enough coverage in the bedroom." / "The hallway transition failed." Reasons link to the matching capture-guide section.
+
+**Human-in-the-loop:** `Needs review` routes to a manual review queue (internal at MVP; "professional cleanup" paid upsell later).
+
+## Stage 7 — Optimization (`optimize`, CPU)
+
+- **splat-transform** (MIT): PLY → **SOG** compressed format; filtering, quantization, spherical-harmonics band reduction for the mobile variant.
+- Two variants: desktop (~≤ 80 MB) and mobile (~≤ 30 MB, reduced splat count/SH bands).
+- Render cover image, thumbnail, and social-preview (OG) image.
+
+## Stage 8 — Viewer packaging (`package`, CPU)
+
+- Generate `viewer-config.json`: asset URLs, starting camera, hotspot graph, room labels, navigation bounds (keep-out volumes from hole analysis), branding, CTA config, disclaimer flags.
+- Mint public/unlisted URLs (tokenized slugs), embed snippet, QR code.
+- Write `splat_assets` + `viewer_configs` rows; stage assets to the tour bucket (public only upon publish).
+
+## Stage 9 — QA (`qa`, CPU + headless GPU)
+
+Automated gate before the tour is offered to the agent:
+
+- File sizes within budget (mobile/desktop variants).
+- Headless-browser load test (Playwright + this repo's viewer): time-to-interactive, fps sample, WebGL fallback works.
+- Registered-frame %, camera-path sanity, gaussian count within bounds, no giant holes at the starting view.
+- Mobile viewport smoke test.
+- Result: `ready` (agent notified: "Your tour is ready to review") / `review` (internal queue) / `failed` (reason + recapture guidance).
+
+## Stage 10 — Publish (user action)
+
+Agent approves in the editor → chooses privacy mode (draft / unlisted / public / password / embed-only) → assets flip to CDN-served, analytics activate, lead form goes live. Unpublish reverses within CDN-TTL minutes.
+
+## Pipeline versioning
+
+Every job records `pipeline_version` (git SHA + config hash). Quality regressions are bisectable; reprocessing an old project uses the current pipeline and a new job row, never mutating old artifacts.

--- a/docs/splatestate/05-database-schema.md
+++ b/docs/splatestate/05-database-schema.md
@@ -1,0 +1,417 @@
+# 05 — Database Schema (PostgreSQL 16)
+
+Conventions: UUID v7 primary keys (time-ordered); `timestamptz` everywhere; `created_at`/`updated_at` on all tables (triggers omitted below for brevity); soft delete via `deleted_at` where noted; enums as Postgres types; JSONB for flexible configs with app-level validation.
+
+```sql
+-- ============================================================ enums
+CREATE TYPE member_role       AS ENUM ('owner','agent','editor');
+CREATE TYPE capture_type      AS ENUM ('video_360','video_flat','photo_set');
+CREATE TYPE project_status    AS ENUM ('draft','uploading','processing','ready','review','failed','published','archived');
+CREATE TYPE upload_status     AS ENUM ('initialized','uploading','completed','aborted','validated','invalid');
+CREATE TYPE job_status        AS ENUM ('queued','claimed','running','succeeded','failed','canceled','stalled');
+CREATE TYPE job_stage         AS ENUM ('ingest','frames','quality','sfm','train','cleanup','optimize','package','qa');
+CREATE TYPE worker_class      AS ENUM ('cpu','gpu_train','gpu_ai');
+CREATE TYPE mask_kind         AS ENUM ('person','pet','vehicle','tripod_operator','mirror_reflective','face','license_plate','document','personal_photo','screen','clutter','other');
+CREATE TYPE asset_kind        AS ENUM ('splat_raw','splat_cleaned','sog_desktop','sog_mobile','cover_image','thumbnail','og_image');
+CREATE TYPE privacy_mode      AS ENUM ('private','unlisted','public','password','embed_only');
+CREATE TYPE quality_label     AS ENUM ('excellent','good','usable','needs_review','failed');
+CREATE TYPE lead_status       AS ENUM ('new','contacted','qualified','closed','spam');
+CREATE TYPE plan_code         AS ENUM ('trial','starter','pro','agency');
+CREATE TYPE sub_status        AS ENUM ('trialing','active','past_due','canceled','paused');
+CREATE TYPE credit_reason     AS ENUM ('plan_grant','purchase','job_consume','failure_refund','admin_adjust','expiry');
+CREATE TYPE analytics_kind    AS ENUM ('tour_view','room_view','hotspot_click','cta_click','lead_submit','share_click','embed_load');
+
+-- ============================================================ 1. users
+CREATE TABLE users (
+  id               uuid PRIMARY KEY DEFAULT uuidv7(),
+  email            citext NOT NULL UNIQUE,
+  password_hash    text,                          -- null for OAuth-only accounts
+  oauth_provider   text,                          -- 'google' | null
+  oauth_subject    text,
+  full_name        text NOT NULL,
+  phone            text,
+  avatar_url       text,
+  email_verified_at timestamptz,
+  is_staff_admin   boolean NOT NULL DEFAULT false, -- internal admin; never settable via public API
+  tos_accepted_at  timestamptz,
+  marketing_opt_in boolean NOT NULL DEFAULT false,
+  training_opt_in  boolean NOT NULL DEFAULT false, -- explicit opt-in for ML use of uploads
+  last_login_at    timestamptz,
+  deleted_at       timestamptz,
+  created_at       timestamptz NOT NULL DEFAULT now(),
+  updated_at       timestamptz NOT NULL DEFAULT now(),
+  UNIQUE (oauth_provider, oauth_subject)
+);
+
+-- ============================================================ 2. agencies
+CREATE TABLE agencies (
+  id               uuid PRIMARY KEY DEFAULT uuidv7(),
+  name             text NOT NULL,
+  slug             citext NOT NULL UNIQUE,        -- public URL: /a/{slug}
+  logo_url         text,
+  brand_color      text,                          -- hex
+  website_url      text,
+  contact_email    citext,
+  contact_phone    text,
+  whatsapp_number  text,
+  country          text,                          -- ISO 3166-1
+  locale           text NOT NULL DEFAULT 'en',
+  white_label_domain text UNIQUE,                 -- upsell
+  deleted_at       timestamptz,
+  created_at       timestamptz NOT NULL DEFAULT now(),
+  updated_at       timestamptz NOT NULL DEFAULT now()
+);
+
+-- ============================================================ 3. agency_members
+CREATE TABLE agency_members (
+  id           uuid PRIMARY KEY DEFAULT uuidv7(),
+  agency_id    uuid NOT NULL REFERENCES agencies(id) ON DELETE CASCADE,
+  user_id      uuid NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  role         member_role NOT NULL DEFAULT 'agent',
+  invited_by   uuid REFERENCES users(id),
+  invited_email citext,                           -- pending invite before user exists
+  accepted_at  timestamptz,
+  created_at   timestamptz NOT NULL DEFAULT now(),
+  updated_at   timestamptz NOT NULL DEFAULT now(),
+  UNIQUE (agency_id, user_id)
+);
+CREATE INDEX idx_members_user   ON agency_members (user_id);
+CREATE INDEX idx_members_agency ON agency_members (agency_id, role);
+
+-- ============================================================ 4. projects
+CREATE TABLE projects (
+  id               uuid PRIMARY KEY DEFAULT uuidv7(),
+  agency_id        uuid NOT NULL REFERENCES agencies(id) ON DELETE CASCADE,
+  created_by       uuid NOT NULL REFERENCES users(id),
+  title            text NOT NULL,
+  status           project_status NOT NULL DEFAULT 'draft',
+  capture_type     capture_type,
+  address          text,
+  city             text,
+  country          text,
+  price_amount     numeric(14,2),
+  price_currency   text,                          -- ISO 4217
+  listing_url      text,
+  description      text,
+  cover_asset_id   uuid,                          -- FK added after splat_assets
+  active_job_id    uuid,                          -- FK added after processing_jobs
+  published_at     timestamptz,
+  archived_at      timestamptz,
+  deleted_at       timestamptz,                   -- soft delete; hard purge job follows
+  purge_after      timestamptz,                   -- GDPR grace deadline
+  created_at       timestamptz NOT NULL DEFAULT now(),
+  updated_at       timestamptz NOT NULL DEFAULT now()
+);
+CREATE INDEX idx_projects_agency  ON projects (agency_id, status) WHERE deleted_at IS NULL;
+CREATE INDEX idx_projects_creator ON projects (created_by)         WHERE deleted_at IS NULL;
+
+-- ============================================================ 5. uploads
+CREATE TABLE uploads (
+  id               uuid PRIMARY KEY DEFAULT uuidv7(),
+  project_id       uuid NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
+  uploaded_by      uuid NOT NULL REFERENCES users(id),
+  status           upload_status NOT NULL DEFAULT 'initialized',
+  capture_type     capture_type NOT NULL,
+  storage_key      text NOT NULL,                 -- s3 key of original
+  s3_upload_id     text,                          -- multipart upload id
+  filename         text NOT NULL,
+  content_type     text,
+  size_bytes       bigint,
+  parts_total      integer,
+  parts_completed  integer NOT NULL DEFAULT 0,
+  checksum_sha256  text,
+  media_meta       jsonb,                         -- codec, duration, resolution, fps, is_equirect...
+  validation_errors jsonb,                        -- [{code, message}]
+  consent_confirmed boolean NOT NULL DEFAULT false, -- "I have permission to publish this media"
+  created_at       timestamptz NOT NULL DEFAULT now(),
+  updated_at       timestamptz NOT NULL DEFAULT now()
+);
+CREATE INDEX idx_uploads_project ON uploads (project_id, status);
+
+-- ============================================================ 6. frames
+CREATE TABLE frames (
+  id               uuid PRIMARY KEY DEFAULT uuidv7(),
+  job_id           uuid NOT NULL,                 -- FK added after processing_jobs
+  upload_id        uuid NOT NULL REFERENCES uploads(id) ON DELETE CASCADE,
+  frame_index      integer NOT NULL,
+  source_time_ms   integer,                       -- position in source video
+  view_yaw_deg     real,                          -- for 360→pinhole crops
+  view_pitch_deg   real,
+  storage_key      text NOT NULL,
+  lowres_key       text,
+  width            integer,
+  height           integer,
+  sharpness        real,                          -- variance of Laplacian
+  exposure_score   real,                          -- 0..1 (0=clipped)
+  shake_score      real,
+  is_duplicate_of  uuid REFERENCES frames(id),
+  excluded         boolean NOT NULL DEFAULT false,
+  exclusion_reason text,                          -- 'blur','overexposed','duplicate','dynamic_object',...
+  registered       boolean,                       -- SfM registered this frame
+  pose             jsonb,                         -- {q:[...], t:[...]} after SfM
+  created_at       timestamptz NOT NULL DEFAULT now()
+);
+CREATE UNIQUE INDEX idx_frames_job_ix ON frames (job_id, frame_index, view_yaw_deg, view_pitch_deg);
+CREATE INDEX idx_frames_job_included  ON frames (job_id) WHERE excluded = false;
+
+-- ============================================================ 7. masks
+CREATE TABLE masks (
+  id           uuid PRIMARY KEY DEFAULT uuidv7(),
+  frame_id     uuid NOT NULL REFERENCES frames(id) ON DELETE CASCADE,
+  kind         mask_kind NOT NULL,
+  storage_key  text NOT NULL,                     -- PNG mask in object storage
+  bbox         jsonb,                             -- [x,y,w,h] normalized
+  confidence   real,
+  source       text NOT NULL,                     -- 'sam2','detector','nadir_fixed','manual'
+  privacy_flag boolean NOT NULL DEFAULT false,    -- surfaced in privacy review
+  applied_in_training boolean NOT NULL DEFAULT true,
+  created_at   timestamptz NOT NULL DEFAULT now()
+);
+CREATE INDEX idx_masks_frame   ON masks (frame_id);
+CREATE INDEX idx_masks_privacy ON masks (privacy_flag) WHERE privacy_flag;
+
+-- ============================================================ 8. processing_jobs
+CREATE TABLE processing_jobs (
+  id               uuid PRIMARY KEY DEFAULT uuidv7(),
+  project_id       uuid NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
+  upload_id        uuid NOT NULL REFERENCES uploads(id),
+  requested_by     uuid NOT NULL REFERENCES users(id),
+  status           job_status NOT NULL DEFAULT 'queued',
+  current_stage    job_stage,
+  worker_class     worker_class NOT NULL DEFAULT 'cpu', -- class needed for current stage
+  priority         integer NOT NULL DEFAULT 0,
+  attempt          integer NOT NULL DEFAULT 1,
+  max_attempts     integer NOT NULL DEFAULT 3,
+  progress_pct     real NOT NULL DEFAULT 0,
+  progress_message text,
+  pipeline_version text NOT NULL,                 -- git SHA + config hash
+  worker_id        text,                          -- claiming worker instance
+  claimed_at       timestamptz,
+  heartbeat_at     timestamptz,
+  cancel_requested boolean NOT NULL DEFAULT false,
+  failure_code     text,                          -- machine taxonomy: 'capture_quality','sfm_registration',...
+  failure_reason   text,                          -- human-readable, shown to user
+  quality_label    quality_label,
+  quality_reasons  jsonb,                         -- ["Video moved too fast", ...]
+  stage_timings    jsonb,                         -- {stage: seconds}
+  cost_estimate_usd numeric(8,4),
+  gpu_type         text,
+  started_at       timestamptz,
+  finished_at      timestamptz,
+  created_at       timestamptz NOT NULL DEFAULT now(),
+  updated_at       timestamptz NOT NULL DEFAULT now()
+);
+-- queue dequeue index (FOR UPDATE SKIP LOCKED scan)
+CREATE INDEX idx_jobs_queue   ON processing_jobs (worker_class, priority DESC, created_at)
+  WHERE status = 'queued';
+CREATE INDEX idx_jobs_project ON processing_jobs (project_id, created_at DESC);
+CREATE INDEX idx_jobs_stalled ON processing_jobs (heartbeat_at) WHERE status IN ('claimed','running');
+CREATE INDEX idx_jobs_failed  ON processing_jobs (failure_code, created_at DESC) WHERE status = 'failed';
+
+ALTER TABLE frames   ADD CONSTRAINT fk_frames_job  FOREIGN KEY (job_id)        REFERENCES processing_jobs(id) ON DELETE CASCADE;
+ALTER TABLE projects ADD CONSTRAINT fk_active_job  FOREIGN KEY (active_job_id) REFERENCES processing_jobs(id) ON DELETE SET NULL;
+
+-- ============================================================ 9. processing_logs
+CREATE TABLE processing_logs (
+  id           bigint GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+  job_id       uuid NOT NULL REFERENCES processing_jobs(id) ON DELETE CASCADE,
+  stage        job_stage,
+  level        text NOT NULL DEFAULT 'info',      -- debug|info|warn|error
+  message      text NOT NULL,
+  data         jsonb,
+  created_at   timestamptz NOT NULL DEFAULT now()
+);
+CREATE INDEX idx_logs_job ON processing_logs (job_id, id);
+-- partition by month at scale; ship to Loki/S3 for long retention
+
+-- ============================================================ 10. splat_assets
+CREATE TABLE splat_assets (
+  id             uuid PRIMARY KEY DEFAULT uuidv7(),
+  project_id     uuid NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
+  job_id         uuid NOT NULL REFERENCES processing_jobs(id) ON DELETE CASCADE,
+  kind           asset_kind NOT NULL,
+  storage_key    text NOT NULL,
+  cdn_url        text,                            -- set on publish
+  size_bytes     bigint NOT NULL,
+  checksum_sha256 text,
+  gaussian_count integer,
+  sh_bands       smallint,
+  meta           jsonb,                           -- psnr, bounds, format version...
+  created_at     timestamptz NOT NULL DEFAULT now()
+);
+CREATE INDEX idx_assets_project ON splat_assets (project_id, kind);
+ALTER TABLE projects ADD CONSTRAINT fk_cover_asset FOREIGN KEY (cover_asset_id) REFERENCES splat_assets(id) ON DELETE SET NULL;
+
+-- ============================================================ 11. viewer_configs
+CREATE TABLE viewer_configs (
+  id               uuid PRIMARY KEY DEFAULT uuidv7(),
+  project_id       uuid NOT NULL UNIQUE REFERENCES projects(id) ON DELETE CASCADE,
+  privacy_mode     privacy_mode NOT NULL DEFAULT 'private',
+  public_slug      citext UNIQUE,                 -- /t/{slug}
+  unlisted_token   text UNIQUE,                   -- high-entropy token for unlisted links
+  password_hash    text,                          -- for password mode
+  starting_view    jsonb,                         -- {position, rotation, fov}
+  nav_bounds       jsonb,                         -- keep-out volumes, floor height
+  guided_path      jsonb,                         -- ordered hotspot ids + timings
+  branding         jsonb,                         -- {logo, color, agentName, photo, phone, whatsapp}
+  cta_config       jsonb,                         -- buttons, lead-form fields toggles
+  details_panel    jsonb,                         -- price/address/description visibility
+  watermark        boolean NOT NULL DEFAULT false,
+  embed_allowed_origins text[],
+  disclaimer_shown boolean NOT NULL DEFAULT true,
+  published_version integer NOT NULL DEFAULT 0,   -- bump on publish; cache-bust key
+  created_at       timestamptz NOT NULL DEFAULT now(),
+  updated_at       timestamptz NOT NULL DEFAULT now()
+);
+
+-- ============================================================ 12. hotspots
+CREATE TABLE hotspots (
+  id             uuid PRIMARY KEY DEFAULT uuidv7(),
+  project_id     uuid NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
+  kind           text NOT NULL DEFAULT 'nav',     -- 'nav' | 'room_label' | 'info'
+  label          text NOT NULL,                   -- "Kitchen", "Master bedroom"
+  position       jsonb NOT NULL,                  -- [x,y,z] in scene space
+  camera_pose    jsonb,                           -- viewpoint to fly to {position, rotation}
+  sort_order     integer NOT NULL DEFAULT 0,      -- guided-path ordering
+  ai_suggested   boolean NOT NULL DEFAULT false,
+  created_at     timestamptz NOT NULL DEFAULT now(),
+  updated_at     timestamptz NOT NULL DEFAULT now()
+);
+CREATE INDEX idx_hotspots_project ON hotspots (project_id, sort_order);
+
+-- ============================================================ 13. leads
+CREATE TABLE leads (
+  id                uuid PRIMARY KEY DEFAULT uuidv7(),
+  project_id        uuid NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
+  agency_id         uuid NOT NULL REFERENCES agencies(id) ON DELETE CASCADE, -- denormalized for inbox queries
+  status            lead_status NOT NULL DEFAULT 'new',
+  name              text NOT NULL,
+  email             citext,
+  phone             text,
+  message           text,
+  preferred_contact text,                         -- 'email'|'phone'|'whatsapp'
+  viewing_at        timestamptz,                  -- desired viewing date/time (optional)
+  source            text,                         -- 'tour'|'embed'|'agency_page'
+  referrer          text,
+  device_type       text,
+  ip_hash           text,                         -- salted hash, spam control; raw IP never stored
+  consent_at        timestamptz NOT NULL,         -- lead-form privacy consent
+  handled_by        uuid REFERENCES users(id),
+  handled_at        timestamptz,
+  created_at        timestamptz NOT NULL DEFAULT now(),
+  updated_at        timestamptz NOT NULL DEFAULT now()
+);
+CREATE INDEX idx_leads_agency  ON leads (agency_id, status, created_at DESC);
+CREATE INDEX idx_leads_project ON leads (project_id, created_at DESC);
+
+-- ============================================================ 14. analytics_events
+CREATE TABLE analytics_events (
+  id           bigint GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+  project_id   uuid NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
+  kind         analytics_kind NOT NULL,
+  session_id   text NOT NULL,                     -- anonymous, rotating, cookieless
+  hotspot_id   uuid REFERENCES hotspots(id) ON DELETE SET NULL,
+  duration_ms  integer,                           -- for view-time events
+  device_type  text,                              -- 'desktop'|'mobile'|'tablet'
+  country      text,                              -- from IP at edge; IP not stored
+  city         text,                              -- coarse, privacy-safe
+  referrer     text,
+  meta         jsonb,
+  created_at   timestamptz NOT NULL DEFAULT now()
+) PARTITION BY RANGE (created_at);                 -- monthly partitions
+CREATE INDEX idx_events_project ON analytics_events (project_id, kind, created_at);
+-- nightly rollup into project_analytics_daily materialized summaries
+
+-- ============================================================ 15. billing_plans
+CREATE TABLE billing_plans (
+  id               uuid PRIMARY KEY DEFAULT uuidv7(),
+  code             plan_code NOT NULL UNIQUE,
+  name             text NOT NULL,
+  stripe_price_id  text,
+  monthly_price_cents integer NOT NULL,
+  currency         text NOT NULL DEFAULT 'EUR',
+  tours_per_month  integer NOT NULL,               -- credit grant per cycle
+  seats            integer NOT NULL DEFAULT 1,
+  watermark        boolean NOT NULL DEFAULT false,
+  priority         integer NOT NULL DEFAULT 0,     -- queue priority
+  storage_gb       integer NOT NULL,
+  features         jsonb,                          -- {branding: true, analytics: 'full', ...}
+  active           boolean NOT NULL DEFAULT true,
+  created_at       timestamptz NOT NULL DEFAULT now()
+);
+
+-- ============================================================ 16. subscriptions
+CREATE TABLE subscriptions (
+  id                    uuid PRIMARY KEY DEFAULT uuidv7(),
+  agency_id             uuid NOT NULL UNIQUE REFERENCES agencies(id) ON DELETE CASCADE,
+  plan_id               uuid NOT NULL REFERENCES billing_plans(id),
+  status                sub_status NOT NULL,
+  stripe_customer_id    text UNIQUE,
+  stripe_subscription_id text UNIQUE,
+  current_period_start  timestamptz,
+  current_period_end    timestamptz,
+  cancel_at_period_end  boolean NOT NULL DEFAULT false,
+  created_at            timestamptz NOT NULL DEFAULT now(),
+  updated_at            timestamptz NOT NULL DEFAULT now()
+);
+CREATE INDEX idx_subs_status ON subscriptions (status, current_period_end);
+
+-- ============================================================ 17. processing_credits (ledger)
+CREATE TABLE processing_credits (
+  id           uuid PRIMARY KEY DEFAULT uuidv7(),
+  agency_id    uuid NOT NULL REFERENCES agencies(id) ON DELETE CASCADE,
+  delta        integer NOT NULL,                  -- +grant / -consume
+  reason       credit_reason NOT NULL,
+  job_id       uuid REFERENCES processing_jobs(id) ON DELETE SET NULL,
+  stripe_payment_intent_id text,
+  expires_at   timestamptz,                       -- plan-grant credits expire at period end
+  note         text,
+  created_by   uuid REFERENCES users(id),         -- for admin_adjust
+  created_at   timestamptz NOT NULL DEFAULT now()
+);
+CREATE INDEX idx_credits_agency ON processing_credits (agency_id, created_at DESC);
+-- balance = SUM(delta) over non-expired rows; enforced non-negative in app txn:
+--   consume inserts a -1 row inside the same transaction that enqueues the job,
+--   guarded by SELECT ... FOR UPDATE on a per-agency advisory lock.
+
+-- ============================================================ 18. audit_logs
+CREATE TABLE audit_logs (
+  id           bigint GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+  actor_id     uuid REFERENCES users(id),          -- null for system actions
+  actor_type   text NOT NULL DEFAULT 'user',       -- 'user'|'system'|'admin'
+  agency_id    uuid REFERENCES agencies(id) ON DELETE SET NULL,
+  action       text NOT NULL,                      -- 'project.publish','project.delete','member.role_change',
+                                                   -- 'ai.removal_applied','admin.impersonate','data.export',...
+  target_type  text,                               -- 'project'|'user'|'lead'|...
+  target_id    uuid,
+  data         jsonb,                              -- before/after, AI edit list, etc.
+  ip_hash      text,
+  created_at   timestamptz NOT NULL DEFAULT now()
+);
+CREATE INDEX idx_audit_agency ON audit_logs (agency_id, created_at DESC);
+CREATE INDEX idx_audit_target ON audit_logs (target_type, target_id, created_at DESC);
+```
+
+## Relationship summary
+
+```
+users ──< agency_members >── agencies ──1:1── subscriptions >── billing_plans
+                                │  ──< processing_credits (ledger)
+                                │  ──< leads (denormalized agency_id)
+                                └──< projects ──< uploads ──< processing_jobs ──< processing_logs
+                                        │                          │ ──< frames ──< masks
+                                        │                          └──< splat_assets
+                                        │──1:1── viewer_configs
+                                        │──< hotspots
+                                        │──< leads
+                                        └──< analytics_events (partitioned)
+audit_logs — cross-cutting, references actors/targets loosely
+```
+
+## Design notes
+
+- **Queue in the DB:** `idx_jobs_queue` is the partial index behind the `FOR UPDATE SKIP LOCKED` dequeue; queue health = one query.
+- **Credits as an append-only ledger** (never a mutable balance column): auditability, easy refunds (`failure_refund` rows), Stripe reconciliation.
+- **Privacy by construction:** raw IPs never stored (salted `ip_hash` only); analytics are cookieless session-scoped; `training_opt_in` defaults false; `purge_after` drives the hard-delete job that removes DB rows *and* object-storage prefixes.
+- **Denormalizations:** `leads.agency_id` (inbox queries), `projects.active_job_id` (dashboard status chip) — both maintained in the owning transaction.
+- **Scale-outs planned, not built:** partition `analytics_events` monthly from day one; partition `processing_logs` when > ~50 M rows; move analytics rollups to materialized daily summaries.

--- a/docs/splatestate/06-api.md
+++ b/docs/splatestate/06-api.md
@@ -1,0 +1,146 @@
+# 06 — API Plan
+
+REST/JSON, versioned under `/api/v1`. Auth: short-lived JWT access token + rotating refresh token (httpOnly cookies for the web app; Bearer for future API customers). All non-public endpoints enforce agency membership + role (RBAC column notes below). OpenAPI spec generated from FastAPI. Errors: RFC 7807 problem+json with stable `code` fields. Rate limits at the edge; strict limits on public endpoints (lead submit, analytics ingest).
+
+## Authentication
+
+| Method | Path | Role | Notes |
+|---|---|---|---|
+| POST | `/auth/register` | public | email, password, full_name, tos_accept; sends verification email |
+| POST | `/auth/login` | public | email+password → tokens; lockout on brute force |
+| POST | `/auth/oauth/google` | public | OAuth code exchange |
+| POST | `/auth/logout` | any | revokes refresh token |
+| POST | `/auth/refresh` | any | rotate tokens |
+| POST | `/auth/password/forgot` | public | always-200 (no user enumeration) |
+| POST | `/auth/password/reset` | public | token + new password |
+| POST | `/auth/verify-email` | public | token |
+
+## Agency
+
+| Method | Path | Role | Notes |
+|---|---|---|---|
+| GET | `/agency` | member | current user's agency + own role |
+| PATCH | `/agency` | owner | name, contacts, locale, slug |
+| POST | `/agency/logo` | owner | presigned upload → validated (type/size) → set |
+| GET | `/agency/members` | member | list with roles |
+| POST | `/agency/members/invite` | owner | email + role; idempotent per email |
+| DELETE | `/agency/members/{member_id}` | owner | cannot remove last owner |
+| PATCH | `/agency/members/{member_id}` | owner | update role; cannot demote last owner |
+| POST | `/agency/invites/{token}/accept` | authed user | join agency |
+
+## Projects
+
+| Method | Path | Role | Notes |
+|---|---|---|---|
+| POST | `/projects` | agent+ | title, capture_type, address… |
+| GET | `/projects` | member | own (agent) / all (owner); filter by status; cursor pagination |
+| GET | `/projects/{id}` | project access | full detail incl. active job summary |
+| PATCH | `/projects/{id}` | agent(own)/editor/owner | metadata fields |
+| POST | `/projects/{id}/archive` | agent(own)/owner | |
+| DELETE | `/projects/{id}` | agent(own)/owner | soft delete + schedules hard purge; response lists exactly what will be destroyed |
+
+## Uploads (resumable multipart)
+
+| Method | Path | Role | Notes |
+|---|---|---|---|
+| POST | `/projects/{id}/uploads` | agent+ | init: filename, size, content_type, capture_type, consent_confirmed → upload_id + part size |
+| POST | `/uploads/{id}/parts/{n}` | uploader | returns presigned PUT URL for part n (client uploads direct to S3) |
+| POST | `/uploads/{id}/complete` | uploader | part ETags → finalize; triggers async validation |
+| POST | `/uploads/{id}/cancel` | uploader | aborts multipart, cleans parts |
+| GET | `/uploads/{id}` | project access | status, parts_completed, validation result / errors |
+
+## Processing
+
+| Method | Path | Role | Notes |
+|---|---|---|---|
+| POST | `/projects/{id}/process` | agent+ | consumes 1 credit (transactional with enqueue); optional `{priority: true}` (priority credit); 402 if no credits |
+| GET | `/projects/{id}/jobs` | project access | job history |
+| GET | `/jobs/{id}` | project access | status, stage, progress_pct, message, quality label+reasons, failure info |
+| GET | `/jobs/{id}/events` | project access | SSE stream of live progress |
+| GET | `/jobs/{id}/logs` | project access | user-safe log excerpt (full logs admin-only) |
+| POST | `/jobs/{id}/retry` | agent+ | only for retryable failure codes; no extra credit |
+| POST | `/jobs/{id}/cancel` | agent+ | sets cancel_requested |
+
+### Internal (worker-facing, mTLS/token-authed, separate listener)
+
+| Method | Path | Notes |
+|---|---|---|
+| POST | `/internal/jobs/claim` | `{worker_class, worker_id, capabilities}` → job payload + presigned I/O URLs, or 204 |
+| POST | `/internal/jobs/{id}/heartbeat` | liveness + optional progress |
+| POST | `/internal/jobs/{id}/progress` | `{stage, pct, message}` → fan-out to SSE |
+| POST | `/internal/jobs/{id}/stage-complete` | stage outputs manifest; advances stage / re-queues to next worker_class |
+| POST | `/internal/jobs/{id}/fail` | `{failure_code, failure_reason, retryable}` |
+| POST | `/internal/jobs/{id}/complete` | final artifacts manifest, quality score, cost telemetry |
+
+## Editor
+
+| Method | Path | Role | Notes |
+|---|---|---|---|
+| GET | `/projects/{id}/viewer-config` | project access | full config for editor |
+| PATCH | `/projects/{id}/viewer-config` | agent(own)/editor/owner | starting_view, branding, cta_config, details_panel, nav_bounds, guided_path |
+| POST | `/projects/{id}/hotspots` | editor+ | label, kind, position, camera_pose |
+| PATCH | `/hotspots/{id}` | editor+ | |
+| DELETE | `/hotspots/{id}` | editor+ | |
+| PUT | `/projects/{id}/hotspots/order` | editor+ | bulk sort_order for guided path |
+| POST | `/projects/{id}/cover` | editor+ | `{camera_pose}` → server renders cover from that view, or presigned upload |
+| POST | `/projects/{id}/starting-view` | editor+ | set from current camera |
+| POST | `/projects/{id}/splat-edits` | editor+ | crop bounds / deletion selections from the SuperSplat-fork editor → re-runs optimize+package stages only |
+
+## Publishing
+
+| Method | Path | Role | Notes |
+|---|---|---|---|
+| POST | `/projects/{id}/publish` | agent(own)/owner | `{privacy_mode, password?}`; bumps published_version; flips assets to CDN |
+| POST | `/projects/{id}/unpublish` | agent(own)/owner | back to private draft |
+| PATCH | `/projects/{id}/privacy` | agent(own)/owner | change mode without republish |
+| GET | `/public/tours/{slug}` | public* | viewer bootstrap: config + signed asset URLs. *Access check by mode: public → open; unlisted → valid token in slug; password → `X-Tour-Password` verified; embed_only → Origin allow-list |
+| POST | `/public/tours/{slug}/password` | public | password → short-lived tour access token |
+| GET | `/projects/{id}/embed-code` | project access | iframe snippet + allowed origins |
+
+## Leads
+
+| Method | Path | Role | Notes |
+|---|---|---|---|
+| POST | `/public/tours/{slug}/leads` | public | name, email/phone, message, preferred_contact, viewing_at?; consent checkbox required; honeypot + rate limit + optional CAPTCHA on abuse signal; triggers agent email |
+| GET | `/leads` | agent(own)/owner | inbox; filter by project/status; cursor pagination |
+| GET | `/leads/{id}` | lead access | |
+| PATCH | `/leads/{id}` | lead access | status (contacted/qualified/closed/spam), handled_by |
+
+## Analytics
+
+| Method | Path | Role | Notes |
+|---|---|---|---|
+| POST | `/public/tours/{slug}/events` | public | batched viewer events (kind, session_id, duration, hotspot_id); cookieless; validated against published tours only; fire-and-forget 202 |
+| GET | `/projects/{id}/analytics` | project access | rollups: views, uniques, avg time, room engagement, CTA clicks, leads, device/geo/referrer; `?from=&to=` |
+| GET | `/agency/analytics` | owner | agency-wide rollup |
+
+## Billing
+
+| Method | Path | Role | Notes |
+|---|---|---|---|
+| GET | `/billing/plan` | member | current plan, credit balance, usage this period |
+| GET | `/billing/plans` | member | available plans |
+| POST | `/billing/checkout` | owner | Stripe Checkout session for plan change |
+| POST | `/billing/credits/checkout` | owner | buy credit pack |
+| GET | `/billing/usage` | owner | credits ledger, per-tour cost history, invoices link (Stripe portal) |
+| POST | `/billing/portal` | owner | Stripe customer portal session |
+| POST | `/webhooks/stripe` | Stripe (signed) | subscription lifecycle, payment success → credit grants |
+
+## Admin (staff only, separate subdomain, `is_staff_admin` + SSO + audit)
+
+| Method | Path | Notes |
+|---|---|---|
+| GET | `/admin/jobs` | filter by status/failure_code/agency/date; failure-taxonomy counts |
+| GET | `/admin/jobs/{id}` | full logs, artifacts, timings, cost |
+| POST | `/admin/jobs/{id}/retry` | force retry, optional stage override |
+| GET | `/admin/accounts` / `POST /admin/accounts/{id}/suspend` / `.../reinstate` | audited |
+| POST | `/admin/projects/{id}/takedown` | abuse/privacy takedown: unpublish + flag + notify owner |
+| GET | `/admin/reports` | abuse/privacy report queue (from viewer "report" link) |
+| POST | `/admin/credits/adjust` | manual ledger adjustment with note (audited) |
+
+## Cross-cutting conventions
+
+- **Pagination:** cursor-based (`?cursor=&limit=`), `limit ≤ 100`.
+- **Idempotency:** `Idempotency-Key` header honored on POST `/process`, `/publish`, checkout endpoints.
+- **Webhooks (later, CRM upsell):** agency-configurable webhook on `lead.created`, `tour.published`, `job.finished` with HMAC signatures.
+- **Audit:** publish/unpublish/delete/role-change/billing/admin actions and all AI removals write `audit_logs` rows.

--- a/docs/splatestate/07-security-privacy.md
+++ b/docs/splatestate/07-security-privacy.md
@@ -1,0 +1,65 @@
+# 07 — Security, Privacy, GDPR, and Legal Plan
+
+## Security
+
+### Access control
+
+- Role-based access enforced server-side on every endpoint (Owner / Agent / Editor / staff Admin — see [02-user-flows-ux.md](./02-user-flows-ux.md#user-roles)). Agents see only their own projects/leads; Owners see agency-wide; Editors get edit-only scopes.
+- Staff admin is a DB flag never settable via public API; admin console on a separate subdomain behind staff SSO; all admin actions (including support impersonation) audited.
+- Private tours are **never publicly accessible**: private/unlisted/password assets live in the private bucket and are served only via short-lived signed URLs issued after an access check (`GET /public/tours/{slug}` performs mode-specific verification). Unlisted tokens are ≥ 128-bit random; password mode uses hashed passwords + short-lived tour access tokens.
+- No object-storage bucket is world-listable; the public tour bucket contains only assets of currently-published public tours (unpublish removes/invalidates within CDN TTL).
+
+### Application security
+
+- Auth: argon2id password hashing; rate-limited login with lockout; email verification; refresh-token rotation with reuse detection; 2FA (TOTP) post-MVP.
+- **Malicious upload defense:** presigned direct-to-S3 upload (user bytes never traverse the API); content-type + magic-byte validation; size caps; FFmpeg probe/decode in a sandboxed, resource-limited, network-isolated container (media parsers are a classic RCE surface); uploads treated as untrusted data everywhere; images re-encoded before any reuse.
+- Workers are outbound-only (pull model): no inbound ports on GPU fleet; worker auth via per-instance tokens; internal API on a separate listener.
+- Standard web controls: CSP on viewer and app, CSRF protection, strict CORS (embed mode uses per-tour Origin allow-lists), HTML-escaping of all user content (lead messages, descriptions), SSRF-safe URL fields.
+- Secrets in a manager (not env-files in repo); least-privilege IAM per service; per-environment isolation (dev/staging/prod buckets, DBs, keys).
+- Dependency scanning + license scanning in CI ([03-architecture.md](./03-architecture.md#license-inventory)); image scanning for worker containers.
+- Backups: nightly encrypted Postgres backups + point-in-time recovery; object storage versioning on originals; restore drills quarterly.
+
+### Audit
+
+`audit_logs` captures: publish/unpublish, privacy-mode changes, project deletion, member/role changes, billing events, data exports, admin actions, and **every AI removal applied to a tour** (what was removed, by which model, at what confidence) — supporting both security forensics and the truthful-representation policy.
+
+## Privacy & GDPR
+
+### Principles
+
+1. **Private by default.** New tours are private drafts; nothing is public, indexed, or shared until the agent explicitly publishes. `noindex` on unlisted/password tours; only `public` tours may appear in sitemaps.
+2. **Minimal data.** Raw IPs never stored (salted hashes for anti-abuse only); analytics are cookieless and session-scoped; geo is coarse (country/city).
+3. **No training on user data without explicit opt-in.** `training_opt_in` defaults to false; opt-in is granular, revocable, and never bundled into ToS acceptance.
+4. **Consent at upload.** Before every upload the user confirms: (a) they have permission to capture and publish media of this property; (b) they accept processing of the footage (which may incidentally contain personal data) for tour generation.
+
+### Data subject rights (agents and incidental subjects)
+
+- **Delete:** project deletion destroys original media, frames, masks, splat assets, tour bundles, and CDN copies (7-day soft-delete grace, then hard purge job across DB + object storage + backups per rotation schedule; audit record of the deletion retained). Account deletion cascades likewise. Users can also delete only original uploads while keeping the finished tour.
+- **Export:** self-serve export of account data, project metadata, leads, and analytics (JSON/CSV) + download of original media.
+- **Retention policy (defaults, published):** originals 90 days after successful processing (configurable; agent may delete earlier); frames/masks 30 days after job completion (debug window) then purged; published tour assets for subscription lifetime + 90-day grace; leads until agency deletes them; logs 90 days; backups roll off in 30 days.
+- **Incidental subjects** (people in footage, neighbors' plates): pipeline privacy detection (faces, plates, documents, personal photos) defaults to blur-on for GDPR-relevant categories; viewer includes a "report a privacy concern" link feeding the admin takedown queue with an SLA.
+
+### Compliance operations
+
+- Records of processing activities; DPAs with subprocessors (cloud, GPU providers, Stripe, email); data-residency choice (EU region default for EU customers); privacy policy in plain language; DPO/contact route; breach-notification runbook (72-hour clock).
+- Lead form: explicit consent checkbox, purpose limitation (contact about this property), agency is data controller for leads / SplatEstate is processor — reflected in ToS and DPA.
+
+## AI ethics & truthful-representation policy (product-enforced)
+
+**Allowed (capture artifacts & privacy):** removing tripod/operator/passers-by/pets; floater and noise cleanup; boundary cropping; bounded exposure/white-balance correction; blurring faces, plates, documents, personal photos; hiding unreconstructed areas honestly.
+
+**Forbidden (material misrepresentation):** faking renovations or finishes; removing/hiding permanent defects, damage, stains, cracks, mold; altering room dimensions or geometry; adding objects/furniture; brightness manipulation beyond realism bounds; presenting a partial reconstruction as complete.
+
+**Enforcement mechanisms:**
+- The cleanup pipeline only operates on masked *transient/privacy* classes and statistical artifacts — there is no "remove arbitrary object" tool in the agent UI at MVP.
+- Review screen lists every automated removal/correction; agent confirms before publish.
+- Audit log of AI edits per tour (see above) — the evidence trail if a buyer disputes a tour.
+- Viewer footer disclaimer on every tour.
+
+## Legal / product disclaimers (shipped copy)
+
+- "Tours are visual marketing assets, not measurement-grade scans or architectural surveys."
+- "AI cleanup removes capture artifacts and protects privacy; it does not alter the property's actual condition."
+- "The publisher confirms they have the right to capture, upload, and publish media of this property."
+- ToS: user responsibility for upload/publication rights; acceptable-use (no scanning of properties without authorization, no harassment/doxxing use); DMCA/notice-and-takedown route; limitation of liability for reconstruction accuracy.
+- **Pre-launch legal review checklist:** third-party license inventory (code + model weights), ToS/privacy policy/DPA review, GDPR records, marketing-claims review (no "accurate"/"exact" language), insurance review (E&O).

--- a/docs/splatestate/08-personal-testing.md
+++ b/docs/splatestate/08-personal-testing.md
@@ -1,0 +1,54 @@
+# 08 — Personal-Testing Order (Experimental Repos)
+
+Purpose: a hands-on evaluation sequence for learning the space and benchmarking quality — **on your own test footage, on a research machine, in a quarantined environment**. Several of these repos are research code with non-commercial licenses or non-commercial *dependencies*. None of them may be imported into, vendored into, or linked from the production stack without individual license clearance (see the ban list in [03-architecture.md](./03-architecture.md#explicitly-banned-from-production)).
+
+> ⚠️ **The #1 contamination trap:** many research 3DGS repos — even ones whose own LICENSE file says MIT/Apache — depend on Inria/MPI's `diff-gaussian-rasterization` and `simple-knn` (non-commercial research license) via git submodules or pip requirements. Check the *whole dependency tree*, not just the top-level LICENSE.
+
+## Recommended order
+
+### 1. nerfstudio-project/nerfstudio + gsplat — *the production baseline*
+
+- **License:** Apache-2.0 / Apache-2.0. ✅ Production-safe.
+- **Goal:** establish the reference pipeline and quality bar. Run `ns-process-data video` → COLMAP → `ns-train splatfacto` → export PLY. Everything else on this list is compared against this result.
+- **Measure:** wall-clock per stage, PSNR on held-out frames, visual quality walking the scene, floater count.
+
+### 2. playcanvas/supersplat — *this repo*
+
+- **License:** MIT. ✅ Production-safe.
+- **Goal:** load the Splatfacto export, practice the cleanup workflow (crop bounds, delete floaters, camera poses/timeline), export SOG. This is the manual version of what the Stage-6/7 pipeline will automate — note which manual edits you repeat every time; those are the automation backlog.
+
+### 3. playcanvas/supersplat-viewer
+
+- **License:** MIT. ✅ Production-safe.
+- **Goal:** publish the cleaned SOG and test the buyer experience on desktop + a mid-range phone. Measure load time and fps — these numbers calibrate the QA-gate budgets in [04-pipeline.md](./04-pipeline.md).
+
+### 4. inuex35/360-gaussian-splatting
+
+- **License:** ⚠️ **Verify before any use beyond local testing.** Builds on OpenSfM (BSD, fine) but the splatting side derives from the Inria non-commercial codebase — treat as **non-commercial until proven otherwise**.
+- **Goal:** benchmark a purpose-built 360 pipeline (OpenSfM spherical model end-to-end) against our FFmpeg-v360-crops + COLMAP approach on the *same* 360 footage. If its poses are meaningfully better, the lesson to take into production is "use OpenSfM's spherical camera model" (BSD-safe) — not this repo's code.
+
+### 5. LeoDarcy/360GS
+
+- **License:** ⚠️ Research code; verify license **and** the rasterizer dependency (very likely Inria non-commercial). Evaluation only.
+- **Goal:** study how panoramic-native Gaussian training handles equirect input directly; compare artifacts around poles/nadir vs. the crop-based approach.
+
+### 6. zcq15/PFGS360
+
+- **License:** ⚠️ Research code; verify license and dependency tree. Evaluation only.
+- **Goal:** panoramic-focused splatting quality comparison; note any preprocessing/masking tricks (nadir handling, seam handling) worth reimplementing cleanly on gsplat.
+
+### 7. GaussianRoom
+
+- **License:** ⚠️ Research code (typically Inria-derived + SDF components). Evaluation only.
+- **Goal:** study geometry-regularized indoor reconstruction — how much do walls/floors improve with SDF/normal priors? Informs the Phase-5 "floor/wall cleanup" roadmap (which we'd implement as plane priors on gsplat, license-safe).
+
+### 8. SplaTAM / MonoGS — *only if testing phone/SLAM-style capture*
+
+- **Licenses:** ⚠️ SplaTAM's own license is permissive-ish (BSD-style) **but** it depends on a depth-enabled fork of the Inria rasterizer → treat as non-commercial. **MonoGS is explicitly research/non-commercial.** Evaluation only, both.
+- **Goal:** understand whether SLAM-style dense tracking from casual phone video is materially more robust than COLMAP on the "experimental" phone path. If yes, the production takeaway is to plan a license-safe SLAM/odometry front-end later (or on-device ARKit/ARCore poses in Phase 6) — not to ship these repos.
+
+## Method notes
+
+- Use the **same 2–3 capture datasets** (one easy apartment, one hallway-heavy unit, one hard case with mirrors/glass) across all tools; keep a spreadsheet of: registration rate, train time, VRAM, PSNR, subjective walkthrough score, failure notes.
+- Keep experiments in a separate machine/user/venv and a separate git repo; production repos must never import from the experiments repo.
+- Anything learned from non-commercial code must be reimplemented from papers/ideas on gsplat/nerfstudio if it's wanted in production ("clean-room the *technique*, never copy the code").

--- a/docs/splatestate/README.md
+++ b/docs/splatestate/README.md
@@ -1,0 +1,32 @@
+# SplatEstate — PRD & Technical Build Plan
+
+> **Working name:** SplatEstate
+> **Positioning:** "Turn a property video into a photorealistic 3D walkthrough."
+> **Status:** Planning / pre-build. This document set is the master spec.
+> **Repo context:** This repository is a fork of [playcanvas/supersplat](https://github.com/playcanvas/supersplat) (MIT) and is the foundation for the SplatEstate **editor and viewer layer**.
+
+This directory contains the complete Product Requirements Document and technical build plan for SplatEstate — a SaaS that turns real-estate footage (360 video, phone video, photo sets) into photorealistic, browser-based Gaussian Splat virtual tours with AI cleanup, publishing, and lead capture.
+
+## Document index
+
+| # | Document | Contents |
+|---|----------|----------|
+| 1 | [01-prd.md](./01-prd.md) | Product summary, target users, problem, value proposition, feature list, MVP scope, non-goals, monetization, risks, roadmap, acceptance criteria, 30/60/90 plan, build-first recommendation |
+| 2 | [02-user-flows-ux.md](./02-user-flows-ux.md) | User flows, user roles, UX screen inventory, capture guidance content |
+| 3 | [03-architecture.md](./03-architecture.md) | System architecture, tech stack, open-source repo usage & license plan, processing queue design, cloud/GPU infrastructure plan |
+| 4 | [04-pipeline.md](./04-pipeline.md) | End-to-end reconstruction pipeline, AI enhancement & compositing plan, quality scoring, QA gates |
+| 5 | [05-database-schema.md](./05-database-schema.md) | Full PostgreSQL schema: tables, fields, types, relations, indexes |
+| 6 | [06-api.md](./06-api.md) | Complete API endpoint plan: auth, agencies, projects, uploads, processing, editor, publishing, leads, analytics, billing, admin |
+| 7 | [07-security-privacy.md](./07-security-privacy.md) | Security, privacy, GDPR, legal disclaimers, AI ethics rules |
+| 8 | [08-personal-testing.md](./08-personal-testing.md) | Personal-testing order for experimental repos (360GS, PFGS360, SplaTAM, etc.) with license warnings — **evaluation only, not production** |
+
+## The product in one paragraph
+
+A real-estate agent films a property with a 360 camera (or phone), uploads the footage to SplatEstate, and the platform reconstructs the scene with Structure-from-Motion (COLMAP/GLOMAP/OpenSfM) and Gaussian Splatting (Nerfstudio Splatfacto + gsplat), cleans it with an AI enhancement layer (frame filtering, segmentation masking via SAM2, artifact cleanup, exposure harmonization, privacy blurring), compresses it for the web (splat-transform → SOG), and returns a shareable, embeddable, branded browser tour (SuperSplat Viewer–based) where buyers can walk through the property and submit viewing requests that land in the agent's lead inbox.
+
+## Hard constraints (apply to every document)
+
+1. **License safety.** Production stack uses only permissive-license open source (MIT, Apache-2.0, BSD, PostgreSQL-style). No Inria non-commercial 3DGS code, no no-license repos, no AGPL (unless deliberately accepted), no research-only forks. A license inventory is maintained in [03-architecture.md](./03-architecture.md#license-inventory). Final legal review required before launch.
+2. **Truthful representation.** AI cleans capture artifacts, removes tripods/people, fixes exposure, and blurs private items. AI must never fake renovations, hide damage or permanent defects, alter room dimensions, or otherwise materially misrepresent the property.
+3. **Privacy by default.** Tours are private drafts until explicitly published. Uploads are deletable, never used for model training without explicit opt-in, and processed with GDPR-compliant controls.
+4. **Marketing asset, not survey.** SplatEstate output is a visual marketing asset — not a measurement-grade scan, CAD model, or architectural survey — and is labeled as such throughout the product.


### PR DESCRIPTION
Complete product and engineering spec for a real-estate Gaussian Splatting virtual tour SaaS built on a permissive-license open-source stack (nerfstudio/gsplat, COLMAP/GLOMAP/OpenSfM/HLOC, SuperSplat editor/viewer, splat-transform, SAM2, FFmpeg):

- 01: PRD — product summary, users, MVP scope, non-goals, monetization, risks, roadmap, acceptance criteria, 30/60/90 plan
- 02: user roles, flows, UX screen inventory, capture guidance
- 03: system architecture, license inventory, queue design, GPU plan
- 04: reconstruction pipeline and AI enhancement/compositing plan
- 05: PostgreSQL schema (18 tables with indexes and relations)
- 06: full API endpoint plan
- 07: security, privacy/GDPR, AI ethics and legal plan
- 08: personal-testing order for experimental repos with license warnings (evaluation only, quarantined from production)


Claude-Session: https://claude.ai/code/session_01SMJfAAPUSHroyAaemnpc8m