### PR TITLE
Show a clear error when WebGPU is unavailable during SOG and viewer export

### DIFF
--- a/src/file-handler.ts
+++ b/src/file-handler.ts
@@ -6,7 +6,7 @@ import { Events } from './events';
 import { BrowserFileSystem, MappedReadFileSystem } from './io';
 import { Scene } from './scene';
 import { Splat } from './splat';
-import { serializePly, serializePlyCompressed, SerializeSettings, serializeSog, serializeSplat, serializeSpz, serializeViewer, SogSettings, SpzSettings, ViewerExportSettings } from './splat-serialize';
+import { serializePly, serializePlyCompressed, SerializeSettings, serializeSog, serializeSplat, serializeSpz, serializeViewer, SogSettings, SpzSettings, ViewerExportSettings, WebGPUUnavailableError } from './splat-serialize';
 import { i18n } from './ui/localization';
 
 // ts compiler and vscode find this type, but eslint does not
@@ -585,11 +585,19 @@ const initFileHandler = (scene: Scene, events: Events, dropTarget: HTMLElement) 
             }
 
         } catch (error) {
-            await events.invoke('showPopup', {
-                type: 'error',
-                header: i18n.t('popup.error-loading'),
-                message: `${error.message ?? error} while saving file`
-            });
+            if (error instanceof WebGPUUnavailableError) {
+                await events.invoke('showPopup', {
+                    type: 'error',
+                    header: i18n.t('popup.error'),
+                    message: i18n.t('popup.webgpu-unavailable')
+                });
+            } else {
+                await events.invoke('showPopup', {
+                    type: 'error',
+                    header: i18n.t('popup.error'),
+                    message: `${error.message ?? error} while saving file`
+                });
+            }
         } finally {
             if (useSpinner) {
                 events.fire('stopSpinner');

--- a/src/file-handler.ts
+++ b/src/file-handler.ts
@@ -592,10 +592,11 @@ const initFileHandler = (scene: Scene, events: Events, dropTarget: HTMLElement) 
                     message: i18n.t('popup.webgpu-unavailable')
                 });
             } else {
+                const message = error instanceof Error ? error.message : String(error);
                 await events.invoke('showPopup', {
                     type: 'error',
                     header: i18n.t('popup.error'),
-                    message: `${error.message ?? error} while saving file`
+                    message: `${message} while saving file`
                 });
             }
         } finally {

--- a/src/splat-serialize.ts
+++ b/src/splat-serialize.ts
@@ -1116,6 +1116,15 @@ const serializeSplat = async (splats: Splat[], options: SerializeSettings, fs: F
     await writer.close();
 };
 
+// Thrown when the WebGPU device needed for SOG compression can't be created.
+// Callers show a friendly message for this instead of the raw error text.
+class WebGPUUnavailableError extends Error {
+    constructor() {
+        super('WebGPU is not available');
+        this.name = 'WebGPUUnavailableError';
+    }
+}
+
 // Cached WebGPU device for SOG compression
 let cachedGpuDevice: WebgpuGraphicsDevice | null = null;
 let cachedBackbuffer: Texture | null = null;
@@ -1126,7 +1135,7 @@ const createGpuDevice = async (): Promise<WebgpuGraphicsDevice> => {
     }
 
     if (!navigator.gpu) {
-        throw new Error('WebGPU is not available in this browser');
+        throw new WebGPUUnavailableError();
     }
 
     // Create a minimal canvas for the graphics device
@@ -1140,7 +1149,21 @@ const createGpuDevice = async (): Promise<WebgpuGraphicsDevice> => {
         stencil: false
     });
 
