### PR TITLE
Add PNG and JPEG image render formats

### DIFF
--- a/src/png-writer.ts
+++ b/src/png-writer.ts
@@ -1,0 +1,70 @@
+// minimal png encoder producing bit-exact rgba output. scanlines use filter
+// type 0 so pixel bytes are stored verbatim - slightly larger files than a
+// filtering encoder, but exact (no canvas premultiplied-alpha round trip)
+// and dependency-free.
+
+const crcTable = new Uint32Array(256);
+for (let n = 0; n < 256; n++) {
+    let c = n;
+    for (let k = 0; k < 8; k++) {
+        c = (c & 1) ? (0xedb88320 ^ (c >>> 1)) : (c >>> 1);
+    }
+    crcTable[n] = c;
+}
+
+const crc32 = (...buffers: Uint8Array[]) => {
+    let c = 0xffffffff;
+    for (const buffer of buffers) {
+        for (let i = 0; i < buffer.length; i++) {
+            c = crcTable[(c ^ buffer[i]) & 0xff] ^ (c >>> 8);
+        }
+    }
+    return (c ^ 0xffffffff) >>> 0;
+};
+
+const chunk = (type: string, data: Uint8Array) => {
+    const typeBytes = new TextEncoder().encode(type);
+    const result = new Uint8Array(12 + data.length);
+    const view = new DataView(result.buffer);
+    view.setUint32(0, data.length);
+    result.set(typeBytes, 4);
+    result.set(data, 8);
+    view.setUint32(8 + data.length, crc32(typeBytes, data));
+    return result;
+};
+
+// encode top-down 8-bit rgba pixels as a png
+const encodePng = async (rgba: Uint8Array, width: number, height: number): Promise<Uint8Array<ArrayBuffer>> => {
+    // ihdr: 8-bit rgba, no interlace
+    const ihdr = new Uint8Array(13);
+    const ihdrView = new DataView(ihdr.buffer);
+    ihdrView.setUint32(0, width);
+    ihdrView.setUint32(4, height);
+    ihdr[8] = 8;    // bit depth
+    ihdr[9] = 6;    // color type: rgba (compression, filter and interlace bytes stay 0)
+
+    // raw scanlines: a filter-type byte (0 = none) followed by the row's pixels
+    const rowBytes = width * 4;
+    const raw = new Uint8Array((rowBytes + 1) * height);
+    for (let y = 0; y < height; y++) {
+        raw.set(rgba.subarray(y * rowBytes, (y + 1) * rowBytes), y * (rowBytes + 1) + 1);
+    }
+
+    // 'deflate' is the zlib wrapper (rfc 1950) that idat requires
+    const compressed = new Uint8Array(await new Response(
+        new Blob([raw]).stream().pipeThrough(new CompressionStream('deflate'))
+    ).arrayBuffer());
+
+    const signature = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+    const chunks = [signature, chunk('IHDR', ihdr), chunk('IDAT', compressed), chunk('IEND', new Uint8Array(0))];
+
+    const result = new Uint8Array(chunks.reduce((total, c) => total + c.length, 0));
+    let offset = 0;
+    for (const c of chunks) {
+        result.set(c, offset);
+        offset += c.length;
+    }
+    return result;
+};
+
+export { encodePng };

--- a/src/render.ts
+++ b/src/render.ts
@@ -284,13 +284,30 @@ const registerRenderEvents = (scene: Scene, events: Events) => {
                     data[i] = 255;
                 }
 
