### PR TITLE
Persist user preferences in localStorage

### DIFF
--- a/src/doc.ts
+++ b/src/doc.ts
@@ -86,16 +86,17 @@ const registerDocEvents = (scene: Scene, events: Events) => {
     const loadDocument = async (file: File) => {
         events.fire('startSpinner');
 
-        // the document's view settings are applied through the same events as
-        // user changes - suspend preference capture so they don't overwrite
-        // the user's stored preferences
-        events.fire('preferences.suspend');
-
         // Create streaming ZIP reader from the file
         const blobSource = new BlobReadSource(file);
         const zipFs = new ZipReadFileSystem(blobSource);
 
         try {
+            // the document's view settings are applied through the same events
+            // as user changes - suspend preference capture so they don't
+            // overwrite the user's stored preferences. resumed in the finally
+            // below so a failed load can't leave capture suspended.
+            events.fire('preferences.suspend');
+
             // reset the scene
             resetScene();
 
@@ -146,10 +147,13 @@ const registerDocEvents = (scene: Scene, events: Events) => {
                 message: `'${error.message ?? error}'`
             });
         } finally {
-            // Clean up resources
-            zipFs.close();
+            // fire events before cleanup so a throwing close can't leave
+            // preference capture suspended or the spinner running
             events.fire('preferences.resume');
             events.fire('stopSpinner');
+
+            // Clean up resources
+            zipFs.close();
         }
     };
 

--- a/src/doc.ts
+++ b/src/doc.ts
@@ -86,6 +86,11 @@ const registerDocEvents = (scene: Scene, events: Events) => {
     const loadDocument = async (file: File) => {
         events.fire('startSpinner');
 
+        // the document's view settings are applied through the same events as
+        // user changes - suspend preference capture so they don't overwrite
+        // the user's stored preferences
+        events.fire('preferences.suspend');
+
         // Create streaming ZIP reader from the file
         const blobSource = new BlobReadSource(file);
         const zipFs = new ZipReadFileSystem(blobSource);
@@ -143,6 +148,7 @@ const registerDocEvents = (scene: Scene, events: Events) => {
         } finally {
             // Clean up resources
             zipFs.close();
+            events.fire('preferences.resume');
             events.fire('stopSpinner');
         }
     };
@@ -205,6 +211,9 @@ const registerDocEvents = (scene: Scene, events: Events) => {
             return false;
         }
         resetScene();
+        // new documents start from the user's stored preferences rather than
+        // whatever view state the previous document left behind
+        events.fire('preferences.apply');
         return true;
     });
 

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -817,8 +817,13 @@ const registerEditorEvents = (events: Events, editHistory: EditHistory, scene: S
     events.on('camera.setPose', (pose: { position: Vec3, target: Vec3, fov?: number }, speed = 1) => {
         // assign fov before setPose so distance is computed using the new fovFactor
         if (pose.fov !== undefined) {
+            // pose-driven fov (timeline playback, fly-to-pose) is not a user
+            // preference - suspend capture around the notify and the
+            // synchronous ui echo it triggers
+            events.fire('preferences.suspend');
             scene.camera.fov = pose.fov;
             events.fire('camera.fov', pose.fov);
+            events.fire('preferences.resume');
         }
         scene.camera.setPose(pose.position, pose.target, speed);
     });

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -821,9 +821,12 @@ const registerEditorEvents = (events: Events, editHistory: EditHistory, scene: S
             // preference - suspend capture around the notify and the
             // synchronous ui echo it triggers
             events.fire('preferences.suspend');
-            scene.camera.fov = pose.fov;
-            events.fire('camera.fov', pose.fov);
-            events.fire('preferences.resume');
+            try {
+                scene.camera.fov = pose.fov;
+                events.fire('camera.fov', pose.fov);
+            } finally {
+                events.fire('preferences.resume');
+            }
         }
         scene.camera.setPose(pose.position, pose.target, speed);
     });

--- a/src/main.ts
+++ b/src/main.ts
@@ -9,6 +9,7 @@ import { registerEditorEvents } from './editor';
 import { Events } from './events';
 import { initFileHandler } from './file-handler';
 import { registerIframeApi } from './iframe-api';
+import { registerPreferences } from './preferences';
 import { registerPublishEvents } from './publish';
 import { registerRenderEvents } from './render';
 import { Scene } from './scene';
@@ -131,8 +132,10 @@ const main = async () => {
         powerPreference: 'high-performance'
     });
 
