### PR TITLE
Fix Unlock All across splat layers

### DIFF
--- a/src/editor.ts
+++ b/src/editor.ts
@@ -604,9 +604,13 @@ const registerEditorEvents = (events: Events, editHistory: EditHistory, scene: S
     });
 
     events.on('select.unhide', () => {
-        selectedSplats().forEach((splat) => {
-            events.fire('edit.add', new UnhideAllOp(splat));
-        });
+        const ops = (scene.getElementsByType(ElementType.splat) as Splat[])
+        .map(splat => new UnhideAllOp(splat))
+        .filter(op => !op.ranges.empty);
+
+        if (ops.length > 0) {
+            events.fire('edit.add', ops.length === 1 ? ops[0] : new MultiOp(ops));
+        }
     });
 
     events.on('select.delete', () => {


### PR DESCRIPTION
## Summary

- unlock locked Gaussians across every splat layer
- group multi-layer unlocks into one undoable history operation
- avoid empty history entries when no locks exist

Fixes #600

## Validation

- npm.cmd run lint
- npm.cmd run build
- git diff --check