### PR TITLE
Use global pivot button in Orient tool

### DIFF
--- a/src/tools/orient-tool.ts
+++ b/src/tools/orient-tool.ts
@@ -63,9 +63,6 @@ class OrientTool {
         const alignButton = new Button({ class: 'select-toolbar-button', enabled: false });
         i18n.bindText(alignButton, 'orient.align');
 
-        const frameButton = new Button({ class: 'select-toolbar-button', enabled: false });
-        i18n.bindText(frameButton, 'orient.set-pivot');
-
         const clearButton = new Button({ class: 'select-toolbar-button', enabled: false });
         i18n.bindText(clearButton, 'orient.clear');
 
@@ -80,7 +77,6 @@ class OrientTool {
 
         selectToolbar.append(hintLabel);
         selectToolbar.append(alignButton);
-        selectToolbar.append(frameButton);
         selectToolbar.append(clearButton);
         canvasContainer.append(selectToolbar);
 
@@ -186,7 +182,6 @@ class OrientTool {
         const updateButtons = () => {
             const planeReady = !!splat && splat.orientPoints.length === 3 && calcPlane();
             alignButton.enabled = planeReady;
-            frameButton.enabled = planeReady;
             clearButton.enabled = !!splat && splat.orientPoints.length > 0;
         };
 
@@ -346,7 +341,11 @@ class OrientTool {
 
         // make the picked plane the model's local frame without moving it:
         // the transform gizmos and panel use it in local coordinate space
-        frameButton.on('click', () => {
+        events.on('orient.setPivot', () => {
+            if (!active) {
+                return;
+            }
+
             if (!splat || splat.orientPoints.length !== 3 || !calcPlane()) {
                 return;
             }

--- a/src/ui/bottom-toolbar.ts
+++ b/src/ui/bottom-toolbar.ts
@@ -186,7 +186,13 @@ class BottomToolbar extends Container {
         measure.dom.addEventListener('click', () => events.fire('tool.measure'));
         orient.dom.addEventListener('click', () => events.fire('tool.orient'));
         coordSpace.dom.addEventListener('click', () => events.fire('tool.toggleCoordSpace'));
-        origin.dom.addEventListener('click', (e: MouseEvent) => events.fire('pivot.reset', e.shiftKey));
+        origin.dom.addEventListener('click', (e: MouseEvent) => {
+            if (events.invoke('tool.active') === 'orient') {
+                events.fire('orient.setPivot');
+            } else {
+                events.fire('pivot.reset', e.shiftKey);
+            }
+        });
 
         events.on('edit.canUndo', (value: boolean) => {
             undo.enabled = value;
@@ -245,7 +251,9 @@ class BottomToolbar extends Container {
         tooltips.register(measure, tooltip('tooltip.bottom-toolbar.measure'));
         tooltips.register(orient, tooltip('tooltip.bottom-toolbar.orient'));
         tooltips.register(coordSpace, tooltip('tooltip.bottom-toolbar.local-space', 'tool.toggleCoordSpace'));
-        tooltips.register(origin, tooltip('tooltip.bottom-toolbar.reset-pivot'));
+        tooltips.register(origin, () => i18n.t(
+            events.invoke('tool.active') === 'orient' ? 'orient.set-pivot' : 'tooltip.bottom-toolbar.reset-pivot'
+        ));
         tooltips.register(eyedropper, tooltip('tooltip.bottom-toolbar.eyedropper-selection', 'tool.eyedropperSelection'));
     }
 }


### PR DESCRIPTION
## Summary
- Remove the Orient tool’s dedicated Set Pivot button.
- Reuse the global pivot button to set the picked plane as the local frame while Orient is active.
- Update the global button tooltip contextually.

## Testing
- `npm run lint`
- `npm run build`