+    const urlArgs = getURLArgs();
+
     const overrides = [
-        getURLArgs()
+        urlArgs
     ];
 
     // resolve scene config
@@ -264,6 +267,11 @@ const main = async () => {
     registerDocEvents(scene, events);
     registerRenderEvents(scene, events);
     initFileHandler(scene, events, editorUI.appContainer.dom);
+
+    // apply stored user preferences and start capturing changes to them.
+    // registered after the boot-time initialization events above so they are
+    // never captured as user changes.
+    registerPreferences(events, sceneConfig, urlArgs);
 
     // load async models
     scene.start();

--- a/src/preferences.ts
+++ b/src/preferences.ts
@@ -2,6 +2,7 @@ import { Color } from 'playcanvas';
 
 import { Events } from './events';
 import { SceneConfig } from './scene-config';
+import { i18n } from './ui/localization';
 
 const storageKey = 'supersplat:preferences';
 const storageVersion = 1;
@@ -199,13 +200,15 @@ const registerPreferences = (events: Events, config: SceneConfig, urlArgs: any) 
         apply();
     });
 
-    // clear stored preferences and restore defaults
+    // clear stored preferences and restore defaults. language lives in its
+    // own store (i18nextLng) but its default is 'automatic', so reset it too.
     events.on('preferences.reset', () => {
         for (const key in values) {
             delete values[key];
         }
         scheduleWrite();
         apply();
+        i18n.setLanguage(null);
     });
 };
 

