### PR TITLE
Add switchable translate/rotate/scale gizmos to box/sphere select

### DIFF
--- a/src/box-shape.ts
+++ b/src/box-shape.ts
@@ -7,6 +7,7 @@ import {
     BlendState,
     BoundingBox,
     Entity,
+    Mat4,
     ShaderMaterial,
     Vec3
 } from 'playcanvas';
@@ -15,8 +16,12 @@ import { Element, ElementType } from './element';
 import { Serializer } from './serializer';
 import { vertexShader, fragmentShader } from './shaders/box-shape-shader';
 
-const v = new Vec3();
+const invMat = new Mat4();
 const bound = new BoundingBox();
+
+// the pivot's local scale carries the box lengths, so in the pivot's local
+// space the box is the unit cube
+const unitBound = new BoundingBox(new Vec3(0, 0, 0), new Vec3(0.5, 0.5, 0.5));
 
 class BoxShape extends Element {
     _lenX = 2;
@@ -76,8 +81,8 @@ class BoxShape extends Element {
 
     onPreRender() {
         this.pivot.setLocalScale(this._lenX, this._lenY, this._lenZ);
-        this.pivot.getWorldTransform().getTranslation(v);
-        this.material.setParameter('boxCen', [v.x, v.y, v.z]);
+        invMat.copy(this.pivot.getWorldTransform()).invert();
+        this.material.setParameter('boxInvMat', invMat.data);
         this.material.setParameter('boxLen', [this._lenX * 0.5, this._lenY * 0.5, this._lenZ  * 0.5]);
 
         const device = this.scene.graphicsDevice;
@@ -89,9 +94,15 @@ class BoxShape extends Element {
     }
 
     updateBound() {
-        bound.center.copy(this.pivot.getPosition());
-        bound.halfExtents.set(this._lenX, this._lenY, this._lenZ);
-        this.scene.boundDirty = true;
+        // keep the pivot's scale in sync immediately (not just at the next
+        // prerender) so world-transform reads are never stale
+        this.pivot.setLocalScale(this._lenX, this._lenY, this._lenZ);
+        bound.setFromTransformedAabb(unitBound, this.pivot.getWorldTransform());
+
+        // undo/redo can change the volume while it's not in the scene
+        if (this.scene) {
+            this.scene.boundDirty = true;
+        }
     }
 
     get worldBound(): BoundingBox | null {

--- a/src/data-processor/intersect.ts
+++ b/src/data-processor/intersect.ts
@@ -27,14 +27,19 @@ type RectOptions = {
 };
 
 type SphereOptions = {
-    sphere: { x: number, y: number, z: number, radius: number };
+    // transform mapping the unit sphere (diameter 1) to world space
+    sphere: { transform: Mat4 };
 };
 
 type BoxOptions = {
-    box: { x: number, y: number, z: number, lenx: number, leny: number, lenz: number };
+    // transform mapping the unit cube (side 1) to world space
+    box: { transform: Mat4 };
 };
 
 type IntersectOptions = MaskOptions | RectOptions | SphereOptions | BoxOptions;
+
+const shapeInvMat = new Mat4();
+const identityMat = new Mat4();
 
 const resolve = (scope: ScopeSpace, values: any) => {
     for (const key in values) {
@@ -164,43 +169,22 @@ class Intersect {
         }
 
         const sphereOptions = options as SphereOptions;
+        const boxOptions = options as BoxOptions;
         if (sphereOptions.sphere) {
+            shapeInvMat.copy(sphereOptions.sphere.transform).invert();
             resolve(scope, {
                 mode: 2,
-                sphere_params: [
-                    sphereOptions.sphere.x,
-                    sphereOptions.sphere.y,
-                    sphereOptions.sphere.z,
-                    sphereOptions.sphere.radius
-                ]
+                shape_matrix_inv: shapeInvMat.data
             });
-        } else {
-            resolve(scope, {
-                sphere_params: [0, 0, 0, 0]
-            });
-        }
-
-        const boxOptions = options as BoxOptions;
-        if (boxOptions.box) {
+        } else if (boxOptions.box) {
+            shapeInvMat.copy(boxOptions.box.transform).invert();
             resolve(scope, {
                 mode: 3,
-                box_params: [
-                    boxOptions.box.x,
-                    boxOptions.box.y,
-                    boxOptions.box.z,
-                    0
-                ],
-                aabb_params: [
-                    boxOptions.box.lenx * 0.5,
-                    boxOptions.box.leny * 0.5,
-                    boxOptions.box.lenz * 0.5,
-                    0
-                ]
+                shape_matrix_inv: shapeInvMat.data
             });
         } else {
             resolve(scope, {
-                box_params: [0, 0, 0, 0],
-                aabb_params: [0, 0, 0, 0]
+                shape_matrix_inv: identityMat.data
             });
         }
 

--- a/src/edit-history.ts
+++ b/src/edit-history.ts
@@ -30,6 +30,7 @@ class EditHistory {
         events.on('edit.undo', () => this.undo());
         events.on('edit.redo', () => this.redo());
         events.on('edit.add', (editOp: EditOp, suppressOp = false) => this.add(editOp, suppressOp));
+        events.on('edit.removeForShape', (shape: unknown) => this.removeForShape(shape));
     }
 
     private queue<T>(fn: () => T | Promise<T>): Promise<T> {
@@ -108,6 +109,33 @@ class EditHistory {
             });
             this.history = [];
             this.cursor = 0;
+            this.fireEvents();
+        });
+    }
+
+    // Remove all operations that reference a specific selection shape. Called
+    // when a shape tool deactivates: the volume is transient tool state, so
+    // its ops must not linger in history as steps that visibly change nothing.
+    // Shape ops are never nested inside MultiOp, so a flat scan suffices.
+    removeForShape(shape: unknown) {
+        return this.queue(() => {
+            let newCursor = 0;
+            const newHistory: EditOp[] = [];
+
+            for (let i = 0; i < this.history.length; i++) {
+                const op = this.history[i];
+                if ((op as any).shape === shape) {
+                    op.destroy?.();
+                } else {
+                    newHistory.push(op);
+                    if (i < this.cursor) {
+                        newCursor++;
+                    }
+                }
+            }
+
+            this.history = newHistory;
+            this.cursor = newCursor;
             this.fireEvents();
         });
     }

--- a/src/edit-ops.ts
+++ b/src/edit-ops.ts
@@ -1,9 +1,11 @@
-import { Color, Mat4 } from 'playcanvas';
+import { Color, Mat4, Quat, Vec3 } from 'playcanvas';
 
 import { AnimTrack } from './anim-track';
+import { BoxShape } from './box-shape';
 import { IndexRanges, sortedPredicate } from './index-ranges';
 import { Pivot } from './pivot';
 import { Scene } from './scene';
+import { SphereShape } from './sphere-shape';
 import { Splat } from './splat';
 import { State } from './splat-state';
 import { Transform } from './transform';
@@ -304,6 +306,56 @@ class PlacePivotOp {
     }
 }
 
+type ShapeTransformState = {
+    position: Vec3;
+    rotation?: Quat;
+    lens?: Vec3;        // box lengths
+    radius?: number;    // sphere radius
+};
+
+// moves/rotates/resizes a box/sphere selection volume
+class ShapeTransformOp {
+    name = 'shapeTransform';
+    shape: BoxShape | SphereShape;
+    oldState: ShapeTransformState;
+    newState: ShapeTransformState;
+
+    constructor(options: { shape: BoxShape | SphereShape, oldState: ShapeTransformState, newState: ShapeTransformState }) {
+        this.shape = options.shape;
+        this.oldState = options.oldState;
+        this.newState = options.newState;
+    }
+
+    apply(state: ShapeTransformState) {
+        const { shape } = this;
+        shape.pivot.setPosition(state.position);
+        if (state.rotation) {
+            shape.pivot.setRotation(state.rotation);
+        }
+        if (shape instanceof BoxShape && state.lens) {
+            shape.lenX = state.lens.x;
+            shape.lenY = state.lens.y;
+            shape.lenZ = state.lens.z;
+        }
+        if (shape instanceof SphereShape && state.radius !== undefined) {
+            shape.radius = state.radius;
+        }
+        shape.moved();
+
+        // refresh the owning tool's ui. while the shape is not in the scene
+        // the state changes silently and shows on the tool's next activation.
+        shape.scene?.events.fire('shapeSelection.changed', shape);
+    }
+
+    do() {
+        this.apply(this.newState);
+    }
+
+    undo() {
+        this.apply(this.oldState);
+    }
+}
+
 type ColorAdjustment = {
     tintClr?: Color
     temperature?: number,
@@ -455,6 +507,8 @@ export {
     EntityTransformOp,
     SplatsTransformOp,
     PlacePivotOp,
+    ShapeTransformOp,
+    ShapeTransformState,
     ColorAdjustment,
     SetSplatColorAdjustmentOp,
     AnimTrackEditOp,

--- a/src/edit-ops.ts
+++ b/src/edit-ops.ts
@@ -333,14 +333,16 @@ class ShapeTransformOp {
             shape.pivot.setRotation(state.rotation);
         }
         if (shape instanceof BoxShape && state.lens) {
+            // the length setters refresh the bound with the new transform
             shape.lenX = state.lens.x;
             shape.lenY = state.lens.y;
             shape.lenZ = state.lens.z;
-        }
-        if (shape instanceof SphereShape && state.radius !== undefined) {
+        } else if (shape instanceof SphereShape && state.radius !== undefined) {
+            // the radius setter refreshes the bound with the new transform
             shape.radius = state.radius;
+        } else {
+            shape.moved();
         }
-        shape.moved();
 
         // refresh the owning tool's ui. while the shape is not in the scene
         // the state changes silently and shows on the tool's next activation.

--- a/src/edit-ops.ts
+++ b/src/edit-ops.ts
@@ -344,8 +344,10 @@ class ShapeTransformOp {
             shape.moved();
         }
 
-        // refresh the owning tool's ui. while the shape is not in the scene
-        // the state changes silently and shows on the tool's next activation.
+        // refresh the owning tool's ui. shape ops are purged from history when
+        // the tool deactivates, so the shape is normally in the scene here; the
+        // guard covers the brief window where an already-queued undo/redo runs
+        // after a synchronous deactivate.
         shape.scene?.events.fire('shapeSelection.changed', shape);
     }
 

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -352,18 +352,20 @@ const registerEditorEvents = (events: Events, editHistory: EditHistory, scene: S
         });
     };
 
-    events.on('select.bySphere', async (op: 'add'|'remove'|'set'|'intersect', sphere: number[]) => {
+    // transform maps the unit sphere (diameter 1) to world space
+    events.on('select.bySphere', async (op: 'add'|'remove'|'set'|'intersect', transform: Mat4) => {
         for (const splat of selectedSplats()) {
             await runSelectIntersect(splat, op, {
-                sphere: { x: sphere[0], y: sphere[1], z: sphere[2], radius: sphere[3] }
+                sphere: { transform }
             });
         }
     });
 
-    events.on('select.byBox', async (op: 'add'|'remove'|'set'|'intersect', box: number[]) => {
+    // transform maps the unit cube (side 1) to world space
+    events.on('select.byBox', async (op: 'add'|'remove'|'set'|'intersect', transform: Mat4) => {
         for (const splat of selectedSplats()) {
             await runSelectIntersect(splat, op, {
-                box: { x: box[0], y: box[1], z: box[2], lenx: box[3], leny: box[4], lenz: box[5] }
+                box: { transform }
             });
         }
     });

--- a/src/main.ts
+++ b/src/main.ts
@@ -243,8 +243,8 @@ const main = async () => {
     toolManager.register('floodSelection', new FloodSelection(events, editorUI.toolsContainer.dom, mask, editorUI.canvasContainer));
     toolManager.register('polygonSelection', new PolygonSelection(events, editorUI.toolsContainer.dom, mask));
     toolManager.register('lassoSelection', new LassoSelection(events, editorUI.toolsContainer.dom, mask));
-    toolManager.register('sphereSelection', new SphereSelection(events, scene, editorUI.canvasContainer));
-    toolManager.register('boxSelection', new BoxSelection(events, scene, editorUI.canvasContainer));
+    toolManager.register('sphereSelection', new SphereSelection(events, scene, editorUI.canvasContainer, editorUI.tooltips));
+    toolManager.register('boxSelection', new BoxSelection(events, scene, editorUI.canvasContainer, editorUI.tooltips));
     toolManager.register('eyedropperSelection', new EyedropperSelection(events, editorUI.toolsContainer.dom, editorUI.canvasContainer));
     toolManager.register('move', new MoveTool(events, scene));
     toolManager.register('rotate', new RotateTool(events, scene));

--- a/src/shaders/box-shape-shader.ts
+++ b/src/shaders/box-shape-shader.ts
@@ -51,8 +51,9 @@ const fragmentShader = /* glsl */ `
     }
 
     uniform sampler2D blueNoiseTex32;
+    uniform mat4 matrix_model;
     uniform mat4 matrix_viewProjection;
-    uniform vec3 boxCen;
+    uniform mat4 boxInvMat;
     uniform vec3 boxLen;
 
     uniform vec3 near_origin;
@@ -81,25 +82,34 @@ const fragmentShader = /* glsl */ `
         vec2 clip = gl_FragCoord.xy / targetSize;
         vec3 worldNear = near_origin + near_x * clip.x + near_y * clip.y;
         vec3 worldFar = far_origin + far_x * clip.x + far_y * clip.y;
-        vec3 rayDir = normalize(worldFar - worldNear);
+
+        // transform the ray into the box's local space, where the box is the
+        // axis-aligned unit cube centered on the origin (the pivot's scale
+        // carries the box lengths)
+        vec3 localNear = (boxInvMat * vec4(worldNear, 1.0)).xyz;
+        vec3 localDir = normalize((boxInvMat * vec4(worldFar, 1.0)).xyz - localNear);
 
         float t0, t1;
         int axis0, axis1;
-        if (!intersectBox(t0, t1, axis0, axis1, worldNear, rayDir, boxCen, boxLen)) {
+        if (!intersectBox(t0, t1, axis0, axis1, localNear, localDir, vec3(0.0), vec3(0.5))) {
             gl_FragColor = vec4(1.0, 0.0, 0.0, 0.6);
             return;
         }
 
-        vec3 frontPos = worldNear + rayDir * t0;
-        bool front = t0 > 0.0 && strips(frontPos - boxCen, axis0);
+        // strips operate on box-metric offsets (local * lengths) so the
+        // 0.5-unit grid spacing is preserved and rotates with the box
+        vec3 frontLocal = localNear + localDir * t0;
+        bool front = t0 > 0.0 && strips(frontLocal * boxLen * 2.0, axis0);
 
-        vec3 backPos = worldNear + rayDir * t1;
-        bool back = strips(backPos - boxCen, axis1);
+        vec3 backLocal = localNear + localDir * t1;
+        bool back = strips(backLocal * boxLen * 2.0, axis1);
 
         if (front) {
+            vec3 frontPos = (matrix_model * vec4(frontLocal, 1.0)).xyz;
             gl_FragColor = vec4(1.0, 1.0, 1.0, 0.6);
             gl_FragDepth = writeDepth(0.6) ? calcDepth(frontPos, matrix_viewProjection) : 1.0;
         } else if (back) {
+            vec3 backPos = (matrix_model * vec4(backLocal, 1.0)).xyz;
             gl_FragColor = vec4(0.0, 0.0, 0.0, 0.6);
             gl_FragDepth = writeDepth(0.6) ? calcDepth(backPos, matrix_viewProjection) : 1.0;
         } else {

--- a/src/shaders/intersection-shader.ts
+++ b/src/shaders/intersection-shader.ts
@@ -26,12 +26,9 @@ const fragmentShader = /* glsl */ `
     // rect params
     uniform vec4 rect_params;                       // rect x, y, width, height
 
-    // sphere params
-    uniform vec4 sphere_params;                     // sphere x, y, z, radius
-
-    // box params
-    uniform vec4 box_params;                     // box x, y, z
-    uniform vec4 aabb_params;                    // len x, y, z
+    // sphere/box params: transforms world space into the shape's local space,
+    // where the shape is the unit sphere (diameter 1) or unit cube (side 1)
+    uniform mat4 shape_matrix_inv;
 
     void main(void) {
         // calculate output id
@@ -90,22 +87,15 @@ const fragmentShader = /* glsl */ `
                     }
                 }
             } else if (mode == 2) {
-                // select by sphere (world-space, independent of camera frustum)
-                clr[i] = length(world - sphere_params.xyz) < sphere_params.w ? 1.0 : 0.0;
+                // select by sphere (world-space, independent of camera frustum):
+                // unit sphere test in shape-local space
+                vec3 local = (shape_matrix_inv * vec4(world, 1.0)).xyz;
+                clr[i] = length(local) < 0.5 ? 1.0 : 0.0;
             } else if (mode == 3) {
-                // select by box (world-space, independent of camera frustum)
-                vec3 relativePosition = world - box_params.xyz;
-                bool isInsideCube = true;
-                if (relativePosition.x < -aabb_params.x || relativePosition.x > aabb_params.x) {
-                    isInsideCube = false;
-                }
-                if (relativePosition.y < -aabb_params.y || relativePosition.y > aabb_params.y) {
-                    isInsideCube = false;
-                }
-                if (relativePosition.z < -aabb_params.z || relativePosition.z > aabb_params.z) {
-                    isInsideCube = false;
-                }
-                clr[i] = isInsideCube ? 1.0 : 0.0;
+                // select by box (world-space, independent of camera frustum):
+                // unit cube test in shape-local space
+                vec3 local = (shape_matrix_inv * vec4(world, 1.0)).xyz;
+                clr[i] = all(lessThanEqual(abs(local), vec3(0.5))) ? 1.0 : 0.0;
             }
         }
 

--- a/src/shortcut-manager.ts
+++ b/src/shortcut-manager.ts
@@ -37,9 +37,12 @@ const defaultShortcuts: Record<string, ShortcutBinding> = {
     'select.delete': { keys: ['Delete', 'Backspace'] },
 
     // Tools
-    'tool.move': { keys: ['1'] },
-    'tool.rotate': { keys: ['2'] },
-    'tool.scale': { keys: ['3'] },
+    // 1/2/3 don't fire tool.move/rotate/scale directly: while a shape
+    // selection tool (box/sphere) is active they switch its gizmo mode
+    // instead of switching tools (see ToolManager)
+    'tool.moveShortcut': { keys: ['1'] },
+    'tool.rotateShortcut': { keys: ['2'] },
+    'tool.scaleShortcut': { keys: ['3'] },
     'tool.rectSelection': { keys: ['r'] },
     'tool.lassoSelection': { keys: ['l'] },
     'tool.polygonSelection': { keys: ['p'] },

--- a/src/sphere-shape.ts
+++ b/src/sphere-shape.ts
@@ -87,7 +87,11 @@ class SphereShape extends Element {
     updateBound() {
         bound.center.copy(this.pivot.getPosition());
         bound.halfExtents.set(this.radius, this.radius, this.radius);
-        this.scene.boundDirty = true;
+
+        // undo/redo can change the volume while it's not in the scene
+        if (this.scene) {
+            this.scene.boundDirty = true;
+        }
     }
 
     get worldBound(): BoundingBox | null {

--- a/src/tools/box-selection.ts
+++ b/src/tools/box-selection.ts
@@ -313,6 +313,11 @@ class BoxSelection {
             gizmo.detach();
             scene.remove(box);
             this.active = false;
+
+            // the volume is transient tool state: drop its ops from history so
+            // undo/redo never hits steps that visibly change nothing while the
+            // tool is hidden
+            events.fire('edit.removeForShape', box);
         };
     }
 }

--- a/src/tools/box-selection.ts
+++ b/src/tools/box-selection.ts
@@ -1,30 +1,34 @@
-import { Button, Container, Label, VectorInput } from '@playcanvas/pcui';
-import { TranslateGizmo, Vec3 } from 'playcanvas';
+import { Button, Container, Element, Label, VectorInput } from '@playcanvas/pcui';
+import { Vec3 } from 'playcanvas';
 
+import { ShapeGizmoMode, ShapeTransformGizmo } from './shape-transform-gizmo';
 import { BoxShape } from '../box-shape';
+import { ShapeTransformOp } from '../edit-ops';
 import { Events } from '../events';
 import { Scene } from '../scene';
+import { ShortcutManager } from '../shortcut-manager';
 import { Splat } from '../splat';
 import { i18n } from '../ui/localization';
+import addSvg from '../ui/svg/select-add.svg';
+import intersectSvg from '../ui/svg/select-intersect.svg';
+import removeSvg from '../ui/svg/select-remove.svg';
+import setSvg from '../ui/svg/select-set.svg';
+import { Tooltips } from '../ui/tooltips';
+
+const createSvg = (svgString: string) => {
+    const decodedStr = decodeURIComponent(svgString.substring('data:image/svg+xml,'.length));
+    return new DOMParser().parseFromString(decodedStr, 'image/svg+xml').documentElement;
+};
 
 class BoxSelection {
     activate: () => void;
     deactivate: () => void;
+    setTransformMode: (mode: Exclude<ShapeGizmoMode, 'none'>) => boolean;
 
     active = false;
 
-    constructor(events: Events, scene: Scene, canvasContainer: Container) {
+    constructor(events: Events, scene: Scene, canvasContainer: Container, tooltips: Tooltips) {
         const box = new BoxShape();
-
-        const gizmo = new TranslateGizmo(scene.camera.camera, scene.gizmoLayer);
-
-        gizmo.on('render:update', () => {
-            scene.forceRender = true;
-        });
-
-        gizmo.on('transform:move', () => {
-            box.moved();
-        });
 
         // ui
         const selectToolbar = new Container({
@@ -36,15 +40,27 @@ class BoxSelection {
             e.stopPropagation();
         });
 
-        const setButton = new Button({ class: 'select-toolbar-button' });
-        const addButton = new Button({ class: 'select-toolbar-button' });
-        const removeButton = new Button({ class: 'select-toolbar-button' });
-        const intersectButton = new Button({ class: 'select-toolbar-button' });
+        const translateButton = new Button({ class: 'select-toolbar-mode', icon: 'E111' });
+        const rotateButton = new Button({ class: 'select-toolbar-mode', icon: 'E113' });
+        const scaleButton = new Button({ class: 'select-toolbar-mode', icon: 'E112' });
 
-        i18n.bindText(setButton, 'select-toolbar.set');
-        i18n.bindText(addButton, 'select-toolbar.add');
-        i18n.bindText(removeButton, 'select-toolbar.remove');
-        i18n.bindText(intersectButton, 'select-toolbar.intersect');
+        const setButton = new Button({ class: 'select-toolbar-op' });
+        const addButton = new Button({ class: 'select-toolbar-op' });
+        const removeButton = new Button({ class: 'select-toolbar-op' });
+        const intersectButton = new Button({ class: 'select-toolbar-op' });
+
+        setButton.dom.appendChild(createSvg(setSvg));
+        addButton.dom.appendChild(createSvg(addSvg));
+        removeButton.dom.appendChild(createSvg(removeSvg));
+        intersectButton.dom.appendChild(createSvg(intersectSvg));
+
+        // icon-only buttons need localized accessible names
+        i18n.onChange(() => {
+            setButton.dom.setAttribute('aria-label', i18n.t('select-toolbar.set'));
+            addButton.dom.setAttribute('aria-label', i18n.t('select-toolbar.add'));
+            removeButton.dom.setAttribute('aria-label', i18n.t('select-toolbar.remove'));
+            intersectButton.dom.setAttribute('aria-label', i18n.t('select-toolbar.intersect'));
+        }, setButton);
 
         const positionLabel = new Label({ class: 'select-toolbar-label' });
         i18n.bindText(positionLabel, 'select-toolbar.position');
@@ -69,6 +85,22 @@ class BoxSelection {
             min: 0.01
         });
 
+        const rotationLabel = new Label({ class: 'select-toolbar-label', hidden: true });
+        i18n.bindText(rotationLabel, 'select-toolbar.rotation');
+
+        const rotation = new VectorInput({
+            class: 'select-toolbar-vector',
+            precision: 2,
+            dimensions: 3,
+            placeholder: ['X', 'Y', 'Z'],
+            value: [0, 0, 0],
+            hidden: true
+        });
+
+        selectToolbar.append(translateButton);
+        selectToolbar.append(rotateButton);
+        selectToolbar.append(scaleButton);
+        selectToolbar.append(new Element({ class: 'select-toolbar-separator' }));
         selectToolbar.append(setButton);
         selectToolbar.append(addButton);
         selectToolbar.append(removeButton);
@@ -77,28 +109,114 @@ class BoxSelection {
         selectToolbar.append(position);
         selectToolbar.append(sizeLabel);
         selectToolbar.append(size);
+        selectToolbar.append(rotationLabel);
+        selectToolbar.append(rotation);
 
         canvasContainer.append(selectToolbar);
 
-        // write the volume's world position into the ui without retriggering
-        // the position input's change handler
+        // write the volume's transform into the ui without retriggering the
+        // inputs' change handlers
         let uiUpdating = false;
         const updateUI = () => {
             uiUpdating = true;
             const p = box.pivot.getPosition();
             position.value = [p.x, p.y, p.z];
+            size.value = [box.lenX, box.lenY, box.lenZ];
+            const e = box.pivot.getLocalEulerAngles();
+            rotation.value = [e.x, e.y, e.z];
             uiUpdating = false;
         };
 
-        gizmo.on('transform:move', () => {
-            updateUI();
-        });
+        const syncModeUI = (mode: ShapeGizmoMode) => {
+            translateButton.class[mode === 'translate' ? 'add' : 'remove']('active');
+            rotateButton.class[mode === 'rotate' ? 'add' : 'remove']('active');
+            scaleButton.class[mode === 'scale' ? 'add' : 'remove']('active');
 
-        const apply = (op: 'set' | 'add' | 'remove' | 'intersect') => {
-            const p = box.pivot.getPosition();
-            events.fire('select.byBox', op, [p.x, p.y, p.z, box.lenX, box.lenY, box.lenZ]);
+            // show the rotation fields while rotating, the size fields otherwise
+            const rotating = mode === 'rotate';
+            sizeLabel.hidden = rotating;
+            size.hidden = rotating;
+            rotationLabel.hidden = !rotating;
+            rotation.hidden = !rotating;
         };
 
+        // undo/redo support for volume transforms
+        const captureState = () => ({
+            position: box.pivot.getPosition().clone(),
+            rotation: box.pivot.getRotation().clone(),
+            lens: new Vec3(box.lenX, box.lenY, box.lenZ)
+        });
+
+        type BoxState = ReturnType<typeof captureState>;
+
+        const statesEqual = (a: BoxState, b: BoxState) => {
+            return a.position.equals(b.position) && a.rotation.equals(b.rotation) && a.lens.equals(b.lens);
+        };
+
+        const addOp = (oldState: BoxState, newState: BoxState) => {
+            if (!statesEqual(oldState, newState)) {
+                // the change is already applied, so suppress the op's do()
+                events.fire('edit.add', new ShapeTransformOp({ shape: box, oldState, newState }), true);
+            }
+        };
+
+        // record an undo op for the state change performed by fn
+        const recordOp = (fn: () => void) => {
+            const oldState = captureState();
+            fn();
+            addOp(oldState, captureState());
+        };
+
+        let dragState: BoxState | null = null;
+
+        const gizmo = new ShapeTransformGizmo(events, scene, {
+            rotate: true,
+            uniformScale: false,
+            lowerBoundScale: new Vec3(0.01, 0.01, 0.01),
+            onTransformStart: () => {
+                dragState = captureState();
+            },
+            onTransform: (mode) => {
+                if (mode === 'scale') {
+                    const s = box.pivot.getLocalScale();
+                    box.lenX = s.x;
+                    box.lenY = s.y;
+                    box.lenZ = s.z;
+                }
+                box.moved();
+                updateUI();
+            },
+            onTransformEnd: () => {
+                if (dragState) {
+                    addOp(dragState, captureState());
+                    dragState = null;
+                }
+            },
+            onModeChanged: syncModeUI
+        });
+        syncModeUI(gizmo.mode);
+
+        this.setTransformMode = (mode) => {
+            gizmo.toggleMode(mode);
+            return true;
+        };
+
+        const apply = (op: 'set' | 'add' | 'remove' | 'intersect') => {
+            events.fire('select.byBox', op, box.pivot.getWorldTransform().clone());
+        };
+
+        translateButton.dom.addEventListener('pointerdown', (e) => {
+            e.stopPropagation();
+            gizmo.toggleMode('translate');
+        });
+        rotateButton.dom.addEventListener('pointerdown', (e) => {
+            e.stopPropagation();
+            gizmo.toggleMode('rotate');
+        });
+        scaleButton.dom.addEventListener('pointerdown', (e) => {
+            e.stopPropagation();
+            gizmo.toggleMode('scale');
+        });
         setButton.dom.addEventListener('pointerdown', (e) => {
             e.stopPropagation();
             apply('set');
@@ -117,42 +235,73 @@ class BoxSelection {
         });
         position.on('change', (v: number[]) => {
             if (!uiUpdating) {
-                box.pivot.setPosition(v[0], v[1], v[2]);
-                box.moved();
-                gizmo.attach([box.pivot]);
+                recordOp(() => {
+                    box.pivot.setPosition(v[0], v[1], v[2]);
+                    box.moved();
+                });
+                gizmo.attach(box.pivot);
             }
         });
         size.on('change', (v: number[]) => {
-            box.lenX = v[0];
-            box.lenY = v[1];
-            box.lenZ = v[2];
+            if (!uiUpdating) {
+                recordOp(() => {
+                    box.lenX = v[0];
+                    box.lenY = v[1];
+                    box.lenZ = v[2];
+                });
+            }
+        });
+        rotation.on('change', (v: number[]) => {
+            if (!uiUpdating) {
+                recordOp(() => {
+                    box.pivot.setLocalEulerAngles(v[0], v[1], v[2]);
+                    box.moved();
+                });
+                gizmo.attach(box.pivot);
+            }
         });
 
         events.on('camera.focalPointPicked', (details: { splat: Splat, position: Vec3 }) => {
             if (this.active) {
-                box.pivot.setPosition(details.position);
-                box.moved();
-                gizmo.attach([box.pivot]);
+                recordOp(() => {
+                    box.pivot.setPosition(details.position);
+                    box.moved();
+                });
+                gizmo.attach(box.pivot);
                 updateUI();
             }
         });
 
-        const updateGizmoSize = () => {
-            const { camera, canvas } = scene;
-            if (camera.ortho) {
-                gizmo.size = 1125 / canvas.clientHeight;
-            } else {
-                gizmo.size = 1200 / Math.max(canvas.clientWidth, canvas.clientHeight);
+        // refresh the ui when undo/redo changes the volume while the tool is active
+        events.on('shapeSelection.changed', (shape: unknown) => {
+            if (this.active && shape === box) {
+                updateUI();
             }
+        });
+
+        // compose localized tooltip text with the shortcut key
+        const shortcutManager: ShortcutManager = events.invoke('shortcutManager');
+        const tooltip = (localeKey: string, shortcutId: string) => () => {
+            const text = i18n.t(localeKey);
+            const shortcut = shortcutManager.formatShortcut(shortcutId);
+            return shortcut ? i18n.formatTooltipWithShortcut(text, shortcut) : text;
         };
-        updateGizmoSize();
-        events.on('camera.resize', updateGizmoSize);
-        events.on('camera.ortho', updateGizmoSize);
+
+        tooltips.register(translateButton, tooltip('tooltip.bottom-toolbar.translate', 'tool.moveShortcut'), 'top');
+        tooltips.register(rotateButton, tooltip('tooltip.bottom-toolbar.rotate', 'tool.rotateShortcut'), 'top');
+        tooltips.register(scaleButton, tooltip('tooltip.bottom-toolbar.scale', 'tool.scaleShortcut'), 'top');
+        tooltips.register(setButton, () => i18n.t('select-toolbar.set'), 'top');
+        tooltips.register(addButton, () => i18n.t('select-toolbar.add'), 'top');
+        tooltips.register(removeButton, () => i18n.t('select-toolbar.remove'), 'top');
+        tooltips.register(intersectButton, () => i18n.t('select-toolbar.intersect'), 'top');
 
         this.activate = () => {
             this.active = true;
             scene.add(box);
-            gizmo.attach([box.pivot]);
+            if (gizmo.mode === 'none') {
+                gizmo.setMode('translate');
+            }
+            gizmo.attach(box.pivot);
             updateUI();
             selectToolbar.hidden = false;
         };

--- a/src/tools/box-selection.ts
+++ b/src/tools/box-selection.ts
@@ -178,12 +178,14 @@ class BoxSelection {
             },
             onTransform: (mode) => {
                 if (mode === 'scale') {
+                    // the length setters refresh the bound
                     const s = box.pivot.getLocalScale();
                     box.lenX = s.x;
                     box.lenY = s.y;
                     box.lenZ = s.z;
+                } else {
+                    box.moved();
                 }
-                box.moved();
                 updateUI();
             },
             onTransformEnd: () => {

--- a/src/tools/shape-transform-gizmo.ts
+++ b/src/tools/shape-transform-gizmo.ts
@@ -1,0 +1,143 @@
+import { Entity, RotateGizmo, ScaleGizmo, TransformGizmo, TranslateGizmo, Vec3 } from 'playcanvas';
+
+import { Events } from '../events';
+import { Scene } from '../scene';
+
+type ShapeGizmoMode = 'translate' | 'rotate' | 'scale' | 'none';
+
+type ShapeGizmoOptions = {
+    // include a rotate gizmo
+    rotate: boolean;
+    // restrict the scale gizmo to its uniform center handle
+    uniformScale: boolean;
+    // minimum local scale the scale gizmo may apply
+    lowerBoundScale: Vec3;
+    // a gizmo drag started
+    onTransformStart: () => void;
+    // a gizmo changed the pivot's transform
+    onTransform: (mode: ShapeGizmoMode) => void;
+    // a gizmo drag ended
+    onTransformEnd: () => void;
+    // the active mode changed
+    onModeChanged: (mode: ShapeGizmoMode) => void;
+};
+
+// Manages the translate/rotate/scale gizmos for a selection shape (box/sphere).
+// One gizmo is attached at a time based on the current mode; 'none' hides them
+// all while the owning tool stays active.
+class ShapeTransformGizmo {
+    attach: (pivot: Entity) => void;
+    detach: () => void;
+    setMode: (mode: ShapeGizmoMode) => void;
+    toggleMode: (mode: Exclude<ShapeGizmoMode, 'none'>) => void;
+
+    private _mode: ShapeGizmoMode = 'translate';
+
+    get mode() {
+        return this._mode;
+    }
+
+    constructor(events: Events, scene: Scene, options: ShapeGizmoOptions) {
+        const translate = new TranslateGizmo(scene.camera.camera, scene.gizmoLayer);
+
+        const scale = new ScaleGizmo(scene.camera.camera, scene.gizmoLayer);
+        if (options.uniformScale) {
+            // disable everything except uniform scale
+            ['x', 'y', 'z', 'yz', 'xz', 'xy'].forEach((axis) => {
+                scale.enableShape(axis as 'x' | 'y' | 'z' | 'yz' | 'xz' | 'xy', false);
+            });
+        }
+        scale.lowerBoundScale.copy(options.lowerBoundScale);
+
+        const gizmos = new Map<ShapeGizmoMode, TransformGizmo>();
+        gizmos.set('translate', translate);
+        gizmos.set('scale', scale);
+
+        if (options.rotate) {
+            const rotate = new RotateGizmo(scene.camera.camera, scene.gizmoLayer);
+            rotate.rotationMode = 'orbit';
+            gizmos.set('rotate', rotate);
+        }
+
+        const all = Array.from(gizmos.values());
+
+        all.forEach((gizmo) => {
+            gizmo.on('render:update', () => {
+                scene.forceRender = true;
+            });
+
+            gizmo.on('transform:start', () => {
+                options.onTransformStart();
+            });
+
+            gizmo.on('transform:move', () => {
+                options.onTransform(this._mode);
+            });
+
+            gizmo.on('transform:end', () => {
+                options.onTransformEnd();
+            });
+        });
+
+        // translate & rotate follow the editor coordinate space (scale is
+        // always local; the engine ignores the assignment)
+        const setCoordSpace = (space: 'local' | 'world') => {
+            all.forEach((gizmo) => {
+                gizmo.coordSpace = space;
+            });
+        };
+        setCoordSpace(events.invoke('tool.coordSpace'));
+        events.on('tool.coordSpace', setCoordSpace);
+
+        // keep all gizmos a constant size in screen space so switching modes
+        // never shows a stale size
+        const updateGizmoSize = () => {
+            const { camera, canvas } = scene;
+            const size = camera.ortho ?
+                1125 / canvas.clientHeight :
+                1200 / Math.max(canvas.clientWidth, canvas.clientHeight);
+            all.forEach((gizmo) => {
+                gizmo.size = size;
+            });
+        };
+        updateGizmoSize();
+        events.on('camera.resize', updateGizmoSize);
+        events.on('camera.ortho', updateGizmoSize);
+
+        // non-null while the owning tool is active, so the current-mode gizmo
+        // can attach as soon as a mode is picked even while hidden
+        let pivot: Entity | null = null;
+
+        const activeGizmo = () => gizmos.get(this._mode) ?? null;
+
+        this.attach = (p: Entity) => {
+            pivot = p;
+            activeGizmo()?.attach([p]);
+        };
+
+        this.detach = () => {
+            activeGizmo()?.detach();
+            pivot = null;
+        };
+
+        this.setMode = (mode: ShapeGizmoMode) => {
+            // ignore modes this instance doesn't own (e.g. rotate on a sphere)
+            if (mode === this._mode || (mode !== 'none' && !gizmos.has(mode))) {
+                return;
+            }
+            activeGizmo()?.detach();
+            this._mode = mode;
+            if (pivot) {
+                activeGizmo()?.attach([pivot]);
+            }
+            options.onModeChanged(this._mode);
+        };
+
+        // re-selecting the active mode hides the gizmo entirely
+        this.toggleMode = (mode: Exclude<ShapeGizmoMode, 'none'>) => {
+            this.setMode(mode === this._mode ? 'none' : mode);
+        };
+    }
+}
+
+export { ShapeGizmoMode, ShapeTransformGizmo };

--- a/src/tools/sphere-selection.ts
+++ b/src/tools/sphere-selection.ts
@@ -1,30 +1,34 @@
-import { Button, Container, Label, NumericInput, VectorInput } from '@playcanvas/pcui';
-import { TranslateGizmo, Vec3 } from 'playcanvas';
+import { Button, Container, Element, Label, NumericInput, VectorInput } from '@playcanvas/pcui';
+import { Vec3 } from 'playcanvas';
 
+import { ShapeGizmoMode, ShapeTransformGizmo } from './shape-transform-gizmo';
+import { ShapeTransformOp } from '../edit-ops';
 import { Events } from '../events';
 import { Scene } from '../scene';
+import { ShortcutManager } from '../shortcut-manager';
 import { SphereShape } from '../sphere-shape';
 import { Splat } from '../splat';
 import { i18n } from '../ui/localization';
+import addSvg from '../ui/svg/select-add.svg';
+import intersectSvg from '../ui/svg/select-intersect.svg';
+import removeSvg from '../ui/svg/select-remove.svg';
+import setSvg from '../ui/svg/select-set.svg';
+import { Tooltips } from '../ui/tooltips';
+
+const createSvg = (svgString: string) => {
+    const decodedStr = decodeURIComponent(svgString.substring('data:image/svg+xml,'.length));
+    return new DOMParser().parseFromString(decodedStr, 'image/svg+xml').documentElement;
+};
 
 class SphereSelection {
     activate: () => void;
     deactivate: () => void;
+    setTransformMode: (mode: Exclude<ShapeGizmoMode, 'none'>) => boolean;
 
     active = false;
 
-    constructor(events: Events, scene: Scene, canvasContainer: Container) {
+    constructor(events: Events, scene: Scene, canvasContainer: Container, tooltips: Tooltips) {
         const sphere = new SphereShape();
-
-        const gizmo = new TranslateGizmo(scene.camera.camera, scene.gizmoLayer);
-
-        gizmo.on('render:update', () => {
-            scene.forceRender = true;
-        });
-
-        gizmo.on('transform:move', () => {
-            sphere.moved();
-        });
 
         // ui
         const selectToolbar = new Container({
@@ -36,15 +40,26 @@ class SphereSelection {
             e.stopPropagation();
         });
 
-        const setButton = new Button({ class: 'select-toolbar-button' });
-        const addButton = new Button({ class: 'select-toolbar-button' });
-        const removeButton = new Button({ class: 'select-toolbar-button' });
-        const intersectButton = new Button({ class: 'select-toolbar-button' });
+        const translateButton = new Button({ class: 'select-toolbar-mode', icon: 'E111' });
+        const scaleButton = new Button({ class: 'select-toolbar-mode', icon: 'E112' });
 
-        i18n.bindText(setButton, 'select-toolbar.set');
-        i18n.bindText(addButton, 'select-toolbar.add');
-        i18n.bindText(removeButton, 'select-toolbar.remove');
-        i18n.bindText(intersectButton, 'select-toolbar.intersect');
+        const setButton = new Button({ class: 'select-toolbar-op' });
+        const addButton = new Button({ class: 'select-toolbar-op' });
+        const removeButton = new Button({ class: 'select-toolbar-op' });
+        const intersectButton = new Button({ class: 'select-toolbar-op' });
+
+        setButton.dom.appendChild(createSvg(setSvg));
+        addButton.dom.appendChild(createSvg(addSvg));
+        removeButton.dom.appendChild(createSvg(removeSvg));
+        intersectButton.dom.appendChild(createSvg(intersectSvg));
+
+        // icon-only buttons need localized accessible names
+        i18n.onChange(() => {
+            setButton.dom.setAttribute('aria-label', i18n.t('select-toolbar.set'));
+            addButton.dom.setAttribute('aria-label', i18n.t('select-toolbar.add'));
+            removeButton.dom.setAttribute('aria-label', i18n.t('select-toolbar.remove'));
+            intersectButton.dom.setAttribute('aria-label', i18n.t('select-toolbar.intersect'));
+        }, setButton);
 
         const positionLabel = new Label({ class: 'select-toolbar-label' });
         i18n.bindText(positionLabel, 'select-toolbar.position');
@@ -66,6 +81,9 @@ class SphereSelection {
             min: 0.01
         });
 
+        selectToolbar.append(translateButton);
+        selectToolbar.append(scaleButton);
+        selectToolbar.append(new Element({ class: 'select-toolbar-separator' }));
         selectToolbar.append(setButton);
         selectToolbar.append(addButton);
         selectToolbar.append(removeButton);
@@ -77,25 +95,92 @@ class SphereSelection {
 
         canvasContainer.append(selectToolbar);
 
-        // write the volume's world position into the ui without retriggering
-        // the position input's change handler
+        // write the volume's transform into the ui without retriggering the
+        // inputs' change handlers
         let uiUpdating = false;
         const updateUI = () => {
             uiUpdating = true;
             const p = sphere.pivot.getPosition();
             position.value = [p.x, p.y, p.z];
+            radius.value = sphere.radius;
             uiUpdating = false;
         };
 
-        gizmo.on('transform:move', () => {
-            updateUI();
-        });
-
-        const apply = (op: 'set' | 'add' | 'remove' | 'intersect') => {
-            const p = sphere.pivot.getPosition();
-            events.fire('select.bySphere', op, [p.x, p.y, p.z, sphere.radius]);
+        const syncModeUI = (mode: ShapeGizmoMode) => {
+            translateButton.class[mode === 'translate' ? 'add' : 'remove']('active');
+            scaleButton.class[mode === 'scale' ? 'add' : 'remove']('active');
         };
 
+        // undo/redo support for volume transforms
+        const captureState = () => ({
+            position: sphere.pivot.getPosition().clone(),
+            radius: sphere.radius
+        });
+
+        type SphereState = ReturnType<typeof captureState>;
+
+        const statesEqual = (a: SphereState, b: SphereState) => {
+            return a.position.equals(b.position) && a.radius === b.radius;
+        };
+
+        const addOp = (oldState: SphereState, newState: SphereState) => {
+            if (!statesEqual(oldState, newState)) {
+                // the change is already applied, so suppress the op's do()
+                events.fire('edit.add', new ShapeTransformOp({ shape: sphere, oldState, newState }), true);
+            }
+        };
+
+        // record an undo op for the state change performed by fn
+        const recordOp = (fn: () => void) => {
+            const oldState = captureState();
+            fn();
+            addOp(oldState, captureState());
+        };
+
+        let dragState: SphereState | null = null;
+
+        const gizmo = new ShapeTransformGizmo(events, scene, {
+            rotate: false,
+            uniformScale: true,
+            lowerBoundScale: new Vec3(0.02, 0.02, 0.02),
+            onTransformStart: () => {
+                dragState = captureState();
+            },
+            onTransform: (mode) => {
+                if (mode === 'scale') {
+                    // the pivot's uniform scale is the sphere's diameter
+                    sphere.radius = sphere.pivot.getLocalScale().x * 0.5;
+                }
+                sphere.moved();
+                updateUI();
+            },
+            onTransformEnd: () => {
+                if (dragState) {
+                    addOp(dragState, captureState());
+                    dragState = null;
+                }
+            },
+            onModeChanged: syncModeUI
+        });
+        syncModeUI(gizmo.mode);
+
+        this.setTransformMode = (mode) => {
+            gizmo.toggleMode(mode);
+            return true;
+        };
+
+        const apply = (op: 'set' | 'add' | 'remove' | 'intersect') => {
+            events.fire('select.bySphere', op, sphere.pivot.getWorldTransform().clone());
+        };
+
+        translateButton.dom.addEventListener('pointerdown', (e) => {
+            e.stopPropagation();
+            gizmo.toggleMode('translate');
+        });
+        scaleButton.dom.addEventListener('pointerdown', (e) => {
+            e.stopPropagation();
+            gizmo.toggleMode('scale');
+        });
         setButton.dom.addEventListener('pointerdown', (e) => {
             e.stopPropagation(); apply('set');
         });
@@ -110,40 +195,61 @@ class SphereSelection {
         });
         position.on('change', (v: number[]) => {
             if (!uiUpdating) {
-                sphere.pivot.setPosition(v[0], v[1], v[2]);
-                sphere.moved();
-                gizmo.attach([sphere.pivot]);
+                recordOp(() => {
+                    sphere.pivot.setPosition(v[0], v[1], v[2]);
+                    sphere.moved();
+                });
+                gizmo.attach(sphere.pivot);
             }
         });
         radius.on('change', () => {
-            sphere.radius = radius.value;
+            if (!uiUpdating) {
+                recordOp(() => {
+                    sphere.radius = radius.value;
+                });
+            }
         });
 
         events.on('camera.focalPointPicked', (details: { splat: Splat, position: Vec3 }) => {
             if (this.active) {
-                sphere.pivot.setPosition(details.position);
-                sphere.moved();
-                gizmo.attach([sphere.pivot]);
+                recordOp(() => {
+                    sphere.pivot.setPosition(details.position);
+                    sphere.moved();
+                });
+                gizmo.attach(sphere.pivot);
                 updateUI();
             }
         });
 
-        const updateGizmoSize = () => {
-            const { camera, canvas } = scene;
-            if (camera.ortho) {
-                gizmo.size = 1125 / canvas.clientHeight;
-            } else {
-                gizmo.size = 1200 / Math.max(canvas.clientWidth, canvas.clientHeight);
+        // refresh the ui when undo/redo changes the volume while the tool is active
+        events.on('shapeSelection.changed', (shape: unknown) => {
+            if (this.active && shape === sphere) {
+                updateUI();
             }
+        });
+
+        // compose localized tooltip text with the shortcut key
+        const shortcutManager: ShortcutManager = events.invoke('shortcutManager');
+        const tooltip = (localeKey: string, shortcutId: string) => () => {
+            const text = i18n.t(localeKey);
+            const shortcut = shortcutManager.formatShortcut(shortcutId);
+            return shortcut ? i18n.formatTooltipWithShortcut(text, shortcut) : text;
         };
-        updateGizmoSize();
-        events.on('camera.resize', updateGizmoSize);
-        events.on('camera.ortho', updateGizmoSize);
+
+        tooltips.register(translateButton, tooltip('tooltip.bottom-toolbar.translate', 'tool.moveShortcut'), 'top');
+        tooltips.register(scaleButton, tooltip('tooltip.bottom-toolbar.scale', 'tool.scaleShortcut'), 'top');
+        tooltips.register(setButton, () => i18n.t('select-toolbar.set'), 'top');
+        tooltips.register(addButton, () => i18n.t('select-toolbar.add'), 'top');
+        tooltips.register(removeButton, () => i18n.t('select-toolbar.remove'), 'top');
+        tooltips.register(intersectButton, () => i18n.t('select-toolbar.intersect'), 'top');
 
         this.activate = () => {
             this.active = true;
             scene.add(sphere);
-            gizmo.attach([sphere.pivot]);
+            if (gizmo.mode === 'none') {
+                gizmo.setMode('translate');
+            }
+            gizmo.attach(sphere.pivot);
             updateUI();
             selectToolbar.hidden = false;
         };

--- a/src/tools/sphere-selection.ts
+++ b/src/tools/sphere-selection.ts
@@ -148,10 +148,12 @@ class SphereSelection {
             },
             onTransform: (mode) => {
                 if (mode === 'scale') {
-                    // the pivot's uniform scale is the sphere's diameter
+                    // the pivot's uniform scale is the sphere's diameter;
+                    // the radius setter refreshes the bound
                     sphere.radius = sphere.pivot.getLocalScale().x * 0.5;
+                } else {
+                    sphere.moved();
                 }
-                sphere.moved();
                 updateUI();
             },
             onTransformEnd: () => {

--- a/src/tools/sphere-selection.ts
+++ b/src/tools/sphere-selection.ts
@@ -261,6 +261,11 @@ class SphereSelection {
             gizmo.detach();
             scene.remove(sphere);
             this.active = false;
+
+            // the volume is transient tool state: drop its ops from history so
+            // undo/redo never hits steps that visibly change nothing while the
+            // tool is hidden
+            events.fire('edit.removeForShape', sphere);
         };
     }
 }

--- a/src/tools/tool-manager.ts
+++ b/src/tools/tool-manager.ts
@@ -3,6 +3,10 @@ import { Events } from '../events';
 interface Tool {
     activate: () => void;
     deactivate: () => void;
+    // optional: handle a transform-mode request (1/2/3 shortcuts) while this
+    // tool is active. return true if consumed, otherwise the corresponding
+    // transform tool is activated instead.
+    setTransformMode?: (mode: 'translate' | 'rotate' | 'scale') => boolean;
 }
 
 class ToolManager {
@@ -41,6 +45,20 @@ class ToolManager {
         events.on('tool.toggleCoordSpace', () => {
             setCoordSpace(coordSpace === 'local' ? 'world' : 'local');
         });
+
+        // the 1/2/3 shortcuts switch the active tool's gizmo mode if it
+        // supports one (box/sphere selection), otherwise activate the
+        // corresponding transform tool
+        const transformShortcut = (mode: 'translate' | 'rotate' | 'scale', toolName: string) => {
+            const tool = this.active ? this.tools.get(this.active) : null;
+            if (!tool?.setTransformMode?.(mode)) {
+                this.activate(toolName);
+            }
+        };
+
+        events.on('tool.moveShortcut', () => transformShortcut('translate', 'move'));
+        events.on('tool.rotateShortcut', () => transformShortcut('rotate', 'rotate'));
+        events.on('tool.scaleShortcut', () => transformShortcut('scale', 'scale'));
     }
 
     register(name: string, tool: Tool) {

--- a/src/ui/bottom-toolbar.ts
+++ b/src/ui/bottom-toolbar.ts
@@ -231,9 +231,9 @@ class BottomToolbar extends Container {
         tooltips.register(flood, tooltip('tooltip.bottom-toolbar.flood', 'tool.floodSelection'));
         tooltips.register(sphere, tooltip('tooltip.bottom-toolbar.sphere'));
         tooltips.register(box, tooltip('tooltip.bottom-toolbar.box'));
-        tooltips.register(translate, tooltip('tooltip.bottom-toolbar.translate', 'tool.move'));
-        tooltips.register(rotate, tooltip('tooltip.bottom-toolbar.rotate', 'tool.rotate'));
-        tooltips.register(scale, tooltip('tooltip.bottom-toolbar.scale', 'tool.scale'));
+        tooltips.register(translate, tooltip('tooltip.bottom-toolbar.translate', 'tool.moveShortcut'));
+        tooltips.register(rotate, tooltip('tooltip.bottom-toolbar.rotate', 'tool.rotateShortcut'));
+        tooltips.register(scale, tooltip('tooltip.bottom-toolbar.scale', 'tool.scaleShortcut'));
         tooltips.register(measure, tooltip('tooltip.bottom-toolbar.measure'));
         tooltips.register(coordSpace, tooltip('tooltip.bottom-toolbar.local-space', 'tool.toggleCoordSpace'));
         tooltips.register(origin, tooltip('tooltip.bottom-toolbar.bound-center'));

--- a/src/ui/editor.ts
+++ b/src/ui/editor.ts
@@ -38,6 +38,7 @@ class EditorUI {
     toolsContainer: Container;
     canvas: HTMLCanvasElement;
     popup: Popup;
+    tooltips: Tooltips;
 
     constructor(events: Events) {
         // favicon
@@ -182,6 +183,7 @@ class EditorUI {
         this.toolsContainer = toolsContainer;
         this.canvas = canvas;
         this.popup = popup;
+        this.tooltips = tooltips;
 
         document.body.appendChild(appContainer.dom);
         document.body.setAttribute('tabIndex', '-1');

--- a/src/ui/scss/select-toolbar.scss
+++ b/src/ui/scss/select-toolbar.scss
@@ -17,12 +17,43 @@
     flex-direction: row;
     align-items: center;
 
-    // buttons form a tight cluster like the bottom toolbar's controls
-    .select-toolbar-button {
+    // icon apply buttons (set/add/remove/intersect)
+    .select-toolbar-op {
+        width: 38px;
         height: 38px;
         margin: 0px 1px;
-        padding: 0px 12px;
+        padding: 0px;
         border-radius: 2px;
+
+        svg {
+            color: $clr-default;
+        }
+    }
+
+    // gizmo mode buttons mirror the bottom toolbar's tool buttons
+    .select-toolbar-mode {
+        width: 38px;
+        height: 38px;
+        margin: 0px 1px;
+        padding: 0px;
+        border-radius: 2px;
+
+        &::before {
+            font-size: 16px !important;
+            line-height: 100%;
+        }
+
+        &.active {
+            color: $clr-active;
+            background-color: $clr-hilight !important;
+        }
+    }
+
+    .select-toolbar-separator {
+        width: 2px;
+        height: 38px;
+        margin: 0px 10px;
+        background-color: $bcg-dark;
     }
 
     // 16px group break from the preceding cluster, 6px to the input it labels

--- a/src/ui/shortcuts-popup.ts
+++ b/src/ui/shortcuts-popup.ts
@@ -69,9 +69,9 @@ const popupConfig: Record<string, CategoryConfig> = {
     tools: {
         localeKey: 'popup.shortcuts.tools',
         shortcuts: [
-            { id: 'tool.move', localeKey: 'popup.shortcuts.move' },
-            { id: 'tool.rotate', localeKey: 'popup.shortcuts.rotate' },
-            { id: 'tool.scale', localeKey: 'popup.shortcuts.scale' },
+            { id: 'tool.moveShortcut', localeKey: 'popup.shortcuts.move' },
+            { id: 'tool.rotateShortcut', localeKey: 'popup.shortcuts.rotate' },
+            { id: 'tool.scaleShortcut', localeKey: 'popup.shortcuts.scale' },
             { id: 'tool.rectSelection', localeKey: 'popup.shortcuts.rect-selection' },
             { id: 'tool.lassoSelection', localeKey: 'popup.shortcuts.lasso-selection' },
             { id: 'tool.polygonSelection', localeKey: 'popup.shortcuts.polygon-selection' },

--- a/src/ui/svg/select-add.svg
+++ b/src/ui/svg/select-add.svg
@@ -1,0 +1,3 @@
+<svg width="38" height="38" viewBox="0 0 38 38" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M11 11H22V16H27V27H16V22H11V11Z" fill="currentColor"/>
+</svg>

--- a/src/ui/svg/select-intersect.svg
+++ b/src/ui/svg/select-intersect.svg
@@ -1,0 +1,5 @@
+<svg width="38" height="38" viewBox="0 0 38 38" fill="none" xmlns="http://www.w3.org/2000/svg">
+<rect x="11.75" y="11.75" width="9.5" height="9.5" stroke="currentColor" stroke-width="1.5" fill="none"/>
+<rect x="16.75" y="16.75" width="9.5" height="9.5" stroke="currentColor" stroke-width="1.5" fill="none"/>
+<path d="M16 16H22V22H16V16Z" fill="currentColor"/>
+</svg>

--- a/src/ui/svg/select-remove.svg
+++ b/src/ui/svg/select-remove.svg
@@ -1,0 +1,4 @@
+<svg width="38" height="38" viewBox="0 0 38 38" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M11 11H22V16H16V22H11V11Z" fill="currentColor"/>
+<rect x="16.75" y="16.75" width="9.5" height="9.5" stroke="currentColor" stroke-width="1.5" fill="none"/>
+</svg>

--- a/src/ui/svg/select-set.svg
+++ b/src/ui/svg/select-set.svg
@@ -1,0 +1,3 @@
+<svg width="38" height="38" viewBox="0 0 38 38" fill="none" xmlns="http://www.w3.org/2000/svg">
+<rect x="12" y="12" width="14" height="14" rx="1" fill="currentColor"/>
+</svg>

--- a/static/locales/de.json
+++ b/static/locales/de.json
@@ -132,6 +132,7 @@
     "select-toolbar.intersect": "Schneiden",
     "select-toolbar.position": "Position",
     "select-toolbar.size": "Größe",
+    "select-toolbar.rotation": "Rotation",
     "select-toolbar.radius": "Radius",
     "popup.ok": "OK",
     "popup.cancel": "Abbrechen",

--- a/static/locales/en.json
+++ b/static/locales/en.json
@@ -132,6 +132,7 @@
     "select-toolbar.intersect": "Intersect",
     "select-toolbar.position": "Position",
     "select-toolbar.size": "Size",
+    "select-toolbar.rotation": "Rotation",
     "select-toolbar.radius": "Radius",
     "popup.ok": "OK",
     "popup.cancel": "Cancel",

--- a/static/locales/es.json
+++ b/static/locales/es.json
@@ -132,6 +132,7 @@
     "select-toolbar.intersect": "Intersecar",
     "select-toolbar.position": "Posición",
     "select-toolbar.size": "Tamaño",
+    "select-toolbar.rotation": "Rotación",
     "select-toolbar.radius": "Radio",
     "popup.ok": "Aceptar",
     "popup.cancel": "Cancelar",

--- a/static/locales/fr.json
+++ b/static/locales/fr.json
@@ -132,6 +132,7 @@
     "select-toolbar.intersect": "Intersecter",
     "select-toolbar.position": "Position",
     "select-toolbar.size": "Taille",
+    "select-toolbar.rotation": "Rotation",
     "select-toolbar.radius": "Rayon",
     "popup.ok": "OK",
     "popup.cancel": "Annuler",

--- a/static/locales/ja.json
+++ b/static/locales/ja.json
@@ -132,6 +132,7 @@
     "select-toolbar.intersect": "交差",
     "select-toolbar.position": "位置",
     "select-toolbar.size": "サイズ",
+    "select-toolbar.rotation": "回転",
     "select-toolbar.radius": "半径",
     "popup.ok": "OK",
     "popup.cancel": "キャンセル",

--- a/static/locales/ko.json
+++ b/static/locales/ko.json
@@ -132,6 +132,7 @@
     "select-toolbar.intersect": "교차",
     "select-toolbar.position": "위치",
     "select-toolbar.size": "크기",
+    "select-toolbar.rotation": "회전",
     "select-toolbar.radius": "반경",
     "popup.ok": "확인",
     "popup.cancel": "취소",

--- a/static/locales/pt-BR.json
+++ b/static/locales/pt-BR.json
@@ -132,6 +132,7 @@
     "select-toolbar.intersect": "Interseccionar",
     "select-toolbar.position": "Posição",
     "select-toolbar.size": "Tamanho",
+    "select-toolbar.rotation": "Rotação",
     "select-toolbar.radius": "Raio",
     "popup.ok": "OK",
     "popup.cancel": "Cancelar",

--- a/static/locales/ru.json
+++ b/static/locales/ru.json
@@ -132,6 +132,7 @@
     "select-toolbar.intersect": "Пересечь",
     "select-toolbar.position": "Позиция",
     "select-toolbar.size": "Размер",
+    "select-toolbar.rotation": "Вращение",
     "select-toolbar.radius": "Радиус",
     "popup.ok": "ОК",
     "popup.cancel": "Отмена",

--- a/static/locales/zh-CN.json
+++ b/static/locales/zh-CN.json
@@ -132,6 +132,7 @@
     "select-toolbar.intersect": "相交",
     "select-toolbar.position": "位置",
     "select-toolbar.size": "大小",
+    "select-toolbar.rotation": "旋转",
     "select-toolbar.radius": "半径",
     "popup.ok": "确定",
     "popup.cancel": "取消",


### PR DESCRIPTION
## What

Makes the box/sphere selection volumes fully transformable, addressing requests to rotate the selection box. The hardcoded translate gizmo is replaced by switchable modes, rotation works end to end through both the volume rendering and the GPU selection test, volume edits are undoable, and the floating toolbar's apply buttons move from text to icons.

Box Select:

<img width="1471" height="1299" alt="image" src="https://github.com/user-attachments/assets/b259ab48-c8db-4f35-9f6a-8c879ba61a1f" />

Sphere Select:

<img width="1372" height="1141" alt="image" src="https://github.com/user-attachments/assets/937c874d-548b-484a-a385-91d185447652" />

## UX

- **Box**: translate / rotate / scale gizmo modes. **Sphere**: translate / scale, where scale is the uniform center handle driving radius (same recipe as the splat scale tool).
- Mode switcher icons sit at the left of the floating select toolbar. Re-selecting the active mode **hides the gizmo entirely** (mirrors the "re-activate to deactivate" tool idiom), addressing the long-standing "gizmo can't be disabled" complaint.
- While a volume tool is active, the **1/2/3 keys switch the volume's gizmo mode** instead of switching tools (rotate is a no-op for the sphere); the bottom-toolbar Move/Rotate/Scale buttons keep switching tools. Everywhere else 1/2/3 behave exactly as before. Per-tool mode is remembered across activations.
- A **Rotation** input (world euler degrees) swaps in for Size while in rotate mode; `0,0,0` resets orientation. All inputs remain bidirectional with the gizmos. Volume translate/rotate gizmos honor the local/world coordinate space toggle (Shift+C).
- **Set/Add/Remove/Intersect become boolean-op icons** (filled area = resulting selection, following the Photoshop/Figma convention) with localized tooltips and aria-labels. The toolbar is ~150px narrower and its width no longer depends on the locale.
- **Volume edits are undoable**: one op per gizmo drag, per numeric commit, and per double-click placement, via a new `ShapeTransformOp` (follows the `PlacePivotOp` pattern). Undoing while the tool is inactive restores state silently, visible on next activation.

## Implementation notes

- New `ShapeTransformGizmo` controller owns the per-tool gizmo set (persistent instances, attach/detach on switch, shared screen-size and coord-space wiring).
- The box volume shader now ray-marches in the pivot's unit-cube local space via an inverse-matrix uniform, so the strip pattern rotates with the box. The GPU intersect test for **both** shapes is unified on a single `shape_matrix_inv` uniform (`abs(local) <= 0.5` for the box, `length(local) < 0.5` for the sphere) — numerically identical to the old world-space tests for unrotated volumes, and it makes a future ellipsoid select shader-ready.
- `select.byBox` / `select.bySphere` payloads change from flat arrays to a cloned `Mat4` world transform (snapshot safety for the async GPU queue). Single emitter/consumer each.
- The 1/2/3 shortcuts are rebound to dispatcher events handled by `ToolManager` through an optional `Tool.setTransformMode` hook, so no tool names are hardcoded and all other tools fall through to the existing behavior.
- Fixes in passing: the size input handler was missing the `uiUpdating` guard (would have quantized scale drags through the precision-2 display), and `BoxShape.updateBound` now produces an exact OBB-enclosing AABB (it was 2x oversized) with the pivot scale synced immediately rather than at next prerender.
- One new locale key (`select-toolbar.rotation`) across all 9 languages; the icon buttons reuse the existing Set/Add/Remove/Intersect strings as tooltips.

## Testing

Verified against a synthetic 11×11×11 splat grid with known positions, driving the real UI:

- Oriented selection is exact: a thin box yawed 45° along the diagonal selects exactly the 5 predicted splats (the old axis-aligned test would select 9); a 45°-yaw box selects 125/125; an asymmetric 30° box 36/36; the sphere's matrix path 36/36 and 81/81.
- Real gizmo drags: rotate ring updates the Rotation input live; sphere center-handle drag drives radius; box axis-handle drag drives Size and clamps at the 0.01 floor. One undo op per drag, restore verified for drags, typed values, and placement, including undo while the tool is inactive.
- Regressions: 1/2/3 still switch tools when no volume tool is active, bottom-toolbar buttons always switch tools and never falsely highlight, Escape deactivates, selection undo/redo interleaves correctly with volume ops, ortho/resize gizmo sizing correct.
- `npm run lint`, `npm run lint:locales`, and production build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)