### PR TITLE
Update Orient tool with persistent local frames and dimensions

### DIFF
--- a/src/doc.ts
+++ b/src/doc.ts
@@ -136,8 +136,7 @@ const registerDocEvents = (scene: Scene, events: Events) => {
             if (currentSelection) {
                 const pivot = events.invoke('pivot');
                 const transform = new Transform();
-                const pivotOrigin = events.invoke('pivot.origin');
-                currentSelection.getPivot(pivotOrigin, false, transform);
+                currentSelection.getPivot(transform);
                 pivot.place(transform);
             }
         } catch (error) {

--- a/src/edit-ops.ts
+++ b/src/edit-ops.ts
@@ -306,6 +306,41 @@ class PlacePivotOp {
     }
 }
 
+// op for setting a splat's user-defined local frame (the origin and rotation
+// the transform gizmos and panel use in local coordinate space)
+class SetLocalFrameOp {
+    name = 'setLocalFrame';
+    splat: Splat;
+    oldOrigin: Vec3;
+    oldFrame: Quat;
+    newOrigin: Vec3;
+    newFrame: Quat;
+
+    constructor(options: { splat: Splat, oldOrigin: Vec3, oldFrame: Quat, newOrigin: Vec3, newFrame: Quat }) {
+        this.splat = options.splat;
+        this.oldOrigin = options.oldOrigin;
+        this.oldFrame = options.oldFrame;
+        this.newOrigin = options.newOrigin;
+        this.newFrame = options.newFrame;
+    }
+
+    do() {
+        this.splat.setLocalFrame(this.newOrigin, this.newFrame);
+    }
+
+    undo() {
+        this.splat.setLocalFrame(this.oldOrigin, this.oldFrame);
+    }
+
+    destroy() {
+        this.splat = null;
+        this.oldOrigin = null;
+        this.oldFrame = null;
+        this.newOrigin = null;
+        this.newFrame = null;
+    }
+}
+
 type ShapeTransformState = {
     position: Vec3;
     rotation?: Quat;
@@ -511,6 +546,7 @@ export {
     EntityTransformOp,
     SplatsTransformOp,
     PlacePivotOp,
+    SetLocalFrameOp,
     ShapeTransformOp,
     ShapeTransformState,
     ColorAdjustment,

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -1,8 +1,8 @@
 import { MemoryFileSystem } from '@playcanvas/splat-transform';
-import { Color, Mat4, path, Texture, Vec3, Vec4 } from 'playcanvas';
+import { Color, Mat4, path, Quat, Texture, Vec3, Vec4 } from 'playcanvas';
 
 import { EditHistory } from './edit-history';
-import { SelectAllOp, SelectNoneOp, SelectInvertOp, SelectOp, HideSelectionOp, UnhideAllOp, DeleteSelectionOp, ResetOp, MultiOp, AddSplatOp } from './edit-ops';
+import { SelectAllOp, SelectNoneOp, SelectInvertOp, SelectOp, HideSelectionOp, UnhideAllOp, DeleteSelectionOp, ResetOp, MultiOp, AddSplatOp, SetLocalFrameOp } from './edit-ops';
 import { Element, ElementType } from './element';
 import { Events } from './events';
 import type { GridPlane } from './infinite-grid';
@@ -310,6 +310,34 @@ const registerEditorEvents = (events: Events, editHistory: EditHistory, scene: S
                 speed: 1
             });
         }
