### PR TITLE
Fix uninitialized op names and localize scene panel tooltips

### DIFF
--- a/src/edit-ops.ts
+++ b/src/edit-ops.ts
@@ -315,7 +315,7 @@ type ColorAdjustment = {
 };
 
 class SetSplatColorAdjustmentOp {
-    name: 'setSplatColor';
+    name = 'setSplatColor';
     splat: Splat;
 
     newState: ColorAdjustment;
@@ -399,7 +399,7 @@ class MultiOp {
 }
 
 class AddSplatOp {
-    name: 'addSplat';
+    name = 'addSplat';
     scene: Scene;
     splat: Splat;
 

--- a/src/ui/scene-panel.ts
+++ b/src/ui/scene-panel.ts
@@ -85,8 +85,8 @@ class ScenePanel extends Container {
         });
 
         tooltips.register(soloToggle, () => i18n.t('tooltip.scene.solo'), 'top');
-        tooltips.register(sceneImport, 'Import Scene', 'top');
-        tooltips.register(sceneNew, 'New Scene', 'top');
+        tooltips.register(sceneImport, () => i18n.t('tooltip.scene.import'), 'top');
+        tooltips.register(sceneNew, () => i18n.t('tooltip.scene.new'), 'top');
 
         const splatList = new SplatList(events);
 

--- a/static/locales/de.json
+++ b/static/locales/de.json
@@ -300,6 +300,8 @@
     "tooltip.timeline.smoothness": "Weichheit",
     "tooltip.timeline.loop": "Animation wiederholen",
     "tooltip.scene.solo": "Auswahl solo anzeigen",
+    "tooltip.scene.import": "Szene importieren",
+    "tooltip.scene.new": "Neue Szene",
     "status-bar.splats": "Splats",
     "status-bar.selected": "Ausgewählt",
     "status-bar.locked": "Gesperrt",

--- a/static/locales/en.json
+++ b/static/locales/en.json
@@ -300,6 +300,8 @@
     "tooltip.timeline.smoothness": "Smoothness",
     "tooltip.timeline.loop": "Loop Animation",
     "tooltip.scene.solo": "Solo Selected",
+    "tooltip.scene.import": "Import Scene",
+    "tooltip.scene.new": "New Scene",
     "status-bar.splats": "Splats",
     "status-bar.selected": "Selected",
     "status-bar.locked": "Locked",

--- a/static/locales/es.json
+++ b/static/locales/es.json
@@ -300,6 +300,8 @@
     "tooltip.timeline.smoothness": "Suavidad",
     "tooltip.timeline.loop": "Animación en bucle",
     "tooltip.scene.solo": "Solo seleccionado",
+    "tooltip.scene.import": "Importar escena",
+    "tooltip.scene.new": "Nueva escena",
     "status-bar.splats": "Splats",
     "status-bar.selected": "Seleccionados",
     "status-bar.locked": "Bloqueados",

--- a/static/locales/fr.json
+++ b/static/locales/fr.json
@@ -300,6 +300,8 @@
     "tooltip.timeline.smoothness": "Douceur",
     "tooltip.timeline.loop": "Animation en boucle",
     "tooltip.scene.solo": "Solo sélectionné",
+    "tooltip.scene.import": "Importer une scène",
+    "tooltip.scene.new": "Nouvelle scène",
     "status-bar.splats": "Splats",
     "status-bar.selected": "Sélectionnés",
     "status-bar.locked": "Verrouillés",

--- a/static/locales/ja.json
+++ b/static/locales/ja.json
@@ -300,6 +300,8 @@
     "tooltip.timeline.smoothness": "スムーズさ",
     "tooltip.timeline.loop": "アニメーションをループ",
     "tooltip.scene.solo": "選択をソロ表示",
+    "tooltip.scene.import": "シーンをインポート",
+    "tooltip.scene.new": "新規シーンを作成",
     "status-bar.splats": "スプラット",
     "status-bar.selected": "選択済み",
     "status-bar.locked": "ロック済み",

--- a/static/locales/ko.json
+++ b/static/locales/ko.json
@@ -300,6 +300,8 @@
     "tooltip.timeline.smoothness": "부드러움",
     "tooltip.timeline.loop": "애니메이션 루프",
     "tooltip.scene.solo": "선택 항목 솔로",
+    "tooltip.scene.import": "장면 가져오기",
+    "tooltip.scene.new": "새 장면",
     "status-bar.splats": "스플랫",
     "status-bar.selected": "선택됨",
     "status-bar.locked": "잠김",

--- a/static/locales/pt-BR.json
+++ b/static/locales/pt-BR.json
@@ -300,6 +300,8 @@
     "tooltip.timeline.smoothness": "Suavidade",
     "tooltip.timeline.loop": "Repetir Animação",
     "tooltip.scene.solo": "Solo selecionado",
+    "tooltip.scene.import": "Importar Cena",
+    "tooltip.scene.new": "Nova Cena",
     "status-bar.splats": "Splats",
     "status-bar.selected": "Selecionados",
     "status-bar.locked": "Bloqueados",

--- a/static/locales/ru.json
+++ b/static/locales/ru.json
@@ -300,6 +300,8 @@
     "tooltip.timeline.smoothness": "Плавность",
     "tooltip.timeline.loop": "Зациклить анимацию",
     "tooltip.scene.solo": "Соло выбранного",
+    "tooltip.scene.import": "Импортировать сцену",
+    "tooltip.scene.new": "Новая сцена",
     "status-bar.splats": "Сплаты",
     "status-bar.selected": "Выбрано",
     "status-bar.locked": "Заблокировано",

--- a/static/locales/zh-CN.json
+++ b/static/locales/zh-CN.json
@@ -300,6 +300,8 @@
     "tooltip.timeline.smoothness": "平滑度",
     "tooltip.timeline.loop": "循环动画",
     "tooltip.scene.solo": "独显所选",
+    "tooltip.scene.import": "导入场景",
+    "tooltip.scene.new": "新建场景",
     "status-bar.splats": "高斯点",
     "status-bar.selected": "已选择",
     "status-bar.locked": "已锁定",


### PR DESCRIPTION
### Two small cleanups

**1. Uninitialized `name` fields on two edit ops**

`SetSplatColorAdjustmentOp` and `AddSplatOp` declared their `name` with a type annotation instead of an assignment:

```ts
name: 'setSplatColor';   // type annotation — .name is undefined at runtime
```

Every other op class assigns the value (e.g. `MultiOp` has `name = 'multiOp'`). Changed `:` to `=` on both so `.name` actually holds the string.

**2. Last two unlocalized tooltips**

The scene panel registered its Import Scene / New Scene tooltips with hardcoded English strings — the only unlocalized tooltips left in the app. They now go through i18next like the neighboring solo toggle:

```ts
tooltips.register(sceneImport, () => i18n.t('tooltip.scene.import'), 'top');
tooltips.register(sceneNew, () => i18n.t('tooltip.scene.new'), 'top');
```

`tooltip.scene.import` / `tooltip.scene.new` are added to all 9 locale files, with translations following each locale's existing terminology (`menu.file.import`, `popup.publish.new-scene`).

### Verification

- `npm run lint` — clean
- `npm run lint:locales` — all 8 locales in sync with en.json (314 keys)
- `npx tsc --noEmit` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)