-                const canvas = new OffscreenCanvas(width, height);
-                const context = canvas.getContext('2d');
-                if (!context) {
-                    throw new Error('failed to create 2d context');
+                const imageData = new ImageData(new Uint8ClampedArray(data.buffer, data.byteOffset, data.length), width, height);
+                let blob: Blob;
+                if (typeof OffscreenCanvas !== 'undefined') {
+                    const canvas = new OffscreenCanvas(width, height);
+                    const context = canvas.getContext('2d');
+                    if (!context) {
+                        throw new Error('failed to create 2d context');
+                    }
+                    context.putImageData(imageData, 0, 0);
+                    blob = await canvas.convertToBlob({ type: 'image/jpeg', quality: quality ?? 0.9 });
+                } else {
+                    // fallback for browsers without OffscreenCanvas
+                    const canvas = document.createElement('canvas');
+                    canvas.width = width;
+                    canvas.height = height;
+                    const context = canvas.getContext('2d');
+                    if (!context) {
+                        throw new Error('failed to create 2d context');
+                    }
+                    context.putImageData(imageData, 0, 0);
+                    blob = await new Promise<Blob>((resolve, reject) => {
+                        canvas.toBlob(b => (b ? resolve(b) : reject(new Error('failed to encode jpeg'))), 'image/jpeg', quality ?? 0.9);
+                    });
                 }
-                context.putImageData(new ImageData(new Uint8ClampedArray(data.buffer, data.byteOffset, data.length), width, height), 0, 0);
-                const blob = await canvas.convertToBlob({ type: 'image/jpeg', quality: quality ?? 0.9 });
                 bytes = new Uint8Array(await blob.arrayBuffer());
                 extension = 'jpg';
                 mimeType = 'image/jpeg';

--- a/src/render.ts
+++ b/src/render.ts
@@ -5,6 +5,7 @@ import { Color, path, Quat, Vec3 } from 'playcanvas';
 import { ElementType } from './element';
 import { EquirectRenderer } from './equirect-renderer';
 import { Events } from './events';
+import { encodePng } from './png-writer';
 import { Scene } from './scene';
 import { injectSphericalMetadata } from './spherical-metadata';
 import { Splat } from './splat';
@@ -32,6 +33,8 @@ type ImageSettings = {
     height: number;
     transparentBg: boolean;
     showDebug: boolean;
+    format: 'png' | 'jpeg' | 'webp';
+    quality?: number;           // 0..1, jpeg only
     projection?: 'standard' | 'equirect';
     levelHorizon?: boolean;
 };
@@ -91,8 +94,8 @@ const sortSplatsAndWait = (scene: Scene, splats: Splat[]) => {
     }));
 };
 