+    });
+
+    // pivot.reset
+
+    // reset the selection's local frame back to the model's own frame, or,
+    // with toCenter, to the bound center (the selection bound while gaussians
+    // are selected). resets orientation in both cases
+    events.on('pivot.reset', (toCenter: boolean) => {
+        const splat = selectedSplats()[0];
+        if (!splat) {
+            return;
+        }
+
+        const bound = splat.numSelected > 0 ? splat.selectionBound : splat.localBound;
+        const newOrigin = toCenter ? bound.center.clone() : new Vec3();
+        const newFrame = new Quat();
+
+        if (splat.localFrameOrigin.equals(newOrigin) && splat.localFrame.equals(newFrame)) {
+            return;
+        }
+
+        events.fire('edit.add', new SetLocalFrameOp({
+            splat,
+            oldOrigin: splat.localFrameOrigin.clone(),
+            oldFrame: splat.localFrame.clone(),
+            newOrigin,
+            newFrame
+        }));
     });
 
     events.on('camera.reset', () => {

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -281,6 +281,17 @@ const registerEditorEvents = (events: Events, editHistory: EditHistory, scene: S
     // camera.focus
 
     events.on('camera.focus', () => {
+        // the active tool's focus target (e.g. orient points) takes precedence
+        const toolFocus: { position: Vec3, radius: number } | null = events.invoke('tool.focus');
+        if (toolFocus) {
+            scene.camera.focus({
+                focalPoint: toolFocus.position,
+                radius: toolFocus.radius,
+                speed: 1
+            });
+            return;
+        }
+
         const splat = selectedSplats()[0];
         if (splat) {
             // use current bounds (caller should have awaited the operation that changed data)

--- a/src/entity-transform-handler.ts
+++ b/src/entity-transform-handler.ts
@@ -39,8 +39,8 @@ class EntityTransformHandler implements TransformHandler {
             }
         });
 
-        events.on('pivot.origin', (mode: 'center' | 'boundCenter') => {
-            if (this.splat) {
+        events.on('splat.localFrame', (splat: Splat) => {
+            if (this.splat === splat) {
                 this.placePivot();
             }
         });
@@ -57,8 +57,7 @@ class EntityTransformHandler implements TransformHandler {
 
     placePivot() {
         // place initial pivot point
-        const origin = this.events.invoke('pivot.origin');
-        this.splat.getPivot(origin === 'center' ? 'center' : 'boundCenter', false, transform);
+        this.splat.getPivot(transform);
         this.events.invoke('pivot').place(transform);
     }
 

--- a/src/pivot.ts
+++ b/src/pivot.ts
@@ -51,35 +51,11 @@ class Pivot {
     }
 }
 
-type PivotOrigin = 'center' | 'boundCenter';
-
 const registerPivotEvents = (events: Events) => {
     const pivot = new Pivot(events);
 
     events.function('pivot', () => {
         return pivot;
-    });
-
-    // pivot mode
-    let origin: PivotOrigin = 'center';
-
-    const setOrigin = (o: PivotOrigin) => {
-        if (o !== origin) {
-            origin = o;
-            events.fire('pivot.origin', origin);
-        }
-    };
-
-    events.function('pivot.origin', () => {
-        return origin;
-    });
-
-    events.on('pivot.setOrigin', (o: PivotOrigin) => {
-        setOrigin(o === 'center' ? 'center' : 'boundCenter');
-    });
-
-    events.on('pivot.toggleOrigin', () => {
-        setOrigin(origin === 'center' ? 'boundCenter' : 'center');
     });
 };
 

--- a/src/shaders/tool-overlay-shader.ts
+++ b/src/shaders/tool-overlay-shader.ts
@@ -43,13 +43,9 @@ const lineVertexShader = /* glsl */ `
 
     uniform mat4 matrix_model;
     uniform mat4 matrix_viewProjection;
-    uniform float depthBias;
 
     void main() {
         gl_Position = matrix_viewProjection * matrix_model * vec4(vertex_position, 1.0);
-
-        // depth stratum in ndc (see the strata table in tool-overlay.ts)
-        gl_Position.z += depthBias * gl_Position.w;
     }
 `;
 
@@ -67,20 +63,15 @@ const fillVertexShader = /* glsl */ `
     uniform mat4 matrix_model;
     uniform mat4 matrix_viewProjection;
 
-    varying vec4 clipPos;
-
     void main() {
-        clipPos = matrix_viewProjection * matrix_model * vec4(vertex_position, 1.0);
-        gl_Position = clipPos;
+        gl_Position = matrix_viewProjection * matrix_model * vec4(vertex_position, 1.0);
     }
 `;
 
 const fillFragmentShader = /* glsl */ `
     uniform sampler2D blueNoiseTex32;
     uniform vec4 fillColor;
-    uniform float depthBias;
-
-    varying vec4 clipPos;
+    uniform vec2 depthBias;
 
     bool writeDepth(float alpha) {
         vec2 uv = fract(gl_FragCoord.xy / 32.0);
@@ -90,10 +81,13 @@ const fillFragmentShader = /* glsl */ `
 
     void main() {
         gl_FragColor = fillColor;
-        // depth stratum in window space (see the strata table in
-        // tool-overlay.ts): the fill sits behind the coplanar dot/line strata
-        // so its stochastic depth writes can't flicker the triangle edges
-        gl_FragDepth = writeDepth(fillColor.a) ? (clipPos.z / clipPos.w) * 0.5 + 0.5 + depthBias : 1.0;
+        // depth stratum (see the strata table in tool-overlay.ts): a manual
+        // polygon offset (slope-scaled term plus a constant a few depth
+        // quanta wide) keeping the fill just behind the coplanar dot/line
+        // strata at any camera distance. writing gl_FragDepth disables the
+        // hardware polygon offset the line strata use, so it is applied here.
+        gl_FragDepth = writeDepth(fillColor.a) ?
+            gl_FragCoord.z + depthBias.x * fwidth(gl_FragCoord.z) + depthBias.y : 1.0;
     }
 `;
 

--- a/src/shortcuts.ts
+++ b/src/shortcuts.ts
@@ -51,6 +51,13 @@ const controlKeys = new Set([
     'Home', 'End', 'PageUp', 'PageDown'
 ]);
 
+// input types whose value can be entered as text; unlike checkbox/radio/range
+// controls, these own every key while focused
+const textInputTypes = new Set([
+    'text', 'search', 'email', 'url', 'tel', 'password', 'number',
+    'date', 'datetime-local', 'month', 'time', 'week'
+]);
+
 // true if the focused element owns this key press: text entry contexts and
 // modal overlays (marked with .blocks-shortcuts) own all keys, any other
 // focused control owns only the keys such controls handle (controlKeys).
@@ -60,7 +67,11 @@ const targetConsumesKey = (e: KeyboardEvent): boolean => {
     if (!(target instanceof Element) || target === document.body) {
         return false;
     }
-    if (target.closest('input, textarea, select, [contenteditable], .blocks-shortcuts')) {
+    if (target.closest('textarea, [contenteditable], .blocks-shortcuts')) {
+        return true;
+    }
+    const input = target.closest('input');
+    if (input && textInputTypes.has(input.type)) {
         return true;
     }
     return controlKeys.has(e.key);

--- a/src/shortcuts.ts
+++ b/src/shortcuts.ts
@@ -43,6 +43,29 @@ const checkMod = (requirement: ModifierState | undefined, isPressed: boolean): b
     }
 };
 
+// keys that focusable controls (buttons, selects, sliders) handle themselves;
+// while such an element has focus these must not fire global shortcuts
+const controlKeys = new Set([
+    'Enter', ' ', 'Tab',
+    'ArrowUp', 'ArrowDown', 'ArrowLeft', 'ArrowRight',
+    'Home', 'End', 'PageUp', 'PageDown'
+]);
+
+// true if the focused element owns this key press: text entry contexts and
+// modal overlays (marked with .blocks-shortcuts) own all keys, any other
+// focused control owns only the keys such controls handle (controlKeys).
+// everything else falls through to the global shortcuts.
+const targetConsumesKey = (e: KeyboardEvent): boolean => {
+    const target = e.target;
+    if (!(target instanceof Element) || target === document.body) {
+        return false;
+    }
+    if (target.closest('input, textarea, select, [contenteditable], .blocks-shortcuts')) {
+        return true;
+    }
+    return controlKeys.has(e.key);
+};
+
 class Shortcuts {
     shortcuts: ShortcutOptions[] = [];
 
@@ -50,8 +73,8 @@ class Shortcuts {
         const shortcuts = this.shortcuts;
 
         const handleEvent = (e: KeyboardEvent, down: boolean, capture: boolean) => {
-            // skip if focus is elsewhere (input fields, modals, etc.)
-            if (e.target !== document.body) return;
+            // skip keys owned by the focused element (text entry, modals, control keys)
+            if (targetConsumesKey(e)) return;
 
             const isCtrlKey = e.code.startsWith('Control');
             const isShiftKey = e.code.startsWith('Shift');

--- a/src/splat.ts
+++ b/src/splat.ts
@@ -25,6 +25,7 @@ import { TransformPalette } from './transform-palette';
 const vec = new Vec3();
 const veca = new Vec3();
 const vecb = new Vec3();
+const quat = new Quat();
 
 const boundingPoints =
     [-1, 1].map((x) => {
@@ -76,6 +77,14 @@ class Splat extends Element {
 
     orientPoints: Vec3[] = [];
     orientSelection = -1;
+
+    // user-defined local frame (relative to the data frame), set from the
+    // orient tool's picked plane: origin at the first picked point, rotation
+    // aligning +y with the plane normal. the transform gizmos and panel use
+    // it as the model's local coordinate space; the gaussian data is
+    // unaffected. the defaults reproduce the entity's own frame
+    localFrameOrigin = new Vec3();
+    localFrame = new Quat();
 
     rebuildMaterial: (bands: number) => void;
 
@@ -626,19 +635,24 @@ class Splat extends Element {
     }
 
     // get pivot position/rotation/scale (caller should have awaited operation that changed data)
-    getPivot(mode: 'center' | 'boundCenter', selection: boolean, result: Transform) {
+    getPivot(result: Transform) {
         const { entity } = this;
-        switch (mode) {
-            case 'center':
-                result.set(entity.getLocalPosition(), entity.getLocalRotation(), entity.getLocalScale());
-                break;
-            case 'boundCenter': {
-                const bound = selection ? this.selectionBound : this.localBound;
-                entity.getLocalTransform().transformPoint(bound.center, vec);
-                result.set(vec, entity.getLocalRotation(), entity.getLocalScale());
-                break;
-            }
-        }
+        // the pivot is the model's local frame: the entity's own frame
+        // amended by the user-defined local frame (identity by default, so
+        // the pivot then lands exactly on the entity transform)
+        quat.mul2(entity.getLocalRotation(), this.localFrame);
+        entity.getLocalTransform().transformPoint(this.localFrameOrigin, vec);
+        result.set(vec, quat, entity.getLocalScale());
+    }
+
+    setLocalFrame(origin: Vec3, rotation: Quat) {
+        this.localFrameOrigin.copy(origin);
+        this.localFrame.copy(rotation);
+        this.scene.events.fire('splat.localFrame', this);
+    }
+
+    get hasLocalFrame() {
+        return !this.localFrameOrigin.equals(Vec3.ZERO) || !this.localFrame.equals(Quat.IDENTITY);
     }
 
     docSerialize() {
@@ -650,6 +664,8 @@ class Splat extends Element {
             position: pack3(this.entity.getLocalPosition()),
             rotation: pack4(this.entity.getLocalRotation()),
             scale: pack3(this.entity.getLocalScale()),
+            localFrameOrigin: pack3(this.localFrameOrigin),
+            localFrame: pack4(this.localFrame),
             visible: this.visible,
             tintClr: packC(this.tintClr),
             temperature: this.temperature,
@@ -666,6 +682,9 @@ class Splat extends Element {
 
         this.name = name;
         this.move(new Vec3(position), new Quat(rotation), new Vec3(scale));
+        // older documents predate the local frame
+        this.localFrameOrigin = doc.localFrameOrigin ? new Vec3(doc.localFrameOrigin) : new Vec3();
+        this.localFrame = doc.localFrame ? new Quat(doc.localFrame) : new Quat();
         this.visible = visible;
         this.tintClr = new Color(tintClr[0], tintClr[1], tintClr[2], tintClr[3]);
         this.temperature = temperature ?? 0;

--- a/src/splats-transform-handler.ts
+++ b/src/splats-transform-handler.ts
@@ -49,8 +49,8 @@ class SplatsTransformHandler implements TransformHandler {
             }
         });
 
-        events.on('pivot.origin', (mode: 'center' | 'boundCenter') => {
-            if (this.splat) {
+        events.on('splat.localFrame', (splat: Splat) => {
+            if (this.splat === splat) {
                 this.placePivot();
             }
         });
@@ -67,8 +67,7 @@ class SplatsTransformHandler implements TransformHandler {
     }
 
     placePivot() {
-        const origin = this.events.invoke('pivot.origin');
-        this.splat.getPivot(origin === 'center' ? 'center' : 'boundCenter', true, transform);
+        this.splat.getPivot(transform);
         this.events.invoke('pivot').place(transform);
     }
 

--- a/src/tool-overlay.ts
+++ b/src/tool-overlay.ts
@@ -39,15 +39,18 @@ const GHOST_OPACITY = 0.25;
 // the plane fill color
 const FILL_COLOR = [1, 0.4, 0, 0.6];
 
-// depth strata (window space), front to back: dots (no bias), line core, line
-// outline, fill. the overlay elements are coplanar, so ties between them are
-// broken with explicit biases rather than draw order, which the layer sorting
-// does not guarantee. the line strata are applied in the vertex shader in ndc
-// (2x window space); the fill stratum is applied in its fragment shader, since
-// the fill writes stochastic depth there.
-const STRATUM_LINE = 0.5e-4;
-const STRATUM_OUTLINE = 1e-4;
-const STRATUM_FILL = 2e-4;
+// depth strata, front to back: dots (no bias), line core, line outline, fill.
+// the overlay elements are coplanar, so ties between them are broken with
+// polygon-offset style biases (a slope-scaled term plus a handful of depth
+// buffer quanta), which stay tie-breaking-sized at any camera distance. a
+// fixed window-space offset does not: its world-space size swings with the
+// dynamic near/far planes, which made the fill/splat blend change with zoom.
+// the lines use the hardware polygon offset via material state; the fill
+// writes stochastic gl_FragDepth (which disables the hardware offset), so its
+// fragment shader applies the same formula manually.
+const STRATUM_LINE = { slope: 1, bias: 2 };
+const STRATUM_OUTLINE = { slope: 2, bias: 4 };
+const STRATUM_FILL = [3, 2e-6]; // slope factor, constant window-space offset
 
 // view depth at which behind-camera segment endpoints are clipped
 const NEAR_CLIP = 1e-3;
@@ -227,15 +230,16 @@ class ToolOverlay extends Element {
 
         const lineBase = makeMaterial('toolOverlayLineBase', lineVertexShader, lineFragmentShader, false);
         lineBase.setParameter('lineColor', [1, 1, 1, 1]);
-        lineBase.setParameter('depthBias', STRATUM_LINE * 2);
+        lineBase.slopeDepthBias = STRATUM_LINE.slope;
+        lineBase.depthBias = STRATUM_LINE.bias;
 
         const lineGhost = makeMaterial('toolOverlayLineGhost', lineVertexShader, lineFragmentShader, true);
         lineGhost.setParameter('lineColor', [1, 1, 1, GHOST_OPACITY]);
-        lineGhost.setParameter('depthBias', 0);
 
         const outlineBase = makeMaterial('toolOverlayOutlineBase', lineVertexShader, lineFragmentShader, false);
         outlineBase.setParameter('lineColor', [0, 0, 0, 1]);
-        outlineBase.setParameter('depthBias', STRATUM_OUTLINE * 2);
+        outlineBase.slopeDepthBias = STRATUM_OUTLINE.slope;
+        outlineBase.depthBias = STRATUM_OUTLINE.bias;
 
         const fillBase = makeMaterial('toolOverlayFillBase', fillVertexShader, fillFragmentShader, false);
         fillBase.blendState = blend;

--- a/src/tools/measure-tool.ts
+++ b/src/tools/measure-tool.ts
@@ -415,7 +415,8 @@ class MeasureTool {
             // frame with some margin; a lone point falls back to a radius
             // relative to the splat's world size
             splat.worldTransform.getScale(p);
-            radius = Math.max(radius * 1.5, splat.localBound.halfExtents.length() * p.x * 0.05);
+            const maxScale = Math.max(Math.abs(p.x), Math.abs(p.y), Math.abs(p.z));
+            radius = Math.max(radius * 1.5, splat.localBound.halfExtents.length() * maxScale * 0.05);
 
             return { position, radius };
         };

--- a/src/tools/measure-tool.ts
+++ b/src/tools/measure-tool.ts
@@ -55,7 +55,7 @@ class MeasureTool {
         i18n.bindText(clearButton, 'measure.clear');
 
         const selectToolbar = new Container({
-            class: 'select-toolbar',
+            class: ['select-toolbar', 'select-toolbar-tool'],
             hidden: true
         });
 

--- a/src/tools/measure-tool.ts
+++ b/src/tools/measure-tool.ts
@@ -7,6 +7,7 @@ import { Scene } from '../scene';
 import { Splat } from '../splat';
 import { ToolOverlay, OverlayWriter } from '../tool-overlay';
 import { Transform } from '../transform';
+import { DimensionLabels } from '../ui/dimension-labels';
 import { i18n } from '../ui/localization';
 
 // pointer movement below this many pixels still counts as a click
@@ -35,6 +36,11 @@ class MeasureTool {
     getFocus: () => { position: Vec3, radius: number } | null;
 
     constructor(events: Events, scene: Scene, canvasContainer: Container) {
+        // the length label along the measured line (shown when 'show
+        // dimensions' is enabled); the points and line render in the scene
+        // via the shared tool overlay
+        const dimLabels = new DimensionLabels(scene, canvasContainer.dom, canvasContainer.dom, 'measure-tool-svg', 1);
+
         // ui
         const hintLabel = new Label({ class: 'select-toolbar-label' });
         i18n.bindText(hintLabel, 'measure.hint');
@@ -350,6 +356,30 @@ class MeasureTool {
             }
         };
 
+        // length label along the measured line
+        events.on('postrender', () => {
+            // the svg is hidden while the tool is inactive, so skip the work
+            if (!active || !splat) {
+                return;
+            }
+
+            if (splat.measurePoints.length !== 2 || !events.invoke('camera.boundDimensions')) {
+                dimLabels.hideLabel(0);
+                return;
+            }
+
+            getPoint(0, p0);
+            getPoint(1, p1);
+            dimLabels.setLabel(0, p0, p1);
+        });
+
+        // re-render so the label reacts to the setting while the tool is active
+        events.on('camera.boundDimensions', () => {
+            if (active) {
+                scene.forceRender = true;
+            }
+        });
+
         const updateGizmoSize = () => {
             const { camera, canvas } = scene;
             if (camera.ortho) {
@@ -397,6 +427,7 @@ class MeasureTool {
             canvasContainer.dom.addEventListener('pointermove', pointermove);
             canvasContainer.dom.addEventListener('pointerup', pointerup, true);
             selectToolbar.hidden = false;
+            dimLabels.show();
 
             events.fire('transformHandler.push', transformHandler);
 
@@ -415,6 +446,7 @@ class MeasureTool {
             canvasContainer.dom.removeEventListener('pointermove', pointermove);
             canvasContainer.dom.removeEventListener('pointerup', pointerup, true);
             selectToolbar.hidden = true;
+            dimLabels.hide();
 
             events.fire('transformHandler.pop');
 

--- a/src/tools/measure-tool.ts
+++ b/src/tools/measure-tool.ts
@@ -32,6 +32,7 @@ class MeasureTransformHandler {
 class MeasureTool {
     activate: () => void;
     deactivate: () => void;
+    getFocus: () => { position: Vec3, radius: number } | null;
 
     constructor(events: Events, scene: Scene, canvasContainer: Container) {
         // ui
@@ -360,6 +361,34 @@ class MeasureTool {
         updateGizmoSize();
         events.on('camera.resize', updateGizmoSize);
         events.on('camera.ortho', updateGizmoSize);
+
+        // frame the placed points instead of the selection ('f' shortcut)
+        this.getFocus = () => {
+            const count = splat ? splat.measurePoints.length : 0;
+            if (count === 0) {
+                return null;
+            }
+
+            const position = new Vec3();
+            for (let i = 0; i < count; i++) {
+                getPoint(i, p);
+                position.add(p);
+            }
+            position.mulScalar(1 / count);
+
+            let radius = 0;
+            for (let i = 0; i < count; i++) {
+                getPoint(i, p);
+                radius = Math.max(radius, p.distance(position));
+            }
+
+            // frame with some margin; a lone point falls back to a radius
+            // relative to the splat's world size
+            splat.worldTransform.getScale(p);
+            radius = Math.max(radius * 1.5, splat.localBound.halfExtents.length() * p.x * 0.05);
+
+            return { position, radius };
+        };
 
         this.activate = () => {
             active = true;

--- a/src/tools/orient-tool.ts
+++ b/src/tools/orient-tool.ts
@@ -10,6 +10,7 @@ import { Splat } from '../splat';
 import { pickSplatSurfacePoint } from '../splat-pick';
 import { ToolOverlay, OverlayWriter } from '../tool-overlay';
 import { Transform } from '../transform';
+import { DimensionLabels } from '../ui/dimension-labels';
 import { i18n } from '../ui/localization';
 
 // snap the picked plane normal to a splat-local axis within this angle so
@@ -37,8 +38,7 @@ const newRot = new Quat();
 
 const t = new Transform();
 
-const worldPoints = [new Vec3(), new Vec3(), new Vec3()];
-const screenPoints = [new Vec3(), new Vec3(), new Vec3()];
+const cent = new Vec3();
 
 class OrientTransformHandler {
     activate() {}
@@ -51,25 +51,10 @@ class OrientTool {
     getFocus: () => { position: Vec3, radius: number } | null;
 
     constructor(events: Events, scene: Scene, parent: HTMLElement, canvasContainer: Container) {
-        // svg overlay holding the edge length labels; the points, edges and
-        // plane fill render in the scene via the shared tool overlay
-        const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
-        svg.classList.add('tool-svg', 'hidden');
-        svg.id = 'orient-tool-svg';
-        parent.appendChild(svg);
-
-        const ns = svg.namespaceURI;
-
-        // create the edge length labels (shown when 'show dimensions' is enabled)
-        const edgeLabels = [0, 1, 2].map((i) => {
-            const label = document.createElementNS(ns, 'text') as SVGTextElement;
-            label.id = `orient-edge-${i}`;
-            label.setAttribute('text-anchor', 'middle');
-            label.setAttribute('dominant-baseline', 'middle');
-            return label;
-        });
-
-        edgeLabels.forEach(label => svg.appendChild(label));
+        // the edge length labels (shown when 'show dimensions' is enabled);
+        // the points, edges and plane fill render in the scene via the shared
+        // tool overlay
+        const dimLabels = new DimensionLabels(scene, canvasContainer.dom, parent, 'orient-tool-svg', 3);
 
         // ui
         const hintLabel = new Label({ class: 'select-toolbar-label' });
@@ -383,11 +368,6 @@ class OrientTool {
         let clickX = 0;
         let clickY = 0;
 
-        // whether each placed point is in front of the camera, computed and
-        // consumed within the postrender label pass: worldToScreen mirrors
-        // positions behind the camera, so the labels must cull them
-        const pointInFront = [false, false, false];
-
         const pointerdown = (e: PointerEvent) => {
             if (!clicked && isPrimary(e)) {
                 clicked = true;
@@ -451,68 +431,28 @@ class OrientTool {
             }
 
             const count = splat.orientPoints.length;
-            const cameraPos = scene.camera.mainCamera.getPosition();
-            const cameraFwd = scene.camera.mainCamera.forward;
-
-            for (let i = 0; i < 3; i++) {
-                if (i < count) {
-                    getPoint(i, worldPoints[i]);
-                    pointInFront[i] = v.sub2(worldPoints[i], cameraPos).dot(cameraFwd) > 0;
-                    scene.camera.worldToScreen(worldPoints[i], screenPoints[i]);
-                    screenPoints[i].x *= canvasContainer.dom.clientWidth;
-                    screenPoints[i].y *= canvasContainer.dom.clientHeight;
-                } else {
-                    pointInFront[i] = false;
-                }
-            }
-
-            // edge length labels, following the bound dimensions overlay conventions
             const showDims = count > 1 && events.invoke('camera.boundDimensions');
 
-            // screen centroid of the placed points, used to offset labels outwards
-            let scx = 0, scy = 0;
-            for (let i = 0; i < count; i++) {
-                scx += screenPoints[i].x / count;
-                scy += screenPoints[i].y / count;
+            // the labels sit outside the triangle: offset away from the
+            // centroid of the placed points
+            if (showDims) {
+                cent.set(0, 0, 0);
+                for (let i = 0; i < count; i++) {
+                    getPoint(i, p);
+                    cent.add(p);
+                }
+                cent.mulScalar(1 / count);
             }
 
             for (let i = 0; i < 3; i++) {
-                const j = (i + 1) % 3;
-                const label = edgeLabels[i];
                 const exists = count === 3 || (count === 2 && i === 0);
-
-                if (!showDims || !exists || !pointInFront[i] || !pointInFront[j]) {
-                    label.setAttribute('visibility', 'hidden');
+                if (!showDims || !exists) {
+                    dimLabels.hideLabel(i);
                     continue;
                 }
-                label.setAttribute('visibility', 'visible');
-
-                const length = worldPoints[i].distance(worldPoints[j]);
-
-                const x0 = screenPoints[i].x;
-                const y0 = screenPoints[i].y;
-                const x1 = screenPoints[j].x;
-                const y1 = screenPoints[j].y;
-
-                const mx = (x0 + x1) * 0.5;
-                const my = (y0 + y1) * 0.5;
-
-                let theta = Math.atan2(y1 - y0, x1 - x0);
-                // flip 180° to keep text upright
-                if (Math.cos(theta) < 0) {
-                    theta += Math.PI;
-                }
-
-                // perpendicular offset so the label sits outside the triangle
-                const perpX = -Math.sin(theta);
-                const perpY = Math.cos(theta);
-                const dot = perpX * (scx - mx) + perpY * (scy - my);
-                const sign = dot > 0 ? -1 : 1;
-                const offsetPx = 10;
-
-                const thetaDeg = theta * 180 / Math.PI;
-                label.setAttribute('transform', `translate(${(mx + perpX * offsetPx * sign).toFixed(1)}, ${(my + perpY * offsetPx * sign).toFixed(1)}) rotate(${thetaDeg.toFixed(1)})`);
-                label.textContent = length.toFixed(2);
+                getPoint(i, p0);
+                getPoint((i + 1) % 3, p1);
+                dimLabels.setLabel(i, p0, p1, cent);
             }
         });
 
@@ -572,7 +512,7 @@ class OrientTool {
             selectToolbar.hidden = false;
             parent.style.display = 'block';
             parent.classList.add('noevents');
-            svg.classList.remove('hidden');
+            dimLabels.show();
 
             // ensure the grid is visible while the tool is active. suspend
             // preference capture: the forced grid is tool state, not a user
@@ -605,7 +545,7 @@ class OrientTool {
             selectToolbar.hidden = true;
             parent.style.display = 'none';
             parent.classList.remove('noevents');
-            svg.classList.add('hidden');
+            dimLabels.hide();
 
             if (gridForced) {
                 gridSelfToggle = true;

--- a/src/tools/orient-tool.ts
+++ b/src/tools/orient-tool.ts
@@ -82,7 +82,7 @@ class OrientTool {
         i18n.bindText(clearButton, 'orient.clear');
 
         const selectToolbar = new Container({
-            class: 'select-toolbar',
+            class: ['select-toolbar', 'select-toolbar-tool'],
             hidden: true
         });
 
@@ -113,6 +113,16 @@ class OrientTool {
         let active = false;
         let splat: Splat;
         let gridForced = false;
+        let gridSelfToggle = false;
+
+        // if grid visibility changes for any reason other than the tool's own
+        // forcing (e.g. the user pressing 'g'), the grid is the user's again:
+        // leave it alone on deactivate
+        events.on('grid.visible', () => {
+            if (!gridSelfToggle) {
+                gridForced = false;
+            }
+        });
 
         // get world space point
         const getPoint = (index: number, result: Vec3) => {
@@ -569,9 +579,11 @@ class OrientTool {
             // setting change
             gridForced = !events.invoke('grid.visible');
             if (gridForced) {
+                gridSelfToggle = true;
                 events.fire('preferences.suspend');
                 events.fire('grid.setVisible', true);
                 events.fire('preferences.resume');
+                gridSelfToggle = false;
             }
 
             events.fire('transformHandler.push', transformHandler);
@@ -596,9 +608,11 @@ class OrientTool {
             svg.classList.add('hidden');
 
             if (gridForced) {
+                gridSelfToggle = true;
                 events.fire('preferences.suspend');
                 events.fire('grid.setVisible', false);
                 events.fire('preferences.resume');
+                gridSelfToggle = false;
                 gridForced = false;
             }
 

--- a/src/tools/orient-tool.ts
+++ b/src/tools/orient-tool.ts
@@ -523,7 +523,8 @@ class OrientTool {
             // frame with some margin; a lone point falls back to a radius
             // relative to the splat's world size
             splat.worldTransform.getScale(v);
-            radius = Math.max(radius * 1.5, splat.localBound.halfExtents.length() * v.x * 0.05);
+            const maxScale = Math.max(Math.abs(v.x), Math.abs(v.y), Math.abs(v.z));
+            radius = Math.max(radius * 1.5, splat.localBound.halfExtents.length() * maxScale * 0.05);
 
             return { position, radius };
         };

--- a/src/tools/orient-tool.ts
+++ b/src/tools/orient-tool.ts
@@ -48,6 +48,7 @@ class OrientTransformHandler {
 class OrientTool {
     activate: () => void;
     deactivate: () => void;
+    getFocus: () => { position: Vec3, radius: number } | null;
 
     constructor(events: Events, scene: Scene, parent: HTMLElement, canvasContainer: Container) {
         // svg overlay holding the edge length labels; the points, edges and
@@ -95,8 +96,19 @@ class OrientTool {
         canvasContainer.append(selectToolbar);
 
         const gizmo = new TranslateGizmo(scene.camera.camera, scene.gizmoLayer);
-        const entity = new Entity('orientGizmoPivot');
         const transformHandler = new OrientTransformHandler();
+
+        // the gizmo pivot must live in the scene graph: in local coord space
+        // the gizmo divides its translate delta by the parent's world scale,
+        // and a parentless entity leaves that divisor stale (1/0 = Infinity)
+        const entity = new Entity('orientGizmoPivot');
+        scene.app.root.addChild(entity);
+
+        gizmo.coordSpace = events.invoke('tool.coordSpace');
+        events.on('tool.coordSpace', (coordSpace: 'local' | 'world') => {
+            gizmo.coordSpace = coordSpace;
+            scene.forceRender = true;
+        });
 
         let active = false;
         let splat: Splat;
@@ -159,6 +171,19 @@ class OrientTool {
             return true;
         };
 
+        // calculate the rotation aligning +y with the plane normal (on the
+        // camera-facing side, matching the align convention) and +x with the
+        // first edge. requires a valid calcPlane result in p0/p1, n and c.
+        const calcPlaneRotation = (result: Quat) => {
+            if (n.dot(v.sub2(scene.camera.position, c)) < 0) {
+                n.mulScalar(-1);
+            }
+            e0.normalize();
+            e1.cross(e0, n);
+            mat.set([e0.x, e0.y, e0.z, 0, n.x, n.y, n.z, 0, e1.x, e1.y, e1.z, 0, 0, 0, 0, 1]);
+            result.setFromMat4(mat);
+        };
+
         const updateButtons = () => {
             alignButton.enabled = !!splat && splat.orientPoints.length === 3 && calcPlane();
             clearButton.enabled = !!splat && splat.orientPoints.length > 0;
@@ -172,6 +197,15 @@ class OrientTool {
                 t.set(p, Quat.IDENTITY, Vec3.ONE);
                 events.invoke('pivot').place(t);
                 entity.setLocalPosition(p);
+
+                // in local space the gizmo aligns to the picked plane (y perpendicular)
+                if (splat.orientPoints.length === 3 && calcPlane()) {
+                    calcPlaneRotation(q);
+                    entity.setLocalRotation(q);
+                } else {
+                    entity.setLocalRotation(Quat.IDENTITY);
+                }
+
                 gizmo.attach(entity);
             }
 
@@ -491,6 +525,34 @@ class OrientTool {
         events.on('camera.resize', updateGizmoSize);
         events.on('camera.ortho', updateGizmoSize);
 
+        // frame the placed points instead of the selection ('f' shortcut)
+        this.getFocus = () => {
+            const count = splat ? splat.orientPoints.length : 0;
+            if (count === 0) {
+                return null;
+            }
+
+            const position = new Vec3();
+            for (let i = 0; i < count; i++) {
+                getPoint(i, v);
+                position.add(v);
+            }
+            position.mulScalar(1 / count);
+
+            let radius = 0;
+            for (let i = 0; i < count; i++) {
+                getPoint(i, v);
+                radius = Math.max(radius, v.distance(position));
+            }
+
+            // frame with some margin; a lone point falls back to a radius
+            // relative to the splat's world size
+            splat.worldTransform.getScale(v);
+            radius = Math.max(radius * 1.5, splat.localBound.halfExtents.length() * v.x * 0.05);
+
+            return { position, radius };
+        };
+
         this.activate = () => {
             active = true;
             updateVisuals();
@@ -523,12 +585,6 @@ class OrientTool {
             active = false;
 
             scene.remove(overlay);
-
-            // the points are consumed by the alignment, so start the next session fresh
-            if (splat) {
-                splat.orientPoints.length = 0;
-                splat.orientSelection = -1;
-            }
 
             updateVisuals();
             canvasContainer.dom.removeEventListener('pointerdown', pointerdown);

--- a/src/tools/orient-tool.ts
+++ b/src/tools/orient-tool.ts
@@ -1,7 +1,7 @@
 import { Button, Container, Label } from '@playcanvas/pcui';
 import { Entity, Mat4, Quat, TranslateGizmo, Vec3, math } from 'playcanvas';
 
-import { EntityTransformOp, MultiOp, PlacePivotOp } from '../edit-ops';
+import { EntityTransformOp, MultiOp, PlacePivotOp, SetLocalFrameOp } from '../edit-ops';
 import { Events } from '../events';
 import type { GridPlane } from '../infinite-grid';
 import { Pivot } from '../pivot';
@@ -63,6 +63,9 @@ class OrientTool {
         const alignButton = new Button({ class: 'select-toolbar-button', enabled: false });
         i18n.bindText(alignButton, 'orient.align');
 
+        const frameButton = new Button({ class: 'select-toolbar-button', enabled: false });
+        i18n.bindText(frameButton, 'orient.set-pivot');
+
         const clearButton = new Button({ class: 'select-toolbar-button', enabled: false });
         i18n.bindText(clearButton, 'orient.clear');
 
@@ -77,6 +80,7 @@ class OrientTool {
 
         selectToolbar.append(hintLabel);
         selectToolbar.append(alignButton);
+        selectToolbar.append(frameButton);
         selectToolbar.append(clearButton);
         canvasContainer.append(selectToolbar);
 
@@ -180,7 +184,9 @@ class OrientTool {
         };
 
         const updateButtons = () => {
-            alignButton.enabled = !!splat && splat.orientPoints.length === 3 && calcPlane();
+            const planeReady = !!splat && splat.orientPoints.length === 3 && calcPlane();
+            alignButton.enabled = planeReady;
+            frameButton.enabled = planeReady;
             clearButton.enabled = !!splat && splat.orientPoints.length > 0;
         };
 
@@ -319,15 +325,12 @@ class OrientTool {
 
             const top = new EntityTransformOp({ splat, oldt, newt });
 
-            // place the pivot to match the new transform
+            // place the pivot at the local frame under the new transform
             const pivot = events.invoke('pivot') as Pivot;
-            if (events.invoke('pivot.origin') === 'boundCenter') {
-                mat.setTRS(newt.position, newt.rotation, newt.scale);
-                mat.transformPoint(splat.localBound.center, v);
-                t.set(v, newt.rotation, newt.scale);
-            } else {
-                t.copy(newt);
-            }
+            mat.setTRS(newt.position, newt.rotation, newt.scale);
+            mat.transformPoint(splat.localFrameOrigin, v);
+            q.mul2(newt.rotation, splat.localFrame);
+            t.set(v, q, newt.scale);
             const pop = new PlacePivotOp({ pivot, oldt: pivot.transform.clone(), newt: t.clone() });
 
             events.fire('edit.add', new MultiOp([top, pop]));
@@ -340,6 +343,28 @@ class OrientTool {
         };
 
         alignButton.on('click', alignToGrid);
+
+        // make the picked plane the model's local frame without moving it:
+        // the transform gizmos and panel use it in local coordinate space
+        frameButton.on('click', () => {
+            if (!splat || splat.orientPoints.length !== 3 || !calcPlane()) {
+                return;
+            }
+            calcPlaneRotation(q);
+
+            // the frame is stored relative to the entity: rotation from the
+            // picked plane, origin at the first picked point
+            newRot.copy(splat.entity.getLocalRotation()).invert().mul(q);
+
+            events.fire('edit.add', new SetLocalFrameOp({
+                splat,
+                oldOrigin: splat.localFrameOrigin.clone(),
+                oldFrame: splat.localFrame.clone(),
+                newOrigin: splat.orientPoints[0].clone(),
+                newFrame: newRot.clone()
+            }));
+        });
+
 
         clearButton.on('click', () => {
             if (splat) {

--- a/src/tools/shape-transform-gizmo.ts
+++ b/src/tools/shape-transform-gizmo.ts
@@ -85,6 +85,9 @@ class ShapeTransformGizmo {
             all.forEach((gizmo) => {
                 gizmo.coordSpace = space;
             });
+            // the gizmos only request a redraw from within a frame, so with
+            // on-demand rendering the reorientation needs a forced frame
+            scene.forceRender = true;
         };
         setCoordSpace(events.invoke('tool.coordSpace'));
         events.on('tool.coordSpace', setCoordSpace);

--- a/src/tools/tool-manager.ts
+++ b/src/tools/tool-manager.ts
@@ -37,7 +37,7 @@ class ToolManager {
             return tool?.getFocus?.() ?? null;
         });
 
-        let coordSpace: 'local' | 'world' = 'world';
+        let coordSpace: 'local' | 'world' = 'local';
 
         const setCoordSpace = (space: 'local' | 'world') => {
             if (space !== coordSpace) {
@@ -57,6 +57,11 @@ class ToolManager {
         events.on('tool.toggleCoordSpace', () => {
             setCoordSpace(coordSpace === 'local' ? 'world' : 'local');
         });
+
+        // announce the initial space so ui constructed before this (e.g. the
+        // bottom toolbar toggle) reflects the default; tools constructed
+        // after read it via tool.coordSpace
+        events.fire('tool.coordSpace', coordSpace);
 
         // the 1/2/3 shortcuts switch the active tool's gizmo mode if it
         // supports one (box/sphere selection), otherwise activate the

--- a/src/tools/tool-manager.ts
+++ b/src/tools/tool-manager.ts
@@ -1,3 +1,5 @@
+import type { Vec3 } from 'playcanvas';
+
 import { Events } from '../events';
 
 interface Tool {
@@ -7,6 +9,9 @@ interface Tool {
     // tool is active. return true if consumed, otherwise the corresponding
     // transform tool is activated instead.
     setTransformMode?: (mode: 'translate' | 'rotate' | 'scale') => boolean;
+    // optional: world-space focus target for the frame ('f') shortcut. return
+    // null to fall back to framing the selection.
+    getFocus?: () => { position: Vec3, radius: number } | null;
 }
 
 class ToolManager {
@@ -23,6 +28,13 @@ class ToolManager {
 
         this.events.function('tool.active', () => {
             return this.active;
+        });
+
+        // the active tool's focus target (if any), framed by camera.focus in
+        // place of the selection
+        this.events.function('tool.focus', () => {
+            const tool = this.active ? this.tools.get(this.active) : null;
+            return tool?.getFocus?.() ?? null;
         });
 
         let coordSpace: 'local' | 'world' = 'world';

--- a/src/tools/transform-tool.ts
+++ b/src/tools/transform-tool.ts
@@ -53,6 +53,9 @@ class TransformTool {
 
         events.on('tool.coordSpace', (coordSpace: string) => {
             gizmo.coordSpace = coordSpace as 'local' | 'world';
+            // the gizmo only requests a redraw from within a frame, so with
+            // on-demand rendering the reorientation needs a forced frame
+            scene.forceRender = true;
         });
 
         // set the gizmo size to remain a constant size in screen space.

--- a/src/ui/about-popup.ts
+++ b/src/ui/about-popup.ts
@@ -19,6 +19,7 @@ class AboutPopup extends Container {
         args = {
             ...args,
             id: 'about-popup',
+            class: 'blocks-shortcuts',
             hidden: true,
             tabIndex: -1
         };

--- a/src/ui/bottom-toolbar.ts
+++ b/src/ui/bottom-toolbar.ts
@@ -186,7 +186,7 @@ class BottomToolbar extends Container {
         measure.dom.addEventListener('click', () => events.fire('tool.measure'));
         orient.dom.addEventListener('click', () => events.fire('tool.orient'));
         coordSpace.dom.addEventListener('click', () => events.fire('tool.toggleCoordSpace'));
-        origin.dom.addEventListener('click', () => events.fire('pivot.toggleOrigin'));
+        origin.dom.addEventListener('click', (e: MouseEvent) => events.fire('pivot.reset', e.shiftKey));
 
         events.on('edit.canUndo', (value: boolean) => {
             undo.enabled = value;
@@ -215,9 +215,6 @@ class BottomToolbar extends Container {
             coordSpace.dom.classList[space === 'local' ? 'add' : 'remove']('active');
         });
 
-        events.on('pivot.origin', (o: 'center' | 'boundCenter') => {
-            origin.dom.classList[o === 'boundCenter' ? 'add' : 'remove']('active');
-        });
 
         // Helper to compose localized tooltip text with shortcut
         const shortcutManager: ShortcutManager = events.invoke('shortcutManager');
@@ -248,7 +245,7 @@ class BottomToolbar extends Container {
         tooltips.register(measure, tooltip('tooltip.bottom-toolbar.measure'));
         tooltips.register(orient, tooltip('tooltip.bottom-toolbar.orient'));
         tooltips.register(coordSpace, tooltip('tooltip.bottom-toolbar.local-space', 'tool.toggleCoordSpace'));
-        tooltips.register(origin, tooltip('tooltip.bottom-toolbar.bounding-box-center'));
+        tooltips.register(origin, tooltip('tooltip.bottom-toolbar.reset-pivot'));
         tooltips.register(eyedropper, tooltip('tooltip.bottom-toolbar.eyedropper-selection', 'tool.eyedropperSelection'));
     }
 }

--- a/src/ui/bound-dimensions-overlay.ts
+++ b/src/ui/bound-dimensions-overlay.ts
@@ -1,6 +1,7 @@
 import { Container } from '@playcanvas/pcui';
 import { Vec3 } from 'playcanvas';
 
+import { DimensionLabels } from './dimension-labels';
 import { Events } from '../events';
 import { Scene } from '../scene';
 import { Splat } from '../splat';
@@ -43,21 +44,10 @@ const axisEdges: number[][][] = [
 
 class BoundDimensionsOverlay {
     constructor(events: Events, scene: Scene, canvasContainer: Container) {
-        const ns = 'http://www.w3.org/2000/svg';
-        const svg = document.createElementNS(ns, 'svg');
-        svg.classList.add('tool-svg', 'bound-dimensions-svg', 'hidden');
-        svg.id = 'bound-dimensions-svg';
-        canvasContainer.dom.appendChild(svg);
-
-        const labels: SVGTextElement[] = [];
-        for (let i = 0; i < 3; i++) {
-            const text = document.createElementNS(ns, 'text') as SVGTextElement;
-            text.classList.add(['bound-dim-x', 'bound-dim-y', 'bound-dim-z'][i]);
-            text.setAttribute('text-anchor', 'middle');
-            text.setAttribute('dominant-baseline', 'middle');
-            svg.appendChild(text);
-            labels.push(text);
-        }
+        const dimLabels = new DimensionLabels(scene, canvasContainer.dom, canvasContainer.dom, 'bound-dimensions-svg', 3);
+        dimLabels.labels.forEach((label, i) => {
+            label.classList.add(['bound-dim-x', 'bound-dim-y', 'bound-dim-z'][i]);
+        });
 
         events.on('prerender', () => {
             const selection = events.invoke('selection') as Splat;
@@ -66,11 +56,11 @@ class BoundDimensionsOverlay {
                 !selection.visible ||
                 !events.invoke('camera.bound') ||
                 !events.invoke('camera.boundDimensions')) {
-                svg.classList.add('hidden');
+                dimLabels.hide();
                 return;
             }
 
-            svg.classList.remove('hidden');
+            dimLabels.show();
 
             const width = canvasContainer.dom.clientWidth;
             const height = canvasContainer.dom.clientHeight;
@@ -135,51 +125,15 @@ class BoundDimensionsOverlay {
                     }
                 }
 
-                const text = labels[axis];
-
                 if (bestEdge < 0) {
                     // no parallel edge has both endpoints in front of the camera
-                    text.setAttribute('visibility', 'hidden');
+                    dimLabels.hideLabel(axis);
                     continue;
                 }
-                text.setAttribute('visibility', 'visible');
 
+                // label the edge, offset away from the bound center
                 const [a, b] = edges[bestEdge];
-                const sa = screenCorners[a];
-                const sb = screenCorners[b];
-
-                // world-space edge length
-                const length = corners[a].distance(corners[b]);
-
-                // screen-space endpoints in pixels
-                const x0 = sa.x * width;
-                const y0 = sa.y * height;
-                const x1 = sb.x * width;
-                const y1 = sb.y * height;
-
-                const mx = (x0 + x1) * 0.5;
-                const my = (y0 + y1) * 0.5;
-
-                let theta = Math.atan2(y1 - y0, x1 - x0);
-                // flip 180° to keep text upright
-                if (Math.cos(theta) < 0) {
-                    theta += Math.PI;
-                }
-
-                // perpendicular offset so the label sits outside the box
-                const perpX = -Math.sin(theta);
-                const perpY = Math.cos(theta);
-                const toCenterX = scx - mx;
-                const toCenterY = scy - my;
-                const dot = perpX * toCenterX + perpY * toCenterY;
-                const sign = dot > 0 ? -1 : 1;
-                const offsetPx = 10;
-                const ox = perpX * offsetPx * sign;
-                const oy = perpY * offsetPx * sign;
-
-                const thetaDeg = theta * 180 / Math.PI;
-                text.setAttribute('transform', `translate(${(mx + ox).toFixed(1)}, ${(my + oy).toFixed(1)}) rotate(${thetaDeg.toFixed(1)})`);
-                text.textContent = length.toFixed(2);
+                dimLabels.setLabel(axis, corners[a], corners[b], worldBoundCenter);
             }
         });
     }

--- a/src/ui/bound-dimensions-overlay.ts
+++ b/src/ui/bound-dimensions-overlay.ts
@@ -64,6 +64,7 @@ class BoundDimensionsOverlay {
 
             if (!selection ||
                 !selection.visible ||
+                !events.invoke('camera.bound') ||
                 !events.invoke('camera.boundDimensions')) {
                 svg.classList.add('hidden');
                 return;

--- a/src/ui/dimension-labels.ts
+++ b/src/ui/dimension-labels.ts
@@ -1,0 +1,112 @@
+import { Vec3 } from 'playcanvas';
+
+import { Scene } from '../scene';
+
+const va = new Vec3();
+const vb = new Vec3();
+const vc = new Vec3();
+
+// shared world-space edge length labels (bound dimensions overlay, measure
+// and orient tools): a text label per edge, placed at the screen midpoint,
+// rotated along the edge (flipped to stay upright), offset perpendicular to
+// one side and hidden when either endpoint projects from behind the camera
+// (worldToScreen mirrors those positions).
+class DimensionLabels {
+    svg: SVGSVGElement;
+    labels: SVGTextElement[];
+
+    private scene: Scene;
+    private viewport: HTMLElement;
+
+    // the svg is appended to parent and sized by it; screen projections use
+    // the viewport element's client size (the canvas container)
+    constructor(scene: Scene, viewport: HTMLElement, parent: HTMLElement, id: string, count: number) {
+        this.scene = scene;
+        this.viewport = viewport;
+
+        const ns = 'http://www.w3.org/2000/svg';
+        this.svg = document.createElementNS(ns, 'svg') as SVGSVGElement;
+        this.svg.classList.add('tool-svg', 'dimension-labels-svg', 'hidden');
+        this.svg.id = id;
+        parent.appendChild(this.svg);
+
+        this.labels = Array.from({ length: count }, () => {
+            const text = document.createElementNS(ns, 'text') as SVGTextElement;
+            text.setAttribute('text-anchor', 'middle');
+            text.setAttribute('dominant-baseline', 'middle');
+            this.svg.appendChild(text);
+            return text;
+        });
+    }
+
+    show() {
+        this.svg.classList.remove('hidden');
+    }
+
+    hide() {
+        this.svg.classList.add('hidden');
+    }
+
+    hideLabel(index: number) {
+        this.labels[index].setAttribute('visibility', 'hidden');
+    }
+
+    // place a label along the world-space edge a-b, showing its length. the
+    // label sits on the side facing away from the world-space awayFrom
+    // reference (e.g. the shape center), or above the edge when no reference
+    // is given.
+    setLabel(index: number, a: Vec3, b: Vec3, awayFrom?: Vec3) {
+        const label = this.labels[index];
+        const { camera } = this.scene;
+
+        // hide the label when either endpoint is behind the camera
+        const cameraPos = camera.mainCamera.getPosition();
+        const cameraFwd = camera.mainCamera.forward;
+        if (va.sub2(a, cameraPos).dot(cameraFwd) <= 0 ||
+            va.sub2(b, cameraPos).dot(cameraFwd) <= 0) {
+            label.setAttribute('visibility', 'hidden');
+            return;
+        }
+        label.setAttribute('visibility', 'visible');
+
+        const length = a.distance(b);
+
+        const width = this.viewport.clientWidth;
+        const height = this.viewport.clientHeight;
+
+        camera.worldToScreen(a, va);
+        camera.worldToScreen(b, vb);
+
+        const x0 = va.x * width;
+        const y0 = va.y * height;
+        const x1 = vb.x * width;
+        const y1 = vb.y * height;
+
+        const mx = (x0 + x1) * 0.5;
+        const my = (y0 + y1) * 0.5;
+
+        let theta = Math.atan2(y1 - y0, x1 - x0);
+        // flip 180° to keep text upright
+        if (Math.cos(theta) < 0) {
+            theta += Math.PI;
+        }
+
+        // perpendicular offset to the side facing away from the reference
+        // (the upright flip leaves the perpendicular pointing down-screen,
+        // so without a reference the label sits above the edge)
+        const perpX = -Math.sin(theta);
+        const perpY = Math.cos(theta);
+        let sign = -1;
+        if (awayFrom) {
+            camera.worldToScreen(awayFrom, vc);
+            sign = perpX * (vc.x * width - mx) + perpY * (vc.y * height - my) > 0 ? -1 : 1;
+        }
+        const offsetPx = 10;
+
+        const thetaDeg = theta * 180 / Math.PI;
+        label.setAttribute('transform', `translate(${(mx + perpX * offsetPx * sign).toFixed(1)}, ${(my + perpY * offsetPx * sign).toFixed(1)}) rotate(${thetaDeg.toFixed(1)})`);
+        label.textContent = length.toFixed(2);
+    }
+}
+
+export { DimensionLabels };

--- a/src/ui/editor.ts
+++ b/src/ui/editor.ts
@@ -188,6 +188,18 @@ class EditorUI {
         document.body.appendChild(appContainer.dom);
         document.body.setAttribute('tabIndex', '-1');
 
+        // don't let pointer-clicked buttons keep focus (which would swallow
+        // control keys like Space from the global shortcuts). keyboard
+        // activation (e.detail === 0) keeps focus for tab navigation, and
+        // modals keep focus inside so their shortcut blocking stays intact
+        document.addEventListener('click', (e) => {
+            if (e.detail === 0) return;
+            const button = (e.target as Element)?.closest?.('button');
+            if (button && button === document.activeElement && !button.closest('.blocks-shortcuts')) {
+                button.blur();
+            }
+        });
+
         events.on('show.shortcuts', () => {
             shortcutsPopup.hidden = false;
         });

--- a/src/ui/export-popup.ts
+++ b/src/ui/export-popup.ts
@@ -48,6 +48,7 @@ class ExportPopup extends Container {
     constructor(events: Events, args = {}) {
         args = {
             id: 'export-popup',
+            class: 'blocks-shortcuts',
             hidden: true,
             tabIndex: -1,
             ...args

--- a/src/ui/image-settings-dialog.ts
+++ b/src/ui/image-settings-dialog.ts
@@ -22,7 +22,7 @@ class ImageSettingsDialog extends Container {
         args = {
             ...args,
             id: 'image-settings-dialog',
-            class: 'settings-dialog',
+            class: ['settings-dialog', 'blocks-shortcuts'],
             hidden: true,
             tabIndex: -1
         };

--- a/src/ui/popup.ts
+++ b/src/ui/popup.ts
@@ -32,6 +32,7 @@ class Popup extends Container {
     constructor(tooltips: Tooltips, args = {}) {
         args = {
             id: 'popup',
+            class: 'blocks-shortcuts',
             hidden: true,
             tabIndex: -1,
             ...args

--- a/src/ui/progress.ts
+++ b/src/ui/progress.ts
@@ -21,6 +21,7 @@ class Progress extends Container {
         this.onCancel = null;
 
         this.dom.tabIndex = 0;
+        this.dom.classList.add('blocks-shortcuts');
 
         const header = new Label({
             id: 'header'

--- a/src/ui/publish-settings-dialog.ts
+++ b/src/ui/publish-settings-dialog.ts
@@ -24,7 +24,7 @@ class PublishSettingsDialog extends Container {
         args = {
             ...args,
             id: 'publish-settings-dialog',
-            class: 'settings-dialog',
+            class: ['settings-dialog', 'blocks-shortcuts'],
             hidden: true,
             tabIndex: -1
         };

--- a/src/ui/scss/select-toolbar.scss
+++ b/src/ui/scss/select-toolbar.scss
@@ -65,6 +65,18 @@
         line-height: 38px;
     }
 
+    // the measure/orient toolbars: a hint label plus text actions and inputs,
+    // spaced with a uniform flex gap rather than the icon-cluster margins
+    &.select-toolbar-tool {
+        gap: 12px;
+        padding: 0px 16px;
+
+        .select-toolbar-label,
+        .select-toolbar-button {
+            margin: 0px;
+        }
+    }
+
     // 16px group break from the preceding cluster, 6px to the input it labels
     .select-toolbar-label {
         margin: 0px 6px 0px 16px;

--- a/src/ui/scss/select-toolbar.scss
+++ b/src/ui/scss/select-toolbar.scss
@@ -56,13 +56,14 @@
         background-color: $bcg-dark;
     }
 
-    // text action buttons (e.g. the orient tool's align/clear)
+    // text action buttons (e.g. the orient tool's align/clear); shorter than
+    // the icon buttons so they sit in balance with the labels and inputs
     .select-toolbar-button {
-        height: 38px;
+        height: 28px;
         margin: 0px 1px;
         padding: 0px 12px;
         border-radius: 2px;
-        line-height: 38px;
+        line-height: 28px;
     }
 
     // the measure/orient toolbars: a hint label plus text actions and inputs,

--- a/src/ui/scss/tool.scss
+++ b/src/ui/scss/tool.scss
@@ -45,24 +45,12 @@
         }
     }
 
-    &#bound-dimensions-svg {
+    // shared edge length labels: the bound dimensions overlay and the
+    // measure/orient tools (see dimension-labels.ts)
+    &.dimension-labels-svg {
         pointer-events: none;
 
         > text {
-            font-family: monospace;
-            font-size: 11px;
-            fill: white;
-            paint-order: stroke;
-            stroke: rgba(0, 0, 0, 0.7);
-            stroke-width: 3px;
-        }
-    }
-
-    // the orient tool's points, edges and plane fill render in the scene (see
-    // tool-overlay.ts); the svg holds only the edge length labels, which match
-    // the bound dimensions overlay
-    &#orient-tool-svg {
-        >text {
             font-family: monospace;
             font-size: 11px;
             fill: white;

--- a/src/ui/settings-panel.ts
+++ b/src/ui/settings-panel.ts
@@ -387,7 +387,7 @@ class SettingsPanel extends Container {
         const showBoundDimensionsLabel = new Label({
             class: 'settings-panel-row-label'
         });
-        i18n.bindText(showBoundDimensionsLabel, 'panel.settings.show-bounding-box-dimensions');
+        i18n.bindText(showBoundDimensionsLabel, 'panel.settings.show-dimensions');
 
         const showBoundDimensionsToggle = new BooleanInput({
             type: 'toggle',

--- a/src/ui/shortcuts-popup.ts
+++ b/src/ui/shortcuts-popup.ts
@@ -116,6 +116,7 @@ class ShortcutsPopup extends Container {
         args = {
             ...args,
             id: 'shortcuts-popup',
+            class: 'blocks-shortcuts',
             hidden: true,
             tabIndex: -1
         };

--- a/src/ui/spinner.ts
+++ b/src/ui/spinner.ts
@@ -11,6 +11,7 @@ class Spinner extends Container {
         super(args);
 
         this.dom.tabIndex = 0;
+        this.dom.classList.add('blocks-shortcuts');
 
         const spinner = new Element({
             dom: 'div',

--- a/src/ui/transform.ts
+++ b/src/ui/transform.ts
@@ -93,7 +93,9 @@ class Transform extends Container {
         let uiUpdating = false;
         let mouseUpdating = false;
 
-        // update UI with pivot
+        // the panel shows the pivot in world coordinates. with a user-defined
+        // local frame set (see Splat.getPivot), the pivot is that frame, so
+        // zeroing the values aligns the frame with the world origin and axes
         const updateUI = (pivot: Pivot) => {
             uiUpdating = true;
             const transform = pivot.transform;

--- a/src/ui/video-settings-dialog.ts
+++ b/src/ui/video-settings-dialog.ts
@@ -22,7 +22,7 @@ class VideoSettingsDialog extends Container {
         args = {
             ...args,
             id: 'video-settings-dialog',
-            class: 'settings-dialog',
+            class: ['settings-dialog', 'blocks-shortcuts'],
             hidden: true,
             tabIndex: -1
         };

--- a/static/locales/de.json
+++ b/static/locales/de.json
@@ -88,7 +88,7 @@
     "panel.settings.show-grid": "Raster anzeigen",
     "panel.settings.grid-plane": "Rasterebene",
     "panel.settings.show-bounding-box": "Objektbox anzeigen",
-    "panel.settings.show-bounding-box-dimensions": "Abmessungen anzeigen",
+    "panel.settings.show-dimensions": "Abmessungen anzeigen",
     "panel.settings.show-camera-poses": "Kameras anzeigen",
     "panel.settings.show-camera-info": "Kamera-Info anzeigen",
     "panel.settings.reset": "Auf Standard zurücksetzen",

--- a/static/locales/de.json
+++ b/static/locales/de.json
@@ -280,6 +280,7 @@
 
     "orient.hint": "3 Punkte platzieren, um eine Ebene zu definieren",
     "orient.align": "An Raster ausrichten",
+    "orient.set-pivot": "Pivot setzen",
     "orient.clear": "Leeren",
 
     "status-bar.splats": "Splats",
@@ -314,7 +315,7 @@
     "tooltip.bottom-toolbar.measure": "Messen",
     "tooltip.bottom-toolbar.orient": "Ausrichten",
     "tooltip.bottom-toolbar.local-space": "Gizmo in local-space",
-    "tooltip.bottom-toolbar.bounding-box-center": "Mittelpunkt verwenden",
+    "tooltip.bottom-toolbar.reset-pivot": "Pivot zurücksetzen (Umschalt: zur Mitte)",
 
     "tooltip.timeline.prev-frame": "Vorheriges Bild",
     "tooltip.timeline.play": "Abspielen/Pause",

--- a/static/locales/en.json
+++ b/static/locales/en.json
@@ -88,7 +88,7 @@
     "panel.settings.show-grid": "Show Grid",
     "panel.settings.grid-plane": "Grid Plane",
     "panel.settings.show-bounding-box": "Show Bounding Box",
-    "panel.settings.show-bounding-box-dimensions": "Show Bounding Box Dimensions",
+    "panel.settings.show-dimensions": "Show Dimensions",
     "panel.settings.show-camera-poses": "Show Camera Poses",
     "panel.settings.show-camera-info": "Show Camera Info",
     "panel.settings.reset": "Reset to Defaults",

--- a/static/locales/en.json
+++ b/static/locales/en.json
@@ -280,6 +280,7 @@
 
     "orient.hint": "Place 3 points to define a plane",
     "orient.align": "Align to Grid",
+    "orient.set-pivot": "Set Pivot",
     "orient.clear": "Clear",
 
     "status-bar.splats": "Splats",
@@ -314,7 +315,7 @@
     "tooltip.bottom-toolbar.measure": "Measure",
     "tooltip.bottom-toolbar.orient": "Orient",
     "tooltip.bottom-toolbar.local-space": "Use Local Orientation",
-    "tooltip.bottom-toolbar.bounding-box-center": "Use Bounding Box Center",
+    "tooltip.bottom-toolbar.reset-pivot": "Reset Pivot (Shift: to center)",
 
     "tooltip.timeline.prev-frame": "Previous Frame",
     "tooltip.timeline.play": "Play/Pause",

--- a/static/locales/es.json
+++ b/static/locales/es.json
@@ -88,7 +88,7 @@
     "panel.settings.show-grid": "Mostrar cuadrícula",
     "panel.settings.grid-plane": "Plano de cuadrícula",
     "panel.settings.show-bounding-box": "Mostrar límites",
-    "panel.settings.show-bounding-box-dimensions": "Mostrar dimensiones",
+    "panel.settings.show-dimensions": "Mostrar dimensiones",
     "panel.settings.show-camera-poses": "Mostrar cámaras",
     "panel.settings.show-camera-info": "Mostrar info de cámara",
     "panel.settings.reset": "Restablecer valores predeterminados",

--- a/static/locales/es.json
+++ b/static/locales/es.json
@@ -280,6 +280,7 @@
 
     "orient.hint": "Coloca 3 puntos para definir un plano",
     "orient.align": "Alinear con la cuadrícula",
+    "orient.set-pivot": "Fijar pivote",
     "orient.clear": "Borrar",
 
     "status-bar.splats": "Splats",
@@ -314,7 +315,7 @@
     "tooltip.bottom-toolbar.measure": "Medir",
     "tooltip.bottom-toolbar.orient": "Orientar",
     "tooltip.bottom-toolbar.local-space": "Usar orientación local",
-    "tooltip.bottom-toolbar.bounding-box-center": "Usar centro de límites",
+    "tooltip.bottom-toolbar.reset-pivot": "Restablecer pivote (Mayús: al centro)",
 
     "tooltip.timeline.prev-frame": "Fotograma Anterior",
     "tooltip.timeline.play": "Reproducir/Pausar",

--- a/static/locales/fr.json
+++ b/static/locales/fr.json
@@ -88,7 +88,7 @@
     "panel.settings.show-grid": "Afficher la grille",
     "panel.settings.grid-plane": "Plan de la grille",
     "panel.settings.show-bounding-box": "Afficher limites",
-    "panel.settings.show-bounding-box-dimensions": "Afficher dimensions",
+    "panel.settings.show-dimensions": "Afficher dimensions",
     "panel.settings.show-camera-poses": "Afficher caméras",
     "panel.settings.show-camera-info": "Afficher infos caméra",
     "panel.settings.reset": "Réinitialiser les valeurs par défaut",

--- a/static/locales/fr.json
+++ b/static/locales/fr.json
@@ -280,6 +280,7 @@
 
     "orient.hint": "Placez 3 points pour définir un plan",
     "orient.align": "Aligner sur la grille",
+    "orient.set-pivot": "Définir le pivot",
     "orient.clear": "Effacer",
 
     "status-bar.splats": "Splats",
@@ -314,7 +315,7 @@
     "tooltip.bottom-toolbar.measure": "Mesurer",
     "tooltip.bottom-toolbar.orient": "Orienter",
     "tooltip.bottom-toolbar.local-space": "Espace local gizmo",
-    "tooltip.bottom-toolbar.bounding-box-center": "Utiliser le centre de la limite",
+    "tooltip.bottom-toolbar.reset-pivot": "Réinitialiser le pivot (Maj : au centre)",
 
     "tooltip.timeline.prev-frame": "Image Précédente",
     "tooltip.timeline.play": "Lecture/Pause",

--- a/static/locales/ja.json
+++ b/static/locales/ja.json
@@ -88,7 +88,7 @@
     "panel.settings.show-grid": "グリッド",
     "panel.settings.grid-plane": "グリッド平面",
     "panel.settings.show-bounding-box": "バウンディングボックス",
-    "panel.settings.show-bounding-box-dimensions": "寸法を表示",
+    "panel.settings.show-dimensions": "寸法を表示",
     "panel.settings.show-camera-poses": "カメラを表示",
     "panel.settings.show-camera-info": "カメラ情報を表示",
     "panel.settings.reset": "デフォルトに戻す",

--- a/static/locales/ja.json
+++ b/static/locales/ja.json
@@ -280,6 +280,7 @@
 
     "orient.hint": "3点を配置して平面を定義",
     "orient.align": "グリッドに合わせる",
+    "orient.set-pivot": "ピボットを設定",
     "orient.clear": "クリア",
 
     "status-bar.splats": "スプラット",
@@ -314,7 +315,7 @@
     "tooltip.bottom-toolbar.measure": "計測",
     "tooltip.bottom-toolbar.orient": "向きを調整",
     "tooltip.bottom-toolbar.local-space": "ローカル座標へ切り替え",
-    "tooltip.bottom-toolbar.bounding-box-center": "バウンディングボックスの中心を使用",
+    "tooltip.bottom-toolbar.reset-pivot": "ピボットをリセット（Shift：中心へ）",
 
     "tooltip.timeline.prev-frame": "前のフレーム",
     "tooltip.timeline.play": "再生/一時停止",

--- a/static/locales/ko.json
+++ b/static/locales/ko.json
@@ -88,7 +88,7 @@
     "panel.settings.show-grid": "그리드 표시",
     "panel.settings.grid-plane": "그리드 평면",
     "panel.settings.show-bounding-box": "경계 표시",
-    "panel.settings.show-bounding-box-dimensions": "치수 표시",
+    "panel.settings.show-dimensions": "치수 표시",
     "panel.settings.show-camera-poses": "카메라 표시",
     "panel.settings.show-camera-info": "카메라 정보 표시",
     "panel.settings.reset": "기본값으로 재설정",

--- a/static/locales/ko.json
+++ b/static/locales/ko.json
@@ -280,6 +280,7 @@
 
     "orient.hint": "3개의 점을 배치하여 평면 정의",
     "orient.align": "그리드에 정렬",
+    "orient.set-pivot": "피벗 설정",
     "orient.clear": "지우기",
 
     "status-bar.splats": "스플랫",
@@ -314,7 +315,7 @@
     "tooltip.bottom-toolbar.measure": "측정",
     "tooltip.bottom-toolbar.orient": "방향 조정",
     "tooltip.bottom-toolbar.local-space": "로컬 공간",
-    "tooltip.bottom-toolbar.bounding-box-center": "바운드 중심 사용",
+    "tooltip.bottom-toolbar.reset-pivot": "피벗 재설정 (Shift: 중심으로)",
 
     "tooltip.timeline.prev-frame": "이전 프레임",
     "tooltip.timeline.play": "재생/일시정지",

--- a/static/locales/pt-BR.json
+++ b/static/locales/pt-BR.json
@@ -88,7 +88,7 @@
     "panel.settings.show-grid": "Mostrar Grade",
     "panel.settings.grid-plane": "Plano da Grade",
     "panel.settings.show-bounding-box": "Mostrar Limite",
-    "panel.settings.show-bounding-box-dimensions": "Mostrar Dimensões",
+    "panel.settings.show-dimensions": "Mostrar Dimensões",
     "panel.settings.show-camera-poses": "Mostrar Câmeras",
     "panel.settings.show-camera-info": "Mostrar Info da Câmera",
     "panel.settings.reset": "Redefinir padrões",

--- a/static/locales/pt-BR.json
+++ b/static/locales/pt-BR.json
@@ -280,6 +280,7 @@
 
     "orient.hint": "Posicione 3 pontos para definir um plano",
     "orient.align": "Alinhar à Grade",
+    "orient.set-pivot": "Definir Pivô",
     "orient.clear": "Limpar",
 
     "status-bar.splats": "Splats",
@@ -314,7 +315,7 @@
     "tooltip.bottom-toolbar.measure": "Medir",
     "tooltip.bottom-toolbar.orient": "Orientar",
     "tooltip.bottom-toolbar.local-space": "Usar Orientação Local",
-    "tooltip.bottom-toolbar.bounding-box-center": "Usar Centro da Cena",
+    "tooltip.bottom-toolbar.reset-pivot": "Redefinir Pivô (Shift: para o centro)",
 
     "tooltip.timeline.prev-frame": "Quadro Anterior",
     "tooltip.timeline.play": "Reproduzir/Pausar",

--- a/static/locales/ru.json
+++ b/static/locales/ru.json
@@ -88,7 +88,7 @@
     "panel.settings.show-grid": "Показать сетку",
     "panel.settings.grid-plane": "Плоскость сетки",
     "panel.settings.show-bounding-box": "Показать границы",
-    "panel.settings.show-bounding-box-dimensions": "Показать размеры",
+    "panel.settings.show-dimensions": "Показать размеры",
     "panel.settings.show-camera-poses": "Показать камеры",
     "panel.settings.show-camera-info": "Показать информацию о камере",
     "panel.settings.reset": "Сбросить настройки",

--- a/static/locales/ru.json
+++ b/static/locales/ru.json
@@ -280,6 +280,7 @@
 
     "orient.hint": "Разместите 3 точки, чтобы задать плоскость",
     "orient.align": "Выровнять по сетке",
+    "orient.set-pivot": "Задать опорную точку",
     "orient.clear": "Очистить",
 
     "status-bar.splats": "Сплаты",
@@ -314,7 +315,7 @@
     "tooltip.bottom-toolbar.measure": "Измерить",
     "tooltip.bottom-toolbar.orient": "Ориентация",
     "tooltip.bottom-toolbar.local-space": "Использовать локальную ориентацию",
-    "tooltip.bottom-toolbar.bounding-box-center": "Использовать центр границ",
+    "tooltip.bottom-toolbar.reset-pivot": "Сбросить опорную точку (Shift: к центру)",
 
     "tooltip.timeline.prev-frame": "Предыдущий кадр",
     "tooltip.timeline.play": "Воспроизведение/Пауза",

--- a/static/locales/zh-CN.json
+++ b/static/locales/zh-CN.json
@@ -280,6 +280,7 @@
 
     "orient.hint": "放置3个点以定义平面",
     "orient.align": "对齐到网格",
+    "orient.set-pivot": "设置枢轴",
     "orient.clear": "清除",
 
     "status-bar.splats": "高斯点",
@@ -314,7 +315,7 @@
     "tooltip.bottom-toolbar.measure": "测量",
     "tooltip.bottom-toolbar.orient": "调整方向",
     "tooltip.bottom-toolbar.local-space": "局部坐标系",
-    "tooltip.bottom-toolbar.bounding-box-center": "使用边界中心",
+    "tooltip.bottom-toolbar.reset-pivot": "重置枢轴（Shift：至中心）",
 
     "tooltip.timeline.prev-frame": "上一帧",
     "tooltip.timeline.play": "播放/暂停",

--- a/static/locales/zh-CN.json
+++ b/static/locales/zh-CN.json
@@ -88,7 +88,7 @@
     "panel.settings.show-grid": "显示网格",
     "panel.settings.grid-plane": "网格平面",
     "panel.settings.show-bounding-box": "显示边界",
-    "panel.settings.show-bounding-box-dimensions": "显示尺寸",
+    "panel.settings.show-dimensions": "显示尺寸",
     "panel.settings.show-camera-poses": "显示相机",
     "panel.settings.show-camera-info": "显示相机信息",
     "panel.settings.reset": "恢复默认设置",


### PR DESCRIPTION
## Summary
- Add persistent, undoable local frames derived from Orient tool points.
- Improve Orient and Measure tools with dimension labels, focused framing, point editing, and more stable overlays.
- Default transforms to local space and support resetting the local frame.
- Improve global shortcut handling around controls and modal dialogs.
- Preserve local-frame data when saving and loading scenes.

## Test plan
- Create, move, clear, and frame Orient and Measure points.
- Align a picked plane to each grid plane and set/reset the local frame.
- Verify undo/redo and scene save/load preserve frame changes.
- Toggle dimensions and local/world transform space.
- Confirm shortcuts work normally but remain blocked in dialogs and inputs.