### PR TITLE
Show the active selection operation at the cursor

### DIFF
--- a/src/editor.ts
+++ b/src/editor.ts
@@ -466,7 +466,7 @@ const registerEditorEvents = (events: Events, editHistory: EditHistory, scene: S
         }
     });
 
-    events.function('select.point', async (op: 'add'|'remove'|'set', point: { x: number, y: number }) => {
+    events.function('select.point', async (op: 'add'|'remove'|'set'|'intersect', point: { x: number, y: number }) => {
         const { width, height } = scene.targetSize;
         const mode = events.invoke('camera.mode');
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -35,6 +35,7 @@ import { registerTransformHandlerEvents } from './transform-handler';
 import { BoundDimensionsOverlay } from './ui/bound-dimensions-overlay';
 import { EditorUI } from './ui/editor';
 import { i18n } from './ui/localization';
+import { registerSelectCursor } from './ui/select-cursor';
 
 declare global {
     interface LaunchParams {
@@ -250,6 +251,9 @@ const main = async () => {
     const boundDimensionsOverlay = new BoundDimensionsOverlay(events, scene, editorUI.canvasContainer);
 
     editorUI.toolsContainer.dom.appendChild(maskCanvas);
+
+    // show the active selection op (add/remove/intersect) at the cursor
+    registerSelectCursor(events, editorUI.toolsContainer.dom);
 
     window.scene = scene;
 

--- a/src/tools/rect-selection.ts
+++ b/src/tools/rect-selection.ts
@@ -90,7 +90,7 @@ class RectSelection {
                     // pick - wait for selection to complete before hiding rect
                     await events.invoke(
                         'select.point',
-                        e.shiftKey ? 'add' : (e.ctrlKey ? 'remove' : 'set'),
+                        opFromModifiers(e),
                         { x: e.offsetX / parent.clientWidth, y: e.offsetY / parent.clientHeight }
                     );
                 }

--- a/src/ui/histogram.ts
+++ b/src/ui/histogram.ts
@@ -1,5 +1,6 @@
 import { Events } from '../events';
 import { opFromModifiers } from '../select-op';
+import { applyOpCursor } from './select-cursor';
 
 class HistogramData {
     bins: { selected: number, unselected: number }[];
@@ -70,6 +71,7 @@ class Histogram {
         let dragStart = 0;
         let dragEnd = 0;
         let activePointerId = -1;
+        let hovering = false;
 
         const offsetToBucket = (offset: number) => {
             const rect = this.canvas.getBoundingClientRect();
@@ -213,13 +215,33 @@ class Histogram {
             }
         });
 
-        this.canvas.addEventListener('pointerenter', () => {
+        // keep the cursor showing the op the modifiers will apply (add/remove/
+        // intersect) while hovering the interactive histogram, matching the
+        // selection tools. numValues gates it so an empty histogram is unaffected.
+        const syncCursor = (e: { shiftKey: boolean, ctrlKey: boolean }) => {
+            if (hovering) {
+                applyOpCursor(this.canvas, this.histogram.numValues ? opFromModifiers(e) : 'set');
+            }
+        };
+
+        this.canvas.addEventListener('pointerenter', (e: PointerEvent) => {
+            hovering = true;
             this.events.fire('showOverlay');
+            syncCursor(e);
         });
 
         this.canvas.addEventListener('pointerleave', () => {
+            hovering = false;
             this.events.fire('hideOverlay');
+            applyOpCursor(this.canvas, 'set');
         });
+
+        // capture phase so a modifier press updates the cursor even while another
+        // element holds focus; blur clears because a key release while unfocused
+        // never fires. (mirrors the selection-tool cursor and controllers.ts)
+        window.addEventListener('keydown', e => syncCursor(e), { capture: true });
+        window.addEventListener('keyup', e => syncCursor(e), { capture: true });
+        window.addEventListener('blur', () => applyOpCursor(this.canvas, 'set'));
     }
 
     private render(logScale: boolean) {

--- a/src/ui/select-cursor.ts
+++ b/src/ui/select-cursor.ts
@@ -1,0 +1,67 @@
+import { Events } from '../events';
+import { opFromModifiers } from '../select-op';
+import addCursor from './svg/cursor-add.svg';
+import intersectCursor from './svg/cursor-intersect.svg';
+import removeCursor from './svg/cursor-remove.svg';
+
+// tools whose selection op is driven by shift/ctrl modifiers (see opFromModifiers)
+const pointerTools = new Set([
+    'rectSelection',
+    'brushSelection',
+    'floodSelection',
+    'polygonSelection',
+    'lassoSelection'
+]);
+
+// op → cursor image (data-URI). 'set' is intentionally absent: it clears the
+// inline style so the underlying default/crosshair cursor applies.
+const cursors: Record<string, string> = {
+    add: addCursor,
+    remove: removeCursor,
+    intersect: intersectCursor
+};
+
+// Set (or clear, for 'set') the op cursor on an element. Hotspot at the crosshair
+// centre (16 16); the trailing `crosshair` is the fallback when the browser can't
+// render an SVG cursor (older Safari). Shared by the selection tools and the
+// histogram so both surfaces show the same add/remove/intersect badge.
+const applyOpCursor = (element: HTMLElement, op: string) => {
+    element.style.cursor = cursors[op] ? `url("${cursors[op]}") 16 16, crosshair` : '';
+};
+
+// While a pointer selection tool is active, swap the cursor on the tools overlay
+// to reflect the op the held modifiers will produce, so the user sees
+// add/remove/intersect before acting.
+const registerSelectCursor = (events: Events, toolsContainer: HTMLElement) => {
+    let engaged = false;
+
+    const onKey = (e: KeyboardEvent) => {
+        if (engaged) {
+            applyOpCursor(toolsContainer, opFromModifiers(e));
+        }
+    };
+
+    events.on('tool.activated', (name: string) => {
+        engaged = pointerTools.has(name);
+        // default to the plain crosshair; a held modifier corrects on the next key event
+        applyOpCursor(toolsContainer, 'set');
+    });
+
+    events.on('tool.deactivated', () => {
+        engaged = false;
+        applyOpCursor(toolsContainer, 'set');
+    });
+
+    // capture phase so we still see keydown/keyup when a focused dialog stops
+    // propagation; blur resets because a key release while unfocused never fires.
+    // (mirrors the modifier tracking in controllers.ts)
+    window.addEventListener('keydown', onKey, { capture: true });
+    window.addEventListener('keyup', onKey, { capture: true });
+    window.addEventListener('blur', () => {
+        if (engaged) {
+            applyOpCursor(toolsContainer, 'set');
+        }
+    });
+};
+
+export { registerSelectCursor, applyOpCursor };

--- a/src/ui/select-cursor.ts
+++ b/src/ui/select-cursor.ts
@@ -34,17 +34,25 @@ const applyOpCursor = (element: HTMLElement, op: string) => {
 // add/remove/intersect before acting.
 const registerSelectCursor = (events: Events, toolsContainer: HTMLElement) => {
     let engaged = false;
+    // track modifier state so the cursor is correct the instant a tool is activated
+    // with Shift/Ctrl already held, not only after the next key event.
+    const modifiers = { shiftKey: false, ctrlKey: false };
+
+    const refresh = () => {
+        if (engaged) {
+            applyOpCursor(toolsContainer, opFromModifiers(modifiers));
+        }
+    };
 
     const onKey = (e: KeyboardEvent) => {
-        if (engaged) {
-            applyOpCursor(toolsContainer, opFromModifiers(e));
-        }
+        modifiers.shiftKey = e.shiftKey;
+        modifiers.ctrlKey = e.ctrlKey;
+        refresh();
     };
 
     events.on('tool.activated', (name: string) => {
         engaged = pointerTools.has(name);
-        // default to the plain crosshair; a held modifier corrects on the next key event
-        applyOpCursor(toolsContainer, 'set');
+        refresh();
     });
 
     events.on('tool.deactivated', () => {
@@ -53,14 +61,14 @@ const registerSelectCursor = (events: Events, toolsContainer: HTMLElement) => {
     });
 
     // capture phase so we still see keydown/keyup when a focused dialog stops
-    // propagation; blur resets because a key release while unfocused never fires.
-    // (mirrors the modifier tracking in controllers.ts)
+    // propagation; blur clears the tracked modifiers because a key release while
+    // unfocused never fires. (mirrors the modifier tracking in controllers.ts)
     window.addEventListener('keydown', onKey, { capture: true });
     window.addEventListener('keyup', onKey, { capture: true });
     window.addEventListener('blur', () => {
-        if (engaged) {
-            applyOpCursor(toolsContainer, 'set');
-        }
+        modifiers.shiftKey = false;
+        modifiers.ctrlKey = false;
+        refresh();
     });
 };
 

--- a/src/ui/svg/cursor-add.svg
+++ b/src/ui/svg/cursor-add.svg
@@ -1,0 +1,6 @@
+<svg width="32" height="32" viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg">
+<path d="M6 16h6M20 16h6M16 6v6M16 20v6" fill="none" stroke="#000" stroke-opacity="0.5" stroke-width="3" stroke-linecap="round"/>
+<path d="M25 21.5v7M21.5 25h7" fill="none" stroke="#000" stroke-opacity="0.5" stroke-width="3.5" stroke-linecap="round"/>
+<path d="M6 16h6M20 16h6M16 6v6M16 20v6" fill="none" stroke="#fff" stroke-width="1.5" stroke-linecap="round"/>
+<path d="M25 21.5v7M21.5 25h7" fill="none" stroke="#fff" stroke-width="2" stroke-linecap="round"/>
+</svg>

--- a/src/ui/svg/cursor-intersect.svg
+++ b/src/ui/svg/cursor-intersect.svg
@@ -1,0 +1,6 @@
+<svg width="32" height="32" viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg">
+<path d="M6 16h6M20 16h6M16 6v6M16 20v6" fill="none" stroke="#000" stroke-opacity="0.5" stroke-width="3" stroke-linecap="round"/>
+<path d="M21.5 28.5v-3.5a3.5 3.5 0 0 1 7 0v3.5" fill="none" stroke="#000" stroke-opacity="0.5" stroke-width="3.5" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M6 16h6M20 16h6M16 6v6M16 20v6" fill="none" stroke="#fff" stroke-width="1.5" stroke-linecap="round"/>
+<path d="M21.5 28.5v-3.5a3.5 3.5 0 0 1 7 0v3.5" fill="none" stroke="#fff" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/ui/svg/cursor-remove.svg
+++ b/src/ui/svg/cursor-remove.svg
@@ -1,0 +1,6 @@
+<svg width="32" height="32" viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg">
+<path d="M6 16h6M20 16h6M16 6v6M16 20v6" fill="none" stroke="#000" stroke-opacity="0.5" stroke-width="3" stroke-linecap="round"/>
+<path d="M21.5 25h7" fill="none" stroke="#000" stroke-opacity="0.5" stroke-width="3.5" stroke-linecap="round"/>
+<path d="M6 16h6M20 16h6M16 6v6M16 20v6" fill="none" stroke="#fff" stroke-width="1.5" stroke-linecap="round"/>
+<path d="M21.5 25h7" fill="none" stroke="#fff" stroke-width="2" stroke-linecap="round"/>
+</svg>


### PR DESCRIPTION
Adds visual feedback for the selection operation so you can tell whether a gesture will set, add, remove, or intersect before committing it. The intersect modifier (shift+ctrl) already exists, but nothing indicated the active op — this surfaces it right at the cursor.

## What you see
- While a pointer selection tool (rect, brush, lasso, polygon, flood) is active, the cursor reflects the op the held modifiers will apply: a plain crosshair for set, or a crosshair with a small badge for add (+), remove (−), or intersect (∩).
- The same feedback now works over the Splat Data histogram, where shift / ctrl / shift+ctrl-drag selects by value range.
- The badge updates live as you press or release shift/ctrl — even with the mouse stationary or mid-drag — and resets when the window loses focus.

## How it works
- New `src/ui/select-cursor.ts` swaps the CSS cursor on the tools overlay from the current modifiers, reusing the existing `opFromModifiers()` mapping and mirroring the capture-phase key tracking already used for camera controls. It engages only for the modifier-driven selection tools.
- The histogram reuses the same helper to keep its canvas cursor in sync while hovering, gated on the histogram having data so an empty panel is unaffected.
- Cursor art is three small SVGs (`src/ui/svg/cursor-{add,remove,intersect}.svg`): a crosshair plus a monochrome glyph with a dark halo so it stays legible over both light and dark splats.
- Rect single-click now derives its op from `opFromModifiers()` (and `select.point` accepts `intersect`), so the cursor's indication is accurate for clicks as well as drags.

## Notes
- Custom SVG cursors render in Chrome/Firefox and fall back to a plain crosshair where the browser can't render them (older Safari).