### PR TITLE
Add locale consistency check to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,3 +65,6 @@ jobs:
 
     - name: Lint
       run: npm run lint
+
+    - name: Lint locales
+      run: npm run lint:locales

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
         "serve": "serve dist -C",
         "develop": "cross-env BUILD_TYPE=debug concurrently --kill-others \"npm run watch\" \"npm run serve\"",
         "develop:auto-launch": "concurrently --kill-others \"xdg-open 'http://localhost:3000/'\" \"npm run watch\" \"npm run serve\"",
-        "lint": "eslint src"
+        "lint": "eslint src",
+        "lint:locales": "node scripts/check-locales.mjs"
     },
     "engines": {
         "node": ">=20.19.0"

--- a/scripts/check-locales.mjs
+++ b/scripts/check-locales.mjs
@@ -1,0 +1,48 @@
+/**
+ * Locale consistency check.
+ *
+ * Verifies every translation in static/locales has exactly the same set of keys
+ * as the English reference (en.json, the i18next fallback language). Reports any
+ * key that is:
+ *   - missing from a translation (the UI would silently fall back to English), or
+ *   - stale (present in a translation but no longer in en.json).
+ *
+ * This is a pure JSON set comparison — it does not scan source, so it has no
+ * false positives and needs no dependencies. It deliberately does NOT check for
+ * unused or undefined keys, since that requires resolving dynamic localize()
+ * call sites and is not worth the complexity. Run via `npm run lint:locales`.
+ */
+
+import { readFileSync, readdirSync } from 'fs';
+import { dirname, join } from 'path';
+import { fileURLToPath } from 'url';
+
+const localesDir = join(dirname(fileURLToPath(import.meta.url)), '..', 'static', 'locales');
+const referenceFile = 'en.json';
+
+const keysOf = file => new Set(Object.keys(JSON.parse(readFileSync(join(localesDir, file), 'utf8'))));
+
+const referenceKeys = keysOf(referenceFile);
+const localeFiles = readdirSync(localesDir).filter(f => f.endsWith('.json') && f !== referenceFile);
+
+let failed = false;
+
+for (const file of localeFiles) {
+    const keys = keysOf(file);
+    const missing = [...referenceKeys].filter(k => !keys.has(k));
+    const stale = [...keys].filter(k => !referenceKeys.has(k));
+
+    if (missing.length || stale.length) {
+        failed = true;
+        console.error(`\n${file}:`);
+        missing.forEach(k => console.error(`  missing (untranslated): ${k}`));
+        stale.forEach(k => console.error(`  stale (not in ${referenceFile}): ${k}`));
+    }
+}
+
+if (failed) {
+    console.error(`\n✖ Locale check failed. Update static/locales so every language has the same keys as ${referenceFile}.`);
+    process.exit(1);
+}
+
+console.log(`✔ All ${localeFiles.length} locales are in sync with ${referenceFile} (${referenceKeys.size} keys).`);


### PR DESCRIPTION
Closes #535.

## What

Adds `scripts/check-locales.mjs` — a small maintenance script that verifies every translation in `static/locales` has the exact same set of keys as the English reference (`en.json`, the i18next fallback language). It reports two problems per locale:

- **missing** keys — present in `en.json` but absent from the translation (the UI would silently fall back to English)
- **stale** keys — present in the translation but no longer in `en.json`

It's wired into the existing **Lint** CI job via a new `lint:locales` npm script, so PRs that add an English string without updating the other languages (or that leave a renamed/removed key dangling) now fail CI.

```
✔ All 8 locales are in sync with en.json (309 keys).
```

## Why this approach

This is a deliberately minimal take on #535. Rather than statically analysing `localize()` call sites (the approach in the linked external script), it's a **pure JSON set comparison**: no source scanning, no dependencies, no false positives.

It intentionally **omits** the unused-key and undefined-key checks. Those require resolving the ~10 dynamic call sites in the codebase (e.g. `i18n.t(localeKey)`, `item.localeKey`) to avoid false positives, which is where all the complexity lives — and dead/unused entries are harmless. Cross-locale drift is the check that's both high-value and cheap, so that's the only thing automated here. The fuller analysis remains useful as a manual authoring tool.

## Notes for reviewer

- No new dependencies; the script is plain ESM run with `node`.
- Run locally with `npm run lint:locales`.
- Verified both paths: passes on the current (in-sync) locales, and fails with exit 1 reporting the offending key when a key is removed from a translation.