### PR TITLE
Unify render output filenames and add save dialog for image render

### DIFF
--- a/src/render.ts
+++ b/src/render.ts
@@ -55,6 +55,30 @@ const removeExtension = (filename: string) => {
     return filename.substring(0, filename.length - path.getExtension(filename).length);
 };
 
+const isInvalidFilenameChar = (char: string) => {
+    return /[<>:"/\\|?*]/.test(char) || char.charCodeAt(0) < 32;
+};
+
+const sanitizeFilename = (filename: string) => {
+    const sanitized = Array.from(filename, char => (isInvalidFilenameChar(char) ? '_' : char)).join('').trim();
+    return sanitized.length > 0 ? sanitized : 'supersplat';
+};
+
+// extract a plain filename from url-style names (e.g. splats imported via ?load=)
+const getImportedFilename = (filename: string) => {
+    const trimmed = filename.split(/[?#]/)[0];
+
+    if (trimmed.includes('://') || trimmed.startsWith('blob:')) {
+        try {
+            return path.getBasename(new URL(trimmed).pathname);
+        } catch {
+            // fall through to the raw filename below
+        }
+    }
+
+    return path.getBasename(trimmed);
+};
+
 // sort splats and wait for the sort to complete (or a 1s timeout)
 const sortSplatsAndWait = (scene: Scene, splats: Splat[]) => {
     return Promise.all(splats.map((splat) => {
@@ -79,6 +103,17 @@ const downloadFile = (data: ArrayBuffer | Uint8Array<ArrayBuffer>, filename: str
 
 const registerRenderEvents = (scene: Scene, events: Events) => {
     let webpCodec: WebPCodec;
+
+    // default base filename for rendered output: the project document name if
+    // set, otherwise the first visible splat's name
+    const baseFilename = () => {
+        const docName = events.invoke('doc.name');
+        const splats = (scene.getElementsByType(ElementType.splat) as Splat[]).filter(splat => splat.visible);
+        const source = docName || (splats[0]?.name ?? 'supersplat');
+        return sanitizeFilename(removeExtension(getImportedFilename(source)));
+    };
+
+    events.function('render.baseFilename', baseFilename);
 
     // wait for postrender to fire
     const postRender = () => {
@@ -134,7 +169,7 @@ const registerRenderEvents = (scene: Scene, events: Events) => {
         }
     });
 
-    events.function('render.image', async (imageSettings: ImageSettings) => {
+    events.function('render.image', async (imageSettings: ImageSettings, fileStream?: FileSystemWritableFileStream) => {
         events.fire('startSpinner');
 
         let equirect: EquirectRenderer | null = null;
@@ -238,20 +273,32 @@ const registerRenderEvents = (scene: Scene, events: Events) => {
 
             const bytes = webpCodec.encodeLosslessRGBA(data, width, height);
 
-            // construct filename
-            const selected = events.invoke('selection') as Splat;
-            const filename = `${removeExtension(selected?.name ?? 'SuperSplat')}-image.webp`;
-
-            // download
-            downloadFile(bytes, filename);
+            if (fileStream) {
+                await fileStream.write(bytes);
+                await fileStream.close();
+            } else {
+                downloadFile(bytes, `${baseFilename()}.webp`);
+            }
 
             return true;
         } catch (error) {
+            // close the stream even on failure so the caller can remove the
+            // empty file
+            if (fileStream) {
+                try {
+                    await fileStream.close();
+                } catch {
+                    // stream already closed or errored
+                }
+            }
+
             await events.invoke('showPopup', {
                 type: 'error',
                 header: i18n.t('panel.render.failed'),
                 message: `'${error.message ?? error}'`
             });
+
+            return false;
         } finally {
             if (equirect) {
                 scene.camera.setPoseOverride(null);
@@ -571,10 +618,7 @@ const registerRenderEvents = (scene: Scene, events: Events) => {
                 await encoder.flush();
                 await output.finalize();
 
-                const filename = () => {
-                    const currentSplats = (scene.getElementsByType(ElementType.splat) as Splat[]).filter(splat => splat.visible);
-                    return `${removeExtension(currentSplats[0]?.name ?? 'supersplat')}.${fileExtension}`;
-                };
+                const filename = () => `${baseFilename()}.${fileExtension}`;
 
                 if (taggable) {
                     // patch spherical metadata into the finished buffer so

--- a/src/ui/editor.ts
+++ b/src/ui/editor.ts
@@ -1,5 +1,5 @@
 import { Container, Label } from '@playcanvas/pcui';
-import { Mat4, path } from 'playcanvas';
+import { Mat4 } from 'playcanvas';
 
 import { DataPanel } from './data-panel';
 import { Events } from '../events';
@@ -30,10 +30,6 @@ import { version } from '../../package.json';
 
 // ts compiler and vscode find this type, but eslint does not
 type FilePickerAcceptType = unknown;
-
-const removeExtension = (filename: string) => {
-    return filename.substring(0, filename.length - path.getExtension(filename).length);
-};
 
 class EditorUI {
     appContainer: Container;
@@ -223,7 +219,41 @@ class EditorUI {
             const imageSettings = await imageSettingsDialog.show();
 
             if (imageSettings) {
-                await events.invoke('render.image', imageSettings);
+                try {
+                    let writable;
+                    let fileHandle: FileSystemFileHandle | undefined;
+
+                    if (window.showSaveFilePicker) {
+                        fileHandle = await window.showSaveFilePicker({
+                            id: 'SuperSplatImageFileExport',
+                            types: [{
+                                description: 'WebP Image',
+                                accept: { 'image/webp': ['.webp'] }
+                            }],
+                            suggestedName: `${events.invoke('render.baseFilename')}.webp`
+                        });
+
+                        writable = await fileHandle.createWritable();
+                    }
+
+                    const result = await events.invoke('render.image', imageSettings, writable);
+
+                    // if the render failed, remove the empty file left on disk
+                    if (result === false && fileHandle?.remove) {
+                        await fileHandle.remove();
+                    }
+                } catch (error) {
+                    if (error instanceof DOMException && error.name === 'AbortError') {
+                        // user cancelled save dialog
+                        return;
+                    }
+
+                    await events.invoke('showPopup', {
+                        type: 'error',
+                        header: i18n.t('panel.render.failed'),
+                        message: `'${error.message ?? error}'`
+                    });
+                }
             }
         });
 
@@ -233,8 +263,6 @@ class EditorUI {
             if (videoSettings) {
 
                 try {
-                    const docName = events.invoke('doc.name');
-
                     // Determine file extension and mime type based on format
                     let fileExtension: string;
                     let filePickerTypes: FilePickerAcceptType[];
@@ -274,7 +302,7 @@ class EditorUI {
                         }];
                     }
 
-                    const suggested = `${removeExtension(docName ?? 'supersplat')}${fileExtension}`;
+                    const suggested = `${events.invoke('render.baseFilename')}${fileExtension}`;
 
                     let writable;
                     let fileHandle: FileSystemFileHandle | undefined;
@@ -303,7 +331,7 @@ class EditorUI {
 
                     await events.invoke('showPopup', {
                         type: 'error',
-                        header: 'Failed to render video',
+                        header: i18n.t('panel.render.failed'),
                         message: `'${error.message ?? error}'`
                     });
                 }


### PR DESCRIPTION
## Summary

Rendered images and videos previously derived their filenames three different ways: image renders used the selected splat's name (with no rename opportunity), the video save dialog used the project document name (usually unset), and the Safari video fallback used the first visible splat's name.

## Changes

- All render paths share one naming rule via a new `render.baseFilename` events function: project document name if set, else first visible splat name, else `supersplat`
- Names are sanitized for invalid filename characters, and URL-style sources (e.g. `?load=` imports) reduce to their basename — adapted from #881 (thanks @azadbal, credited as co-author)
- Image renders now open the same OS save dialog as video renders where the File System Access API is available, keeping the direct-download fallback elsewhere
- The empty file is removed if a render fails after the save dialog, and the image/video error popup headers use the localized `panel.render.failed` key

## Testing

- `npm run lint` and debug build pass
- Verified in-browser (Chrome, plus a stubbed picker to exercise the Safari fallback): suggested names across doc-name / splat-name / empty-scene cases, URL and invalid-character sanitization, save-dialog cancel (AbortError), and empty-file cleanup on a simulated write failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)