### PR TITLE
Show keyframes stranded beyond the end of the timeline

### DIFF
--- a/src/timeline.ts
+++ b/src/timeline.ts
@@ -13,11 +13,34 @@ const registerTimelineEvents = (events: Events) => {
     let smoothness = 1;
     let loop = true;
 
+    // current frame
+    let frame = 0;
+
+    const setFrame = (value: number) => {
+        if (value !== frame) {
+            frame = value;
+            events.fire('timeline.frame', frame);
+        }
+    };
+
+    events.function('timeline.frame', () => {
+        return frame;
+    });
+
+    events.on('timeline.setFrame', (value: number) => {
+        setFrame(value);
+    });
+
     // frames
 
     const setFrames = (value: number) => {
         if (value !== frames) {
             frames = value;
+            // clamp a stranded playhead before announcing the new length so
+            // 'timeline.frames' listeners observe a consistent frame/frames pair
+            if (frame >= frames) {
+                setFrame(frames - 1);
+            }
             events.fire('timeline.frames', frames);
         }
     };
@@ -81,24 +104,6 @@ const registerTimelineEvents = (events: Events) => {
         setLoop(value);
     });
 
-    // current frame
-    let frame = 0;
-
-    const setFrame = (value: number) => {
-        if (value !== frame) {
-            frame = value;
-            events.fire('timeline.frame', frame);
-        }
-    };
-
-    events.function('timeline.frame', () => {
-        return frame;
-    });
-
-    events.on('timeline.setFrame', (value: number) => {
-        setFrame(value);
-    });
-
     // anim controls
     let animHandle: EventHandle = null;
 