--- a/src/preferences.ts
+++ b/src/preferences.ts
@@ -1,0 +1,212 @@
+import { Color } from 'playcanvas';
+
+import { Events } from './events';
+import { SceneConfig } from './scene-config';
+
+const storageKey = 'supersplat:preferences';
+const storageVersion = 1;
+
+type PrefValue = boolean | number | string | number[];
+
+type Descriptor = {
+    // storage key, which doubles as the notify event fired when the setting changes
+    key: string;
+    // command event used to apply a value
+    setCommand: string;
+    // the sceneConfig path a url query parameter would override. when the url
+    // specifies this setting, the stored preference is ignored for the session.
+    urlPath?: string;
+    // default event payload. reads the resolved sceneConfig, which already has
+    // url overrides folded in, so url parameters naturally take precedence.
+    getDefault: () => any;
+    // validate a stored (json) value
+    validate: (value: PrefValue) => boolean;
+    // stored (json) value -> event payload
+    toEvent?: (value: PrefValue) => any;
+    // notify payload -> stored (json) value
+    fromEvent?: (value: any) => PrefValue;
+};
+
+// mirror the kebab-case matching used by scene-config's Params so url
+// detection agrees with how getSceneConfig consumed the query parameters
+const kebabize = (s: string) => s.replace(/[A-Z]+(?![a-z])|[A-Z]/g, ($, ofs) => (ofs ? '-' : '') + $.toLowerCase());
+
+const registerPreferences = (events: Events, config: SceneConfig, urlArgs: any) => {
+    // returns true if the url query args specify the given config path
+    const urlHas = (path?: string) => {
+        if (!path) {
+            return false;
+        }
+        const lookup = (segments: string[]) => {
+            let obj = urlArgs;
+            for (const segment of segments) {
+                if (typeof obj !== 'object' || obj === null || !obj.hasOwnProperty(segment)) {
+                    return undefined;
+                }
+                obj = obj[segment];
+            }
+            return obj;
+        };
+        const parts = path.split('.');
+        return lookup(parts.map(kebabize)) !== undefined || lookup(parts) !== undefined;
+    };
+
+    const isBool = (v: PrefValue) => typeof v === 'boolean';
+    const isNumber = (min: number, max: number) => (v: PrefValue) => typeof v === 'number' && Number.isFinite(v) && v >= min && v <= max;
+    const isEnum = (options: string[]) => (v: PrefValue) => typeof v === 'string' && options.includes(v);
+    const isColor = (v: PrefValue) => Array.isArray(v) && v.length === 4 && v.every(c => typeof c === 'number' && c >= 0 && c <= 1);
+
+    const color = (key: string, setCommand: string, getDefault: () => { r: number, g: number, b: number, a: number }): Descriptor => ({
+        key,
+        setCommand,
+        urlPath: key,
+        getDefault: () => {
+            const c = getDefault();
+            return new Color(c.r, c.g, c.b, c.a);
+        },
+        validate: isColor,
+        toEvent: (v: PrefValue) => {
+            const a = v as number[];
+            return new Color(a[0], a[1], a[2], a[3]);
+        },
+        fromEvent: (c: Color) => [c.r, c.g, c.b, c.a]
+    });
+
+    // the order of this table is the application order. camera.mode and
+    // camera.overlay must come after camera.splatSize because the view panel's
+    // centers size slider side-fires setOverlay/setMode when its value changes.
+    const descriptors: Descriptor[] = [
+        color('bgClr', 'setBgClr', () => config.bgClr),
+        color('selectedClr', 'setSelectedClr', () => config.selectedClr),
+        color('unselectedClr', 'setUnselectedClr', () => config.unselectedClr),
+        color('lockedClr', 'setLockedClr', () => config.lockedClr),
+        { key: 'camera.tonemapping', setCommand: 'camera.setTonemapping', urlPath: 'camera.toneMapping', getDefault: () => config.camera.toneMapping, validate: isEnum(['linear', 'neutral', 'aces', 'aces2', 'filmic', 'hejl']) },
+        { key: 'camera.fovDolly', setCommand: 'camera.setFovDolly', getDefault: () => false, validate: isBool },
+        { key: 'camera.fov', setCommand: 'camera.setFov', urlPath: 'camera.fov', getDefault: () => config.camera.fov, validate: isNumber(10, 120) },
+        { key: 'view.bands', setCommand: 'view.setBands', urlPath: 'show.shBands', getDefault: () => config.show.shBands, validate: v => typeof v === 'number' && Number.isInteger(v) && v >= 0 && v <= 3 },
+        { key: 'camera.flySpeed', setCommand: 'camera.setFlySpeed', getDefault: () => 1, validate: isNumber(0.1, 30) },
+        { key: 'camera.splatSize', setCommand: 'camera.setSplatSize', getDefault: () => 2, validate: isNumber(0, 10) },
+        { key: 'view.centersUseGaussianColor', setCommand: 'view.setCentersUseGaussianColor', getDefault: () => false, validate: isBool },
+        { key: 'view.outlineSelection', setCommand: 'view.setOutlineSelection', getDefault: () => false, validate: isBool },
+        { key: 'grid.visible', setCommand: 'grid.setVisible', urlPath: 'show.grid', getDefault: () => config.show.grid, validate: isBool },
+        { key: 'camera.bound', setCommand: 'camera.setBound', urlPath: 'show.bound', getDefault: () => config.show.bound, validate: isBool },
+        { key: 'camera.boundDimensions', setCommand: 'camera.setBoundDimensions', urlPath: 'show.boundDimensions', getDefault: () => config.show.boundDimensions, validate: isBool },
+        { key: 'camera.showPoses', setCommand: 'camera.setShowPoses', urlPath: 'show.cameraPoses', getDefault: () => config.show.cameraPoses, validate: isBool },
+        { key: 'camera.showInfo', setCommand: 'camera.setShowInfo', urlPath: 'show.cameraInfo', getDefault: () => config.show.cameraInfo, validate: isBool },
+        { key: 'camera.mode', setCommand: 'camera.setMode', getDefault: () => 'centers', validate: isEnum(['centers', 'rings']) },
+        { key: 'camera.overlay', setCommand: 'camera.setOverlay', urlPath: 'camera.overlay', getDefault: () => config.camera.overlay, validate: isBool },
+        { key: 'camera.controlMode', setCommand: 'camera.setControlMode', getDefault: () => 'orbit', validate: isEnum(['orbit', 'fly']) }
+    ];
+
+    // load and validate the stored blob. unknown keys and invalid values are
+    // discarded so preferences survive settings being added, removed or
+    // reshaped between releases.
+    const load = (): Record<string, PrefValue> => {
+        const result: Record<string, PrefValue> = {};
+        try {
+            const raw = localStorage.getItem(storageKey);
+            if (raw) {
+                const blob = JSON.parse(raw);
+                if (blob?.version === storageVersion && typeof blob.values === 'object' && blob.values) {
+                    for (const descriptor of descriptors) {
+                        const value = blob.values[descriptor.key];
+                        if (value !== undefined && descriptor.validate(value)) {
+                            result[descriptor.key] = value;
+                        }
+                    }
+                }
+            }
+        } catch (e) {
+            // corrupt or inaccessible storage - fall back to defaults
+        }
+        return result;
+    };
+
+    const values = load();
+
+    // coalesce bursts of changes (slider drags, color picking) into a single
+    // write per task
+    let storageWarned = false;
+    let writeScheduled = false;
+    const scheduleWrite = () => {
+        if (writeScheduled) {
+            return;
+        }
+        writeScheduled = true;
+        queueMicrotask(() => {
+            writeScheduled = false;
+            try {
+                localStorage.setItem(storageKey, JSON.stringify({ version: storageVersion, values }));
+            } catch (e) {
+                if (!storageWarned) {
+                    storageWarned = true;
+                    console.warn('preferences will not persist: localStorage is unavailable');
+                }
+            }
+        });
+    };
+
+    // while suspended, changes are not captured. document loading and camera
+    // pose playback suspend capture so programmatic changes don't overwrite
+    // stored preferences.
+    let suspendDepth = 0;
+    events.on('preferences.suspend', () => {
+        suspendDepth++;
+    });
+    events.on('preferences.resume', () => {
+        suspendDepth = Math.max(0, suspendDepth - 1);
+    });
+
+    // apply stored preferences (or defaults) to the live state. every setting
+    // is applied so side effects between settings self-heal, and the resolved
+    // sceneConfig already contains url overrides, which win over stored values.
+    const apply = () => {
+        events.fire('preferences.suspend');
+        try {
+            for (const descriptor of descriptors) {
+                const stored = urlHas(descriptor.urlPath) ? undefined : values[descriptor.key];
+                const payload = stored !== undefined ? (descriptor.toEvent ? descriptor.toEvent(stored) : stored) : descriptor.getDefault();
+                events.fire(descriptor.setCommand, payload);
+            }
+        } finally {
+            events.fire('preferences.resume');
+        }
+    };
+
+    apply();
+
+    // capture user changes. registered after the initial apply so it never
+    // observes its own writes or the boot-time initialization events.
+    descriptors.forEach((descriptor) => {
+        events.on(descriptor.key, (value: any) => {
+            if (suspendDepth > 0) {
+                return;
+            }
+            const stored = descriptor.fromEvent ? descriptor.fromEvent(value) : value;
+            if (!descriptor.validate(stored)) {
+                return;
+            }
+            if (JSON.stringify(values[descriptor.key]) === JSON.stringify(stored)) {
+                return;
+            }
+            values[descriptor.key] = stored;
+            scheduleWrite();
+        });
+    });
+
+    // re-apply stored preferences (used by File > New)
+    events.on('preferences.apply', () => {
+        apply();
+    });
+
+    // clear stored preferences and restore defaults
+    events.on('preferences.reset', () => {
+        for (const key in values) {
+            delete values[key];
+        }
+        scheduleWrite();
+        apply();
+    });
+};
+
+export { registerPreferences };

