### PR TITLE
Fix Box Select scaling on all axes

### DIFF
--- a/src/tools/box-selection.ts
+++ b/src/tools/box-selection.ts
@@ -178,11 +178,11 @@ class BoxSelection {
             },
             onTransform: (mode) => {
                 if (mode === 'scale') {
-                    // the length setters refresh the bound
-                    const s = box.pivot.getLocalScale();
-                    box.lenX = s.x;
-                    box.lenY = s.y;
-                    box.lenZ = s.z;
+                    // snapshot the live scale vector before the length setters mutate it
+                    const { x, y, z } = box.pivot.getLocalScale();
+                    box.lenX = x;
+                    box.lenY = y;
+                    box.lenZ = z;
                 } else {
                     box.moved();
                 }


### PR DESCRIPTION
## Summary
- snapshot the Box Select pivot scale before updating its dimensions
- restore Y/Z axis scaling and uniform center-handle scaling

## Validation
- npm run lint -- --quiet
- npm run build
- git diff --check