-    await graphicsDevice.createDevice();
+    try {
+        await graphicsDevice.createDevice();
+    } catch (err) {
+        // createDevice fails with an obscure internal error when no adapter
+        // is available (e.g. blocklisted GPU or missing drivers)
+        console.error(err);
+        throw new WebGPUUnavailableError();
+    }
+
+    // createDevice can also resolve without creating a device (e.g.
+    // blocklisted adapters)
+    // @ts-ignore - wgpu is an internal property
+    if (!graphicsDevice.wgpu) {
+        throw new WebGPUUnavailableError();
+    }
 
     // Create external backbuffer (required by PlayCanvas)
     cachedBackbuffer = new Texture(graphicsDevice, {
@@ -1403,5 +1426,6 @@ export {
     SerializeSettings,
     SogSettings,
     SpzSettings,
-    ViewerExportSettings
+    ViewerExportSettings,
+    WebGPUUnavailableError
 };

--- a/static/locales/de.json
+++ b/static/locales/de.json
@@ -128,6 +128,7 @@
     "popup.no": "Nein",
     "popup.error": "Fehler",
     "popup.error-loading": "Fehler beim Laden der Datei",
+    "popup.webgpu-unavailable": "Dieser Export erfordert WebGPU, das in diesem Browser nicht verfügbar ist. Bitte verwenden Sie eine aktuelle Version von Chrome, Edge oder Safari.",
     "popup.lcc-upload-warning": "Für eine bessere Veröffentlichung auf superspl.at laden Sie Ihre LCC-Datei direkt über die Upload-Seite hoch.",
     "popup.export": "Exportieren",
     "popup.copy-to-clipboard": "Link in die Zwischenablage kopieren",

--- a/static/locales/en.json
+++ b/static/locales/en.json
@@ -128,6 +128,7 @@
     "popup.no": "No",
     "popup.error": "Error",
     "popup.error-loading": "Error Loading File",
+    "popup.webgpu-unavailable": "This export requires WebGPU, which is not available in this browser. Please try a recent version of Chrome, Edge or Safari.",
     "popup.lcc-upload-warning": "For better publishing to superspl.at, upload your LCC file directly via the upload page.",
     "popup.export": "Export",
     "popup.copy-to-clipboard": "Copy Link to Clipboard",

--- a/static/locales/es.json
+++ b/static/locales/es.json
@@ -128,6 +128,7 @@
     "popup.no": "No",
     "popup.error": "Error",
     "popup.error-loading": "Error al cargar archivo",
+    "popup.webgpu-unavailable": "Esta exportación requiere WebGPU, que no está disponible en este navegador. Pruebe con una versión reciente de Chrome, Edge o Safari.",
     "popup.lcc-upload-warning": "Para una mejor publicación en superspl.at, suba su archivo LCC directamente a través de la página de carga.",
     "popup.export": "Exportar",
     "popup.copy-to-clipboard": "Copiar enlace al portapapeles",

--- a/static/locales/fr.json
+++ b/static/locales/fr.json
@@ -128,6 +128,7 @@
     "popup.no": "Non",
     "popup.error": "Erreur",
     "popup.error-loading": "Erreur de chargement du fichier",
+    "popup.webgpu-unavailable": "Cette exportation nécessite WebGPU, qui n'est pas disponible dans ce navigateur. Veuillez essayer une version récente de Chrome, Edge ou Safari.",
     "popup.lcc-upload-warning": "Pour une meilleure publication sur superspl.at, téléchargez votre fichier LCC directement via la page de téléchargement.",
     "popup.export": "Exporter",
     "popup.copy-to-clipboard": "Copier le lien dans le presse-papiers",

--- a/static/locales/ja.json
+++ b/static/locales/ja.json
@@ -128,6 +128,7 @@
     "popup.no": "いいえ",
     "popup.error": "エラー",
     "popup.error-loading": "ファイルの読み込みエラー",
+    "popup.webgpu-unavailable": "このエクスポートにはWebGPUが必要ですが、このブラウザでは利用できません。Chrome、Edge、Safariの最新バージョンをお試しください。",
     "popup.lcc-upload-warning": "superspl.atへの公開には、アップロードページから直接LCCファイルをアップロードすることをお勧めします。",
     "popup.export": "エクスポート",
     "popup.copy-to-clipboard": "リンクをクリップボードにコピー",

--- a/static/locales/ko.json
+++ b/static/locales/ko.json
@@ -128,6 +128,7 @@
     "popup.no": "아니요",
     "popup.error": "오류",
     "popup.error-loading": "파일 로드 오류",
+    "popup.webgpu-unavailable": "이 내보내기에는 WebGPU가 필요하지만 이 브라우저에서는 사용할 수 없습니다. 최신 버전의 Chrome, Edge 또는 Safari를 사용해 보세요.",
     "popup.lcc-upload-warning": "superspl.at에 더 나은 게시를 위해 업로드 페이지를 통해 LCC 파일을 직접 업로드하세요.",
     "popup.export": "내보내기",
     "popup.copy-to-clipboard": "클립 보드에 링크 복사",

--- a/static/locales/pt-BR.json
+++ b/static/locales/pt-BR.json
@@ -128,6 +128,7 @@
     "popup.no": "Não",
     "popup.error": "Erro",
     "popup.error-loading": "Erro ao Carregar Arquivo",
+    "popup.webgpu-unavailable": "Esta exportação requer WebGPU, que não está disponível neste navegador. Tente uma versão recente do Chrome, Edge ou Safari.",
     "popup.lcc-upload-warning": "Para uma melhor publicação no superspl.at, envie seu arquivo LCC diretamente pela página de upload.",
     "popup.export": "Exportar",
     "popup.copy-to-clipboard": "Copiar Link para Área de Transferência",

--- a/static/locales/ru.json
+++ b/static/locales/ru.json
@@ -128,6 +128,7 @@
     "popup.no": "Нет",
     "popup.error": "Ошибка",
     "popup.error-loading": "Ошибка загрузки файла",
+    "popup.webgpu-unavailable": "Для этого экспорта требуется WebGPU, который недоступен в этом браузере. Попробуйте последнюю версию Chrome, Edge или Safari.",
     "popup.lcc-upload-warning": "Для лучшей публикации на superspl.at загрузите LCC-файл напрямую через страницу загрузки.",
     "popup.export": "Экспорт",
     "popup.copy-to-clipboard": "Скопировать ссылку в буфер обмена",

--- a/static/locales/zh-CN.json
+++ b/static/locales/zh-CN.json
@@ -128,6 +128,7 @@
     "popup.no": "否",
     "popup.error": "错误",
     "popup.error-loading": "加载文件错误",
+    "popup.webgpu-unavailable": "此导出需要 WebGPU，但当前浏览器不支持。请尝试使用最新版本的 Chrome、Edge 或 Safari。",
     "popup.lcc-upload-warning": "为了更好地发布到 superspl.at，请通过上传页面直接上传您的 LCC 文件。",
     "popup.export": "导出",
     "popup.copy-to-clipboard": "复制链接到剪贴板",


### PR DESCRIPTION
Fixes #934

Exporting to SOG (or the HTML viewer, which bundles SOG) requires a WebGPU device for spherical harmonic k-means clustering. On systems where WebGPU is unavailable — no `navigator.gpu`, or `requestAdapter()` returning null, as on the reporter's Ubuntu/Chrome setup — the export failed with the cryptic popup "Cannot read properties of null (reading 'features') while saving file" under an "Error Loading File" header.

`createGpuDevice` now throws a dedicated `WebGPUUnavailableError` for every way device creation can fail: missing `navigator.gpu`, `createDevice()` throwing on a null adapter, and `createDevice()` resolving without creating a device (blocklisted adapters). The underlying error is still logged to the console for debugging. The export handler catches this error type and shows a localized, actionable message instead of the raw error text: "This export requires WebGPU, which is not available in this browser. Please try a recent version of Chrome, Edge or Safari." The new string is translated in all nine locales.

Verified in the browser by simulating both failure modes (removing `navigator.gpu`, and stubbing `requestAdapter()` to resolve null, which reproduces the exact TypeError from #934), and by confirming a normal SOG export still succeeds with a working adapter.