@@ -156,7 +161,8 @@ const registerTimelineEvents = (events: Events) => {
 
     // Key navigation - delegates to active track's keys
     const skipToKey = (dir: 'forward' | 'back') => {
-        const keys = events.invoke('track.keys') as number[] ?? [];
+        // ignore keys beyond the end of the timeline - they don't play
+        const keys = (events.invoke('track.keys') as number[] ?? []).filter(k => k < frames);
 
         if (keys.length > 0) {
             const orderedKeys = keys.slice().sort((a, b) => a - b);

--- a/src/ui/localization.ts
+++ b/src/ui/localization.ts
@@ -4,6 +4,8 @@ import Backend from 'i18next-http-backend';
 
 interface LocalizeOptions {
     ellipsis?: boolean;
+    // any other values are forwarded to i18next as {{placeholder}} interpolation data
+    [key: string]: unknown;
 }
 
 // minimal shapes the binders operate on (pcui elements emit a 'destroy' event)
@@ -76,9 +78,9 @@ class Localization {
         });
     }
 
-    /** Translate a key. */
+    /** Translate a key. Extra option values interpolate into {{placeholders}}. */
     t(key: string, options?: LocalizeOptions): string {
-        let text = i18next.t(key);
+        let text = i18next.t(key, options);
 
         if (options?.ellipsis) text += '...';
 

--- a/src/ui/scss/timeline-panel.scss
+++ b/src/ui/scss/timeline-panel.scss
@@ -165,6 +165,13 @@
                     // border-radius: 50%;
                     cursor: pointer;
                     pointer-events: auto;
+
+                    // keys stranded beyond the timeline's end: pinned just past
+                    // the strip, error-tinted and dimmed - present but not playing
+                    &.out-of-range {
+                        background-color: $error;
+                        opacity: 0.7;
+                    }
                 }
 
                 // declared before dragging/copying so those cursors win

--- a/src/ui/scss/tooltips.scss
+++ b/src/ui/scss/tooltips.scss
@@ -2,6 +2,10 @@
 
 .tooltips {
     position: absolute;
+    // size to content: shrink-to-fit against the space right of `left` would
+    // otherwise crush tooltips near the right viewport edge into thin columns
+    // (the show-time clamp in tooltips.ts shifts any overflow back into view)
+    width: max-content;
     background-color: $bcg-darkest;
     border: 1px solid $bcg-primary;
     padding: 4px;

--- a/src/ui/timeline-panel.ts
+++ b/src/ui/timeline-panel.ts
@@ -83,14 +83,33 @@ class Ticks extends Container {
             // keys - get from active track
             const keys = events.invoke('track.keys') as number[] ?? [];
 
-            const createKey = (keyFrame: number) => {
+            // keys at frame >= numFrames don't play (the spline ignores them);
+            // pin them just past the right end of the strip instead of hiding them
+            const inRangeKeys = keys.filter(k => k < numFrames);
+            const outOfRangeKeys = keys.filter(k => k >= numFrames).sort((a, b) => a - b);
+
+            // center of a pinned marker: 10px right of the last frame, staggered
+            // 2px per extra marker, capped so the 8px diamond stays inside the
+            // 20px right padding
+            const pinnedOffset = (index: number) => {
+                return padding + width + 10 + Math.min(index, 3) * 2;
+            };
+
+            const createKey = (keyFrame: number, pinnedIndex = -1) => {
+                const outOfRange = pinnedIndex !== -1;
+
                 const label = document.createElement('div');
                 label.classList.add('time-label', 'key');
-                label.style.left = `${offsetFromFrame(keyFrame)}px`;
+                if (outOfRange) {
+                    label.classList.add('out-of-range');
+                }
+                label.style.left = `${outOfRange ? pinnedOffset(pinnedIndex) : offsetFromFrame(keyFrame)}px`;
                 label.dataset.frame = keyFrame.toString();
 
                 const wrapper = new Element({ dom: label });
-                tooltips.register(wrapper, () => i18n.t('tooltip.timeline.key'), 'top');
+                tooltips.register(wrapper, () => (outOfRange ?
+                    i18n.t('tooltip.timeline.key-out-of-range', { frame: keyFrame }) :
+                    i18n.t('tooltip.timeline.key')), 'top');
                 keyElements.push(wrapper);
                 let dragging = false;
                 let copying = false;
@@ -123,6 +142,8 @@ class Ticks extends Container {
                         if (copying) {
                             clone.style.left = `${offsetFromFrame(toFrame)}px`;
                         } else {
+                            // once dragged, the key can only land in range
+                            label.classList.remove('out-of-range');
                             label.style.left = `${offsetFromFrame(toFrame)}px`;
                         }
                     } else {
@@ -167,8 +188,13 @@ class Ticks extends Container {
                 workArea.dom.appendChild(label);
             };
 
-            keys.forEach((keyFrame: number) => {
+            inRangeKeys.forEach((keyFrame: number) => {
                 createKey(keyFrame);
+            });
+
+            // ascending order so the marker for the largest frame renders topmost
+            outOfRangeKeys.forEach((keyFrame: number, index: number) => {
+                createKey(keyFrame, index);
             });
 
             // cursor

--- a/static/locales/de.json
+++ b/static/locales/de.json
@@ -305,6 +305,7 @@
     "tooltip.timeline.add-key": "Key hinzufügen",
     "tooltip.timeline.remove-key": "Key entfernen",
     "tooltip.timeline.key": "Ziehen zum Verschieben. Umschalt+Ziehen zum Kopieren. Strg+Klick übernimmt die aktuelle Ansicht.",
+    "tooltip.timeline.key-out-of-range": "Keyframe {{frame}} liegt hinter dem Ende der Timeline und wird nicht abgespielt. Auf die Timeline ziehen oder die Gesamtanzahl der Frames erhöhen.",
     "tooltip.timeline.frame-rate": "Bildrate",
     "tooltip.timeline.total-frames": "Gesamtanzahl der Frames",
     "tooltip.timeline.smoothness": "Weichheit",

--- a/static/locales/en.json
+++ b/static/locales/en.json
@@ -305,6 +305,7 @@
     "tooltip.timeline.add-key": "Add Key",
     "tooltip.timeline.remove-key": "Remove Key",
     "tooltip.timeline.key": "Drag to move. Shift+drag to copy. Ctrl+click to set to current view.",
+    "tooltip.timeline.key-out-of-range": "Keyframe {{frame}} is past the end of the timeline and won't play. Drag it onto the timeline or increase Total Frames.",
     "tooltip.timeline.frame-rate": "Frame Rate",
     "tooltip.timeline.total-frames": "Total Frames",
     "tooltip.timeline.smoothness": "Smoothness",

--- a/static/locales/es.json
+++ b/static/locales/es.json
@@ -305,6 +305,7 @@
     "tooltip.timeline.add-key": "Añadir clave",
     "tooltip.timeline.remove-key": "Eliminar clave",
     "tooltip.timeline.key": "Arrastra para mover. Mayús+arrastrar para copiar. Ctrl+clic para fijar la vista actual.",
+    "tooltip.timeline.key-out-of-range": "El fotograma clave {{frame}} está más allá del final de la línea de tiempo y no se reproducirá. Arrástralo a la línea de tiempo o aumenta los fotogramas totales.",
     "tooltip.timeline.frame-rate": "Velocidad de fotogramas",
     "tooltip.timeline.total-frames": "Fotogramas totales",
     "tooltip.timeline.smoothness": "Suavidad",

--- a/static/locales/fr.json
+++ b/static/locales/fr.json
@@ -305,6 +305,7 @@
     "tooltip.timeline.add-key": "Ajouter une clé",
     "tooltip.timeline.remove-key": "Supprimer une clé",
     "tooltip.timeline.key": "Glisser pour déplacer. Maj+glisser pour copier. Ctrl+clic pour reprendre la vue actuelle.",
+    "tooltip.timeline.key-out-of-range": "L'image clé {{frame}} est au-delà de la fin de la timeline et ne sera pas jouée. Glissez-la sur la timeline ou augmentez le nombre total de frames.",
     "tooltip.timeline.frame-rate": "Fréquence d'image",
     "tooltip.timeline.total-frames": "Nombre total de frames",
     "tooltip.timeline.smoothness": "Douceur",

--- a/static/locales/ja.json
+++ b/static/locales/ja.json
@@ -305,6 +305,7 @@
     "tooltip.timeline.add-key": "キーフレームを追加",
     "tooltip.timeline.remove-key": "キーフレームを削除",
     "tooltip.timeline.key": "ドラッグで移動。Shift+ドラッグでコピー。Ctrl+クリックで現在のビューを設定。",
+    "tooltip.timeline.key-out-of-range": "キーフレーム {{frame}} はタイムラインの終端を超えているため再生されません。タイムライン上にドラッグするか、総フレーム数を増やしてください。",
     "tooltip.timeline.frame-rate": "フレームレート",
     "tooltip.timeline.total-frames": "総フレーム数",
     "tooltip.timeline.smoothness": "スムーズさ",

--- a/static/locales/ko.json
+++ b/static/locales/ko.json
@@ -305,6 +305,7 @@
     "tooltip.timeline.add-key": "키 추가",
     "tooltip.timeline.remove-key": "키 제거",
     "tooltip.timeline.key": "드래그하여 이동. Shift+드래그로 복사. Ctrl+클릭으로 현재 뷰 설정.",
+    "tooltip.timeline.key-out-of-range": "키프레임 {{frame}}이(가) 타임라인 끝을 벗어나 재생되지 않습니다. 타임라인 위로 드래그하거나 총 프레임 수를 늘리세요.",
     "tooltip.timeline.frame-rate": "프레임 속도",
     "tooltip.timeline.total-frames": "총 프레임 수",
     "tooltip.timeline.smoothness": "부드러움",

--- a/static/locales/pt-BR.json
+++ b/static/locales/pt-BR.json
@@ -305,6 +305,7 @@
     "tooltip.timeline.add-key": "Adicionar Quadro",
     "tooltip.timeline.remove-key": "Remover Quadro",
     "tooltip.timeline.key": "Arraste para mover. Shift+arrastar para copiar. Ctrl+clique para definir a visão atual.",
+    "tooltip.timeline.key-out-of-range": "O quadro-chave {{frame}} está além do fim da linha do tempo e não será reproduzido. Arraste-o para a linha do tempo ou aumente o Total de Quadros.",
     "tooltip.timeline.frame-rate": "Taxa de Quadros",
     "tooltip.timeline.total-frames": "Total de Quadros",
     "tooltip.timeline.smoothness": "Suavidade",

--- a/static/locales/ru.json
+++ b/static/locales/ru.json
@@ -305,6 +305,7 @@
     "tooltip.timeline.add-key": "Добавить ключ",
     "tooltip.timeline.remove-key": "Удалить ключ",
     "tooltip.timeline.key": "Перетащите для перемещения. Shift+перетаскивание — копировать. Ctrl+клик — задать текущий вид.",
+    "tooltip.timeline.key-out-of-range": "Ключевой кадр {{frame}} находится за концом таймлайна и не будет воспроизводиться. Перетащите его на таймлайн или увеличьте общее количество кадров.",
     "tooltip.timeline.frame-rate": "Частота кадров",
     "tooltip.timeline.total-frames": "Всего кадров",
     "tooltip.timeline.smoothness": "Плавность",

--- a/static/locales/zh-CN.json
+++ b/static/locales/zh-CN.json
@@ -305,6 +305,7 @@
     "tooltip.timeline.add-key": "添加关键帧",
     "tooltip.timeline.remove-key": "删除关键帧",
     "tooltip.timeline.key": "拖动以移动。Shift+拖动复制。Ctrl+点击设为当前视图。",
+    "tooltip.timeline.key-out-of-range": "关键帧 {{frame}} 超出时间轴末尾，不会播放。将其拖回时间轴或增加总帧数。",
     "tooltip.timeline.frame-rate": "帧率",
     "tooltip.timeline.total-frames": "总帧数",
     "tooltip.timeline.smoothness": "平滑度",


### PR DESCRIPTION
Addresses the last open timeline item in #804:

> When defining keyframe 100 and then shorten the timeline length to 80, the frame 100 silently exists but is not used. I am not sure if this is really intuitive

Keys at frames past the timeline length are excluded from the spline but stay in the document (and revive if the timeline is lengthened) — previously with zero indication on the timeline, since their markers were positioned off the end of the strip.

### What changed

- **Out-of-range keys are now visible**: their markers pin just past the right end of the strip, error-tinted and dimmed, staggered slightly when several stack up. The tooltip names the frame: *"Keyframe 100 is past the end of the timeline and won't play. Drag it onto the timeline or increase Total Frames."* Dragging a pinned marker pulls the key back into range via the existing undo-wrapped move; lengthening the timeline revives keys in place. Non-destructive — nothing is deleted or clamped.
- **Playhead clamps on shorten**: shortening the timeline used to strand the cursor past the end (off-strip cursor, bogus prev/next-frame modulo, playback seeded out of range).
- **Key navigation skips stranded keys**: shift+prev/next no longer jumps the playhead to frames beyond the end.
- **i18n interpolation fix** (prerequisite): the `i18n.t()` wrapper dropped its options object, so `{{placeholder}}` interpolation never reached i18next.
- **Tooltip sizing fix**: tooltips near the right viewport edge computed shrink-to-fit width against the leftover pixels right of their anchor, collapsing into one-word-per-line columns — worst case for the pinned-key tooltip, which always sits at the edge. `width: max-content` sizes them to content; the existing show-time clamp shifts any overflow back into view. All edge-adjacent tooltips benefit.
- New locale string added to all 9 locale files (`lint:locales` passes).

### Known limitations (deliberate)

- A stranded key can't be deleted directly (the remove button needs the playhead on the key's frame, which is now unreachable) — drag it into range first, or lengthen the timeline. Consistent with the non-destructive choice.
- Any nonzero drag of a pinned marker lands the key on the last frame (drag positions clamp to the strip). Undoable, and arguably the right affordance for "grab it back".

### Verification

`npm run lint`, `npm run lint:locales` (325 keys in sync), `npm run build` all pass. Manually verified in the browser: shorten 180→80 with keys at 0/90/100/179 (markers pin with stagger, cursor clamps 150→79), tooltip interpolation in English and German, drag-back into range plus undo/redo, tiny-drag lands on last frame, all-keys-stranded fallback navigation, lengthen-to-revive, re-pinning on window resize, and tooltip boxes at the viewport edge (270×68px content box vs. the previous ~45px column; short tooltips like the loop button's now render on one line).

🤖 Generated with [Claude Code](https://claude.com/claude-code)