--- a/src/ui/scss/view-panel.scss
+++ b/src/ui/scss/view-panel.scss
@@ -68,5 +68,10 @@
             width: 187px;
             margin: 0;
         }
+
+        & > .view-panel-row-button {
+            flex-grow: 1;
+            margin: 0 2px;
+        }
     }
 }

--- a/src/ui/view-panel.ts
+++ b/src/ui/view-panel.ts
@@ -626,6 +626,12 @@ class ViewPanel extends Container {
             events.fire('preferences.reset');
         });
 
+        // reset reverts language to automatic; sync the selector (its change
+        // handler makes the equivalent setLanguage(null) call idempotently)
+        events.on('preferences.reset', () => {
+            languageSelection.value = 'auto';
+        });
+
         // tooltips
         const shortcutManager: ShortcutManager = events.invoke('shortcutManager');
         const shortcut = shortcutManager.formatShortcut('grid.toggleVisible');

--- a/src/ui/view-panel.ts
+++ b/src/ui/view-panel.ts
@@ -1,4 +1,4 @@
-import { BooleanInput, ColorPicker, Container, Label, SelectInput, SliderInput } from '@playcanvas/pcui';
+import { BooleanInput, Button, ColorPicker, Container, Label, SelectInput, SliderInput } from '@playcanvas/pcui';
 import { Color } from 'playcanvas';
 
 import { Events } from '../events';
