### PR TITLE
Ignore Claude workspace files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,4 @@ dist
 .vscode
 .cursor
 .idea
-.claude/
+.claude

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ dist
 .vscode
 .cursor
 .idea
+.claude/

--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,8 @@
-node_modules
-dist
+.claude
+.cursor
 .DS_Store
+.idea
 .npmrc
 .vscode
-.cursor
-.idea
-.claude
+dist
+node_modules


### PR DESCRIPTION
## Summary

- ignore the local .claude directory
- prevent generated Claude settings and worktrees from appearing as untracked files

## Validation

- git check-ignore confirms Claude settings and worktrees are ignored
- git diff --check