### PR TITLE
Hold TypeScript below 6.1 until typescript-eslint supports newer

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -20,6 +20,11 @@
     {
       "matchDepTypes": ["dependencies"],
       "rangeStrategy": "widen"
+    },
+    {
+      "description": "typescript-eslint peer range caps at <6.1.0 - hold TypeScript until it supports newer",
+      "matchPackageNames": ["typescript"],
+      "allowedVersions": "<6.1.0"
     }
   ]
 }


### PR DESCRIPTION
Renovate's major update PR (#967) fails because it bumps `typescript` to 7.0.2, but `@typescript-eslint/eslint-plugin` and `@typescript-eslint/parser` declare a peer dependency of `typescript@">=4.8.4 <6.1.0"` (even at latest, 8.63.0). The resulting ERESOLVE conflict means Renovate cannot regenerate `package-lock.json` (the `renovate/artifacts` failure), leaving the branch with a stale lockfile, so Build and Lint fail immediately at `npm ci`.

This adds a package rule holding `typescript` at `<6.1.0`, matching typescript-eslint's peer range. Once merged, retriggering #967 via its rebase checkbox will recreate the PR without the TypeScript bump, allowing the remaining major updates (splat-transform 3, concurrently 10, i18next-http-backend 4) to proceed.

Remove this rule once typescript-eslint widens its peer range to support TypeScript 6.1+/7.