@@ -413,6 +413,19 @@ class ViewPanel extends Container {
         showCameraInfoRow.append(showCameraInfoLabel);
         showCameraInfoRow.append(showCameraInfoToggle);
 
+        // reset preferences to defaults
+
+        const resetRow = new Container({
+            class: 'view-panel-row'
+        });
+
+        const resetButton = new Button({
+            class: 'view-panel-row-button'
+        });
+        i18n.bindText(resetButton, 'panel.view-options.reset');
+
+        resetRow.append(resetButton);
+
         this.append(header);
         this.append(languageRow);
         this.append(clrRow);
@@ -429,6 +442,7 @@ class ViewPanel extends Container {
         this.append(showBoundDimensionsRow);
         this.append(showCameraPosesRow);
         this.append(showCameraInfoRow);
+        this.append(resetRow);
 
         // handle panel visibility
 
@@ -604,6 +618,12 @@ class ViewPanel extends Container {
 
         tonemappingSelection.on('change', (value: string) => {
             events.fire('camera.setTonemapping', value);
+        });
+
+        // reset preferences
+
+        resetButton.on('click', () => {
+            events.fire('preferences.reset');
         });
 
         // tooltips

--- a/static/locales/de.json
+++ b/static/locales/de.json
@@ -90,6 +90,7 @@
     "panel.view-options.tonemapping.aces2": "ACES2",
     "panel.view-options.tonemapping.filmic": "Filmic",
     "panel.view-options.tonemapping.hejl": "Hejl",
+    "panel.view-options.reset": "Auf Standard zurücksetzen",
     "panel.splat-data": "Splat-Daten",
     "panel.splat-data.distance": "Entfernung",
     "panel.splat-data.camera-depth": "Kameratiefe",

--- a/static/locales/en.json
+++ b/static/locales/en.json
@@ -90,6 +90,7 @@
     "panel.view-options.tonemapping.aces2": "ACES2",
     "panel.view-options.tonemapping.filmic": "Filmic",
     "panel.view-options.tonemapping.hejl": "Hejl",
+    "panel.view-options.reset": "Reset to Defaults",
     "panel.splat-data": "Splat Data",
     "panel.splat-data.distance": "Distance",
     "panel.splat-data.camera-depth": "Camera Depth",

--- a/static/locales/es.json
+++ b/static/locales/es.json
@@ -90,6 +90,7 @@
     "panel.view-options.tonemapping.aces2": "ACES2",
     "panel.view-options.tonemapping.filmic": "Fílmico",
     "panel.view-options.tonemapping.hejl": "Hejl",
+    "panel.view-options.reset": "Restablecer valores predeterminados",
     "panel.splat-data": "Datos de Splat",
     "panel.splat-data.distance": "Distancia",
     "panel.splat-data.camera-depth": "Profundidad de cámara",

--- a/static/locales/fr.json
+++ b/static/locales/fr.json
@@ -90,6 +90,7 @@
     "panel.view-options.tonemapping.aces2": "ACES2",
     "panel.view-options.tonemapping.filmic": "Filmique",
     "panel.view-options.tonemapping.hejl": "Hejl",
+    "panel.view-options.reset": "Réinitialiser les valeurs par défaut",
     "panel.splat-data": "Données Splat",
     "panel.splat-data.distance": "Distance",
     "panel.splat-data.camera-depth": "Profondeur caméra",

--- a/static/locales/ja.json
+++ b/static/locales/ja.json
@@ -90,6 +90,7 @@
     "panel.view-options.tonemapping.aces2": "ACES2",
     "panel.view-options.tonemapping.filmic": "フィルミック",
     "panel.view-options.tonemapping.hejl": "Hejl",
+    "panel.view-options.reset": "デフォルトに戻す",
     "panel.splat-data": "スプラットの統計",
     "panel.splat-data.distance": "距離",
     "panel.splat-data.camera-depth": "カメラ深度",

--- a/static/locales/ko.json
+++ b/static/locales/ko.json
@@ -90,6 +90,7 @@
     "panel.view-options.tonemapping.aces2": "ACES2",
     "panel.view-options.tonemapping.filmic": "필름 스타일",
     "panel.view-options.tonemapping.hejl": "Hejl",
+    "panel.view-options.reset": "기본값으로 재설정",
     "panel.splat-data": "Splat 데이터",
     "panel.splat-data.distance": "거리",
     "panel.splat-data.camera-depth": "카메라 깊이",

--- a/static/locales/pt-BR.json
+++ b/static/locales/pt-BR.json
@@ -90,6 +90,7 @@
     "panel.view-options.tonemapping.aces2": "ACES2",
     "panel.view-options.tonemapping.filmic": "Filmic",
     "panel.view-options.tonemapping.hejl": "Hejl",
+    "panel.view-options.reset": "Redefinir padrões",
     "panel.splat-data": "Dados do Splat",
     "panel.splat-data.distance": "Distância",
     "panel.splat-data.camera-depth": "Profundidade da câmera",

--- a/static/locales/ru.json
+++ b/static/locales/ru.json
@@ -90,6 +90,7 @@
     "panel.view-options.tonemapping.aces2": "ACES2",
     "panel.view-options.tonemapping.filmic": "Кинематографическая",
     "panel.view-options.tonemapping.hejl": "Hejl",
+    "panel.view-options.reset": "Сбросить настройки",
     "panel.splat-data": "Данные Splat",
     "panel.splat-data.distance": "Расстояние",
     "panel.splat-data.camera-depth": "Глубина камеры",

--- a/static/locales/zh-CN.json
+++ b/static/locales/zh-CN.json
@@ -90,6 +90,7 @@
     "panel.view-options.tonemapping.aces2": "ACES2",
     "panel.view-options.tonemapping.filmic": "电影",
     "panel.view-options.tonemapping.hejl": "Hejl",
+    "panel.view-options.reset": "恢复默认设置",
     "panel.splat-data": "Splat 数据",
     "panel.splat-data.distance": "距离",
     "panel.splat-data.camera-depth": "相机深度",


### PR DESCRIPTION
## Summary

Editor settings now persist across sessions. Today every setting except language resets on page reload — the most-requested improvement on the tracker.

- New `src/preferences.ts` module with a descriptor table covering all 20 view/camera settings (colors, tonemapping, FOV, FOV dolly, SH bands, fly speed, centers size/color, outline, grid/bound/dimensions/poses/info toggles, centers-vs-rings mode, splat overlay, orbit/fly control mode). Language keeps its existing `i18nextLng` mechanism for storage and capture, and Reset to Defaults reverts it to Automatic along with everything else.
- **Sparse, versioned blob** (`supersplat:preferences`): only settings the user has explicitly changed are stored — new settings added in future releases are never masked by stale snapshots, removed settings self-prune on load, and per-descriptor validators discard values that no longer parse (corrupt blobs, wrong versions, and blocked localStorage all degrade gracefully).
- **"User changes only" write policy**: loading a `.ssproj` styles the live scene exactly as before but never rewrites stored prefs (suspend window around document deserialization); timeline playback/scrubbing and fly-to-pose never capture the animated FOV (suspend around the `camera.setPose` fov cascade, which otherwise echoes back through the PCUI slider as a set-command).
- **Precedence**: URL params > loaded document (live state only) > stored prefs > defaults. The apply pass sets every setting in a fixed order so cross-setting UI echoes (the centers-size slider force-fires overlay/mode) self-heal.
- **File > New** now re-applies stored preferences instead of keeping whatever view state the previous document left behind.
- Localized **Reset to Defaults** button at the bottom of the View Options panel (all 9 locales).

Fixes #661. Fixes #663. Fixes #235. Fixes #25. Related: #662.

## Notes for reviewers

- `.ssproj` semantics are completely unchanged — documents still serialize and re-apply their view/camera blocks.
- `camera.controlMode` persists "last used mode" including implicit gesture switches (double-click→orbit, WASD→fly). Opting it out is a one-line deletion of its descriptor row if that feels wrong.
- PWA downgrade edge: an older bundle seeing a newer blob version discards it (prefs reset) — accepted trade-off for low-stakes view prefs rather than version-namespacing the storage key.

## Testing

- `npm run lint`, `npm run lint:locales` (322 keys in sync), `npm run build`.
- Verified in the built app: persist/restore across reloads via both set-commands and keyboard-toggle paths, with the blob containing only touched keys and zero spurious captures from the boot sequence; URL params win for the session without touching the blob; a real `.ssproj` save/load round-trip styles the scene without polluting prefs (and a post-load tweak writes exactly one key); timeline scrub across poses with different FOVs plus fly-to-pose leave the FOV pref untouched; a blob containing only `camera.splatSize` boots without flipping overlay/mode; File > New returns the view to stored prefs; the Reset button restores factory defaults and empties the blob; garbage JSON, wrong-version blobs, invalid value types and unknown keys are all discarded/pruned cleanly with no console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