-const downloadFile = (data: ArrayBuffer | Uint8Array<ArrayBuffer>, filename: string) => {
-    const blob = new Blob([data], { type: 'application/octet-stream' });
+const downloadFile = (data: ArrayBuffer | Uint8Array<ArrayBuffer>, filename: string, type = 'application/octet-stream') => {
+    const blob = new Blob([data], { type });
     const url = window.URL.createObjectURL(blob);
     const el = document.createElement('a');
     el.download = filename;
@@ -177,7 +180,7 @@ const registerRenderEvents = (scene: Scene, events: Events) => {
         let savedOrtho = false;
 
         try {
-            const { width, height, transparentBg, showDebug, projection, levelHorizon } = imageSettings;
+            const { width, height, transparentBg, showDebug, format, quality, projection, levelHorizon } = imageSettings;
             const is360 = projection === 'equirect';
 
             // in 360 mode the offscreen target is a square cube face; the
@@ -266,18 +269,47 @@ const registerRenderEvents = (scene: Scene, events: Events) => {
                 data.set(line, bottom);
             }
 
-            // construct the webp codec
-            if (!webpCodec) {
-                webpCodec = await WebPCodec.create();
-            }
+            let bytes: Uint8Array<ArrayBuffer>;
+            let extension: string;
+            let mimeType: string;
 
-            const bytes = webpCodec.encodeLosslessRGBA(data, width, height);
+            if (format === 'png') {
+                bytes = await encodePng(data, width, height);
+                extension = 'png';
+                mimeType = 'image/png';
+            } else if (format === 'jpeg') {
+                // jpeg has no alpha channel and canvas encoding flattens
+                // transparent pixels toward black, so force full opacity
+                for (let i = 3; i < data.length; i += 4) {
+                    data[i] = 255;
+                }
+
+                const canvas = new OffscreenCanvas(width, height);
+                const context = canvas.getContext('2d');
+                if (!context) {
+                    throw new Error('failed to create 2d context');
+                }
+                context.putImageData(new ImageData(new Uint8ClampedArray(data.buffer, data.byteOffset, data.length), width, height), 0, 0);
+                const blob = await canvas.convertToBlob({ type: 'image/jpeg', quality: quality ?? 0.9 });
+                bytes = new Uint8Array(await blob.arrayBuffer());
+                extension = 'jpg';
+                mimeType = 'image/jpeg';
+            } else {
+                // construct the webp codec
+                if (!webpCodec) {
+                    webpCodec = await WebPCodec.create();
+                }
+
+                bytes = webpCodec.encodeLosslessRGBA(data, width, height);
+                extension = 'webp';
+                mimeType = 'image/webp';
+            }
 
             if (fileStream) {
                 await fileStream.write(bytes);
                 await fileStream.close();
             } else {
-                downloadFile(bytes, `${baseFilename()}.webp`);
+                downloadFile(bytes, `${baseFilename()}.${extension}`, mimeType);
             }
 
             return true;

--- a/src/ui/editor.ts
+++ b/src/ui/editor.ts
@@ -223,14 +223,21 @@ class EditorUI {
                     let writable;
                     let fileHandle: FileSystemFileHandle | undefined;
 
+                    const imageFileTypes: Record<string, { description: string, accept: Record<`${string}/${string}`, `.${string}`[]>, extension: string }> = {
+                        png: { description: 'PNG Image', accept: { 'image/png': ['.png'] }, extension: '.png' },
+                        jpeg: { description: 'JPEG Image', accept: { 'image/jpeg': ['.jpg', '.jpeg'] }, extension: '.jpg' },
+                        webp: { description: 'WebP Image', accept: { 'image/webp': ['.webp'] }, extension: '.webp' }
+                    };
+                    const imageFileType = imageFileTypes[imageSettings.format];
+
                     if (window.showSaveFilePicker) {
                         fileHandle = await window.showSaveFilePicker({
                             id: 'SuperSplatImageFileExport',
                             types: [{
-                                description: 'WebP Image',
-                                accept: { 'image/webp': ['.webp'] }
+                                description: imageFileType.description,
+                                accept: imageFileType.accept
                             }],
-                            suggestedName: `${events.invoke('render.baseFilename')}.webp`
+                            suggestedName: `${events.invoke('render.baseFilename')}${imageFileType.extension}`
                         });
 
                         writable = await fileHandle.createWritable();

--- a/src/ui/image-settings-dialog.ts
+++ b/src/ui/image-settings-dialog.ts
@@ -316,7 +316,7 @@ class ImageSettingsDialog extends Container {
                         transparentBg: format !== 'jpeg' && transparentBgBoolean.value,
                         showDebug: !is360 && showDebugBoolean.value,
                         format,
-                        quality: qualitySlider.value / 100,
+                        quality: format === 'jpeg' ? qualitySlider.value / 100 : undefined,
                         projection: (is360 ? 'equirect' : 'standard') as 'standard' | 'equirect',
                         levelHorizon: is360 && levelHorizonBoolean.value
                     };

--- a/src/ui/image-settings-dialog.ts
+++ b/src/ui/image-settings-dialog.ts
@@ -1,4 +1,4 @@
-import { BooleanInput, Button, Container, Element, Label, NumericInput, SelectInput, VectorInput } from '@playcanvas/pcui';
+import { BooleanInput, Button, Container, Element, Label, NumericInput, SelectInput, SliderInput, VectorInput } from '@playcanvas/pcui';
 
 import { Events } from '../events';
 import { ImageSettings } from '../render';
@@ -105,6 +105,41 @@ class ImageSettingsDialog extends Container {
         resolutionRow.append(resolutionLabel);
         resolutionRow.append(resolutionValue);
 
+        // format
+
+        const formatLabel = new Label({ class: 'label' });
+        i18n.bindText(formatLabel, 'popup.render-image.format');
+        const formatSelect = new SelectInput({
+            class: 'select',
+            defaultValue: 'png',
+            options: [
+                { v: 'png', t: 'PNG' },
+                { v: 'jpeg', t: 'JPEG' },
+                { v: 'webp', t: 'WebP' }
+            ]
+        });
+        const formatRow = new Container({ class: 'row' });
+        formatRow.append(formatLabel);
+        formatRow.append(formatSelect);
+
+        // jpeg quality
+
+        const qualityLabel = new Label({ class: 'label' });
+        i18n.bindText(qualityLabel, 'popup.render-image.quality');
+        const qualitySlider = new SliderInput({
+            class: 'slider',
+            min: 1,
+            max: 100,
+            precision: 0,
+            value: 90
+        });
+        const qualityRow = new Container({ class: 'row' });
+        qualityRow.append(qualityLabel);
+        qualityRow.append(qualitySlider);
+
+        // hidden until jpeg is selected
+        qualityRow.hidden = true;
+
         // level horizon (360 only)
 
         const levelHorizonLabel = new Label({ class: 'label' });
@@ -141,6 +176,8 @@ class ImageSettingsDialog extends Container {
         content.append(projectionRow);
         content.append(presetRow);
         content.append(resolutionRow);
+        content.append(formatRow);
+        content.append(qualityRow);
         content.append(transparentBgRow);
         content.append(showDebugRow);
         content.append(levelHorizonRow);
@@ -223,6 +260,14 @@ class ImageSettingsDialog extends Container {
 
         projectionSelect.on('change', syncProjection);
 
+        // jpeg has no alpha channel: hide the transparent background toggle
+        // and show the quality slider instead
+        formatSelect.on('change', () => {
+            const isJpeg = formatSelect.value === 'jpeg';
+            transparentBgRow.hidden = isJpeg;
+            qualityRow.hidden = !isJpeg;
+        });
+
         // handle key bindings for enter and escape
 
         let onCancel: () => void;
@@ -263,12 +308,15 @@ class ImageSettingsDialog extends Container {
                 onOK = () => {
                     const [width, height] = resolutionValue.value;
                     const is360 = projectionSelect.value === 'equirect';
+                    const format = formatSelect.value as 'png' | 'jpeg' | 'webp';
 
                     const imageSettings = {
                         width,
                         height,
-                        transparentBg: transparentBgBoolean.value,
+                        transparentBg: format !== 'jpeg' && transparentBgBoolean.value,
                         showDebug: !is360 && showDebugBoolean.value,
+                        format,
+                        quality: qualitySlider.value / 100,
                         projection: (is360 ? 'equirect' : 'standard') as 'standard' | 'equirect',
                         levelHorizon: is360 && levelHorizonBoolean.value
                     };

--- a/static/locales/de.json
+++ b/static/locales/de.json
@@ -150,6 +150,8 @@
     "popup.render-image.show-debug": "Debug-Überlagerungen anzeigen",
     "popup.render-image.resolution-current": "Aktuell",
     "popup.render-image.resolution-custom": "Benutzerdefiniert",
+    "popup.render-image.format": "Format",
+    "popup.render-image.quality": "Qualität",
     "popup.render-image.projection": "Projektion",
     "popup.render-image.projection-standard": "Standard",
     "popup.render-image.projection-360": "360° Equirektangular",

--- a/static/locales/en.json
+++ b/static/locales/en.json
@@ -150,6 +150,8 @@
     "popup.render-image.show-debug": "Show Debug Overlays",
     "popup.render-image.resolution-current": "Current",
     "popup.render-image.resolution-custom": "Custom",
+    "popup.render-image.format": "Format",
+    "popup.render-image.quality": "Quality",
     "popup.render-image.projection": "Projection",
     "popup.render-image.projection-standard": "Standard",
     "popup.render-image.projection-360": "360° Equirectangular",

--- a/static/locales/es.json
+++ b/static/locales/es.json
@@ -150,6 +150,8 @@
     "popup.render-image.show-debug": "Mostrar superposiciones de depuración",
     "popup.render-image.resolution-current": "Actual",
     "popup.render-image.resolution-custom": "Personalizada",
+    "popup.render-image.format": "Formato",
+    "popup.render-image.quality": "Calidad",
     "popup.render-image.projection": "Proyección",
     "popup.render-image.projection-standard": "Estándar",
     "popup.render-image.projection-360": "Equirrectangular 360°",

--- a/static/locales/fr.json
+++ b/static/locales/fr.json
@@ -150,6 +150,8 @@
     "popup.render-image.show-debug": "Afficher les superpositions de débogage",
     "popup.render-image.resolution-current": "Actuelle",
     "popup.render-image.resolution-custom": "Personnalisée",
+    "popup.render-image.format": "Format",
+    "popup.render-image.quality": "Qualité",
     "popup.render-image.projection": "Projection",
     "popup.render-image.projection-standard": "Standard",
     "popup.render-image.projection-360": "Équirectangulaire 360°",

--- a/static/locales/ja.json
+++ b/static/locales/ja.json
@@ -150,6 +150,8 @@
     "popup.render-image.show-debug": "デバッグオーバーレイを表示",
     "popup.render-image.resolution-current": "現在",
     "popup.render-image.resolution-custom": "カスタム",
+    "popup.render-image.format": "フォーマット",
+    "popup.render-image.quality": "画質",
     "popup.render-image.projection": "投影",
     "popup.render-image.projection-standard": "標準",
     "popup.render-image.projection-360": "360° 正距円筒",

--- a/static/locales/ko.json
+++ b/static/locales/ko.json
@@ -150,6 +150,8 @@
     "popup.render-image.show-debug": "디버그 오버레이 표시",
     "popup.render-image.resolution-current": "현재",
     "popup.render-image.resolution-custom": "사용자 정의",
+    "popup.render-image.format": "형식",
+    "popup.render-image.quality": "품질",
     "popup.render-image.projection": "투영",
     "popup.render-image.projection-standard": "표준",
     "popup.render-image.projection-360": "360° 등장방형",

--- a/static/locales/pt-BR.json
+++ b/static/locales/pt-BR.json
@@ -150,6 +150,8 @@
     "popup.render-image.show-debug": "Mostrar Sobreposições (Debug)",
     "popup.render-image.resolution-current": "Resolução da Tela",
     "popup.render-image.resolution-custom": "Personalizado",
+    "popup.render-image.format": "Formato",
+    "popup.render-image.quality": "Qualidade",
     "popup.render-image.projection": "Projeção",
     "popup.render-image.projection-standard": "Padrão",
     "popup.render-image.projection-360": "Equirretangular 360°",

--- a/static/locales/ru.json
+++ b/static/locales/ru.json
@@ -150,6 +150,8 @@
     "popup.render-image.show-debug": "Показать отладочные наложения",
     "popup.render-image.resolution-current": "Текущее",
     "popup.render-image.resolution-custom": "Пользовательское",
+    "popup.render-image.format": "Формат",
+    "popup.render-image.quality": "Качество",
     "popup.render-image.projection": "Проекция",
     "popup.render-image.projection-standard": "Стандартная",
     "popup.render-image.projection-360": "Эквиректангулярная 360°",

--- a/static/locales/zh-CN.json
+++ b/static/locales/zh-CN.json
@@ -150,6 +150,8 @@
     "popup.render-image.show-debug": "显示调试覆盖",
     "popup.render-image.resolution-current": "当前",
     "popup.render-image.resolution-custom": "自定义",
+    "popup.render-image.format": "格式",
+    "popup.render-image.quality": "质量",
     "popup.render-image.projection": "投影",
     "popup.render-image.projection-standard": "标准",
     "popup.render-image.projection-360": "360° 等距柱状",


### PR DESCRIPTION
## Summary

Image render is currently WebP-lossless only (since #952 replaced the original lodepng path). This adds a **Format** select to the Image Settings dialog — **PNG (new default)**, JPEG, and WebP — plus a JPEG **Quality** slider (1–100, default 90, shown only for JPEG).

- **PNG** encodes through a new minimal exact PNG writer (`src/png-writer.ts`, ~70 lines): PNG chunks + CRC32 with IDAT deflated by the browser-native `CompressionStream('deflate')`. This restores the bit-exact output guarantee the old lodepng path had — no canvas premultiplied-alpha round trip — with zero dependencies and no wasm. Trade-off: no scanline-filter heuristics, so files are somewhat larger than a filtering encoder would produce.
- **JPEG** encodes via `OffscreenCanvas.convertToBlob` with alpha pre-flattened to 255 (splat blending leaves alpha < 255 even over opaque backgrounds, which canvas JPEG encoding would darken). The Transparent Background toggle hides when JPEG is selected, and the setting is forced off in the emitted settings.
- **WebP** keeps the existing wasm `encodeLosslessRGBA` — canvas WebP encoding is Chromium-only (Safari/Firefox silently fall back to producing PNG bytes), so the wasm path remains the only cross-browser lossless option, at zero added weight since SOG already ships it.
- Both standard and 360/equirect projections converge on one top-down RGBA8 buffer feeding a single encode step, so all three formats work for 360 renders automatically.
- Save picker types/descriptions/suggested names are per-format (mirroring the video handler), and the no-picker fallback download uses the right extension and MIME.
- Two new locale keys across all 9 locales (`popup.render-image.format`, reusing each locale's existing video-format translation, and `popup.render-image.quality`).

## Testing

- `npm run lint`, `npm run lint:locales` (324 keys in sync), `npm run build` (no TS warnings).
- Verified in the built app: dialog defaults to PNG and gates Quality/Transparent Background per format; PNG output validated at byte level — an independent decoder (`createImageBitmap`) matched the file's decompressed IDAT scanlines on **all** opaque pixels, while 620 semi-transparent pixels showed the canvas readback diverging from the exactly-stored bytes (demonstrating the precision the exact writer preserves); transparent-background PNGs retain semi-transparent alpha; JPEG output is valid (`FFD8FF`), fully opaque, correct dimensions, and quality measurably affects size (6,145 B at 0.9 vs 2,647 B at 0.3 on the identical scene); WebP path unchanged (`RIFF....WEBP`); 360 + PNG produces a valid 2:1 equirect with content; picker args and fallback download extensions verified per format.

🤖 Generated with [Claude Code](https://claude.com/claude-code)