### PR TITLE
Fix streamed SOG folder drag and drop

### DIFF
--- a/src/drop-handler.ts
+++ b/src/drop-handler.ts
@@ -19,6 +19,10 @@ const resolveDirectories = (entries: Array<FileSystemEntry>): Promise<Array<File
     const result: Array<FileSystemFileEntry> = [];
 
     entries.forEach((entry) => {
+        if (entry.name === '.DS_Store') {
+            return;
+        }
+
         if (entry.isFile) {
             result.push(entry as FileSystemFileEntry);
         } else if (entry.isDirectory) {

--- a/src/file-handler.ts
+++ b/src/file-handler.ts
@@ -136,7 +136,7 @@ const isPlySequence = (filenames: string[]) => {
 // SOG has a meta.json file; streamed SOG has a lod-meta.json file.
 const isSog = (filenames: string[]) => {
     const count = (extension: string) => filenames.reduce((sum, f) => sum + (f.endsWith(extension) ? 1 : 0), 0);
-    return count('meta.json') === 1;
+    return count('lod-meta.json') === 1 || count('meta.json') === 1;
 };
 
 // The LCC file contains meta.lcc, index.bin, data.bin and shcoef.bin (optional).


### PR DESCRIPTION
Recognize streamed SOG folders containing multiple nested meta.json files and ignore macOS .DS_Store entries during recursive drag-and-drop imports.