### PR TITLE
Wait for video muxer writes before finalizing

### DIFF
--- a/src/render.ts
+++ b/src/render.ts
@@ -22,6 +22,9 @@ const FORMAT_CONFIG: Record<string, { create: (streaming: boolean) => Mp4OutputF
     mkv: { create: () => new MkvOutputFormat(), extension: 'mkv' }
 };
 
+// backpressure high-water mark for the encoder queue and pending muxer writes
+const MAX_QUEUE_SIZE = 5;
+
 type ImageSettings = {
     width: number;
     height: number;
@@ -405,10 +408,14 @@ const registerRenderEvents = (scene: Scene, events: Events) => {
                             const encodedPacket = EncodedPacket.fromEncodedChunk(chunk);
                             muxerQueueSize++;
 
-                            // WebCodecs does not await a Promise returned by its
-                            // output callback. Serialize and track packet writes
-                            // explicitly so output.finalize() cannot race ahead
-                            // of the muxer and produce a truncated file.
+                            // WebCodecs ignores a Promise returned by its output
+                            // callback: awaiting the muxer here provides no
+                            // backpressure, and a rejected write becomes an
+                            // unhandled rejection that silently drops packets
+                            // from the finished file. Chain the writes instead
+                            // so failures surface via muxerError, muxerQueueSize
+                            // drives backpressure in the encode loop, and every
+                            // write has settled before output.finalize().
                             muxerWrites = muxerWrites
                             .then(async () => {
                                 if (!muxerError) {
@@ -416,7 +423,7 @@ const registerRenderEvents = (scene: Scene, events: Events) => {
                                 }
                             })
                             .catch((error) => {
-                                muxerError = error;
+                                muxerError = error instanceof Error ? error : new Error(String(error));
                             })
                             .finally(() => {
                                 muxerQueueSize--;
@@ -526,12 +533,12 @@ const registerRenderEvents = (scene: Scene, events: Events) => {
                     });
 
                     // wait for encoder queue to drain if necessary (backpressure handling)
-                    while (encoder.encodeQueueSize > 5) {
+                    while (encoder.encodeQueueSize > MAX_QUEUE_SIZE) {
                         await new Promise<void>((resolve) => {
                             setTimeout(resolve, 1);
                         });
                     }
-                    if (muxerQueueSize > 5) {
+                    if (muxerQueueSize > MAX_QUEUE_SIZE) {
                         await muxerWrites;
                     }
 

--- a/src/render.ts
+++ b/src/render.ts
@@ -393,14 +393,34 @@ const registerRenderEvents = (scene: Scene, events: Events) => {
                 await output.start();
 
                 let encoderError: Error | null = null;
+                let muxerError: Error | null = null;
+                let muxerQueueSize = 0;
+                let muxerWrites = Promise.resolve();
 
                 // helper to create and configure a VideoEncoder instance
                 const createEncoder = () => {
                     encoderError = null;
                     const enc = new VideoEncoder({
-                        output: async (chunk, meta) => {
+                        output: (chunk, meta) => {
                             const encodedPacket = EncodedPacket.fromEncodedChunk(chunk);
-                            await videoSource.add(encodedPacket, meta);
+                            muxerQueueSize++;
+
+                            // WebCodecs does not await a Promise returned by its
+                            // output callback. Serialize and track packet writes
+                            // explicitly so output.finalize() cannot race ahead
+                            // of the muxer and produce a truncated file.
+                            muxerWrites = muxerWrites
+                            .then(async () => {
+                                if (!muxerError) {
+                                    await videoSource.add(encodedPacket, meta);
+                                }
+                            })
+                            .catch((error) => {
+                                muxerError = error;
+                            })
+                            .finally(() => {
+                                muxerQueueSize--;
+                            });
                         },
                         error: (error) => {
                             encoderError = error;
@@ -511,6 +531,9 @@ const registerRenderEvents = (scene: Scene, events: Events) => {
                             setTimeout(resolve, 1);
                         });
                     }
+                    if (muxerQueueSize > 5) {
+                        await muxerWrites;
+                    }
 
                     // if the codec was reclaimed (e.g. browser backgrounded the tab),
                     // recreate the encoder and continue
@@ -521,9 +544,9 @@ const registerRenderEvents = (scene: Scene, events: Events) => {
                     }
 
                     // check for non-recoverable encoder errors
-                    if (encoderError) {
+                    if (encoderError || muxerError) {
                         videoFrame.close();
-                        throw encoderError;
+                        throw encoderError ?? muxerError;
                     }
 
                     encoder.encode(videoFrame, { keyFrame: forceKeyFrame });
@@ -643,6 +666,10 @@ const registerRenderEvents = (scene: Scene, events: Events) => {
 
                 // Flush and finalize output
                 await encoder.flush();
+                await muxerWrites;
+                if (muxerError) {
+                    throw muxerError;
+                }
                 await output.finalize();
 
                 const filename = () => `${baseFilename()}.${fileExtension}`;

--- a/src/render.ts
+++ b/src/render.ts
@@ -539,7 +539,10 @@ const registerRenderEvents = (scene: Scene, events: Events) => {
                             setTimeout(resolve, 1);
                         });
                     }
-                    if (muxerQueueSize > MAX_QUEUE_SIZE) {
+                    // muxerQueueSize is decremented by the write chain settling
+                    // during the await
+                    // eslint-disable-next-line no-unmodified-loop-condition
+                    while (muxerQueueSize > MAX_QUEUE_SIZE) {
                         await muxerWrites;
                     }
 

--- a/src/render.ts
+++ b/src/render.ts
@@ -361,6 +361,8 @@ const registerRenderEvents = (scene: Scene, events: Events) => {
             let equirect: EquirectRenderer | null = null;
             let savedFov = 0;
             let savedOrtho = false;
+            let output: Output | null = null;
+            let muxerWrites = Promise.resolve();
 
             try {
                 const { startFrame, endFrame, frameRate, width, height, bitrate, transparentBg, showDebug, format, codec: codecChoice, projection, levelHorizon } = videoSettings;
@@ -382,7 +384,7 @@ const registerRenderEvents = (scene: Scene, events: Events) => {
                 const encoderConfig = buildVideoEncoderConfig(videoSettings);
                 const codecType = getVideoCodecType(codecChoice);
 
-                const output = new Output({
+                output = new Output({
                     format: outputFormat,
                     target
                 });
@@ -398,7 +400,6 @@ const registerRenderEvents = (scene: Scene, events: Events) => {
                 let encoderError: Error | null = null;
                 let muxerError: Error | null = null;
                 let muxerQueueSize = 0;
-                let muxerWrites = Promise.resolve();
 
                 // helper to create and configure a VideoEncoder instance
                 const createEncoder = () => {
@@ -711,6 +712,35 @@ const registerRenderEvents = (scene: Scene, events: Events) => {
 
                 return !cancelled;
             } catch (error) {
+                // stop the encoder so no further packets are queued while
+                // cleaning up
+                if (encoder && encoder.state !== 'closed') {
+                    encoder.close();
+                }
+
+                // the output's stream target holds a writer lock on the
+                // destination file stream. drain in-flight muxer writes and
+                // cancel the output to release it, otherwise the caller
+                // cannot remove the partial file
+                if (output) {
+                    try {
+                        await muxerWrites;
+                        await output.cancel();
+                    } catch {
+                        // output already finalized or its target already closed
+                    }
+                }
+
+                // tagged 360 exports write to the file stream directly, so
+                // close it here too (mirrors render.image failure handling)
+                if (fileStream) {
+                    try {
+                        await fileStream.close();
+                    } catch {
+                        // stream already closed or still locked by the output
+                    }
+                }
+
                 await events.invoke('showPopup', {
                     type: 'error',
                     header: i18n.t('panel.render.failed'),


### PR DESCRIPTION
## Summary
- surface muxer write failures instead of losing them as unhandled rejections
- apply real muxer backpressure alongside encoder backpressure
- settle every muxer write before finalizing the output container
- release the destination file stream when an export fails, so the caller can remove the partial file

WebCodecs ignores a Promise returned from a `VideoEncoder` output callback, so the previous `await videoSource.add(...)` provided no backpressure, and a failed write (writer error, disk full, timestamp validation) became an unhandled rejection. The export would continue, silently drop packets, and finalize a shorter file with no visible error — producing truncated files with incorrect duration.

This change chains packet writes so any failure aborts the export with a visible error, bounds memory when the muxer is slower than the encoder, and guarantees `output.finalize()` is only called once every sample has been added (its documented contract), rather than relying on mediabunny's internal FIFO mutex ordering.

Failed exports also leaked the output's hold on the destination file: mediabunny's `StreamTarget` acquires a writer lock on the `FileSystemWritableFileStream` for the duration of the export, and the catch block returned without `output.cancel()`, so the caller's `fileHandle.remove()` failed with `NoModificationAllowedError` and left the partial file on disk behind a second error popup. Tagged 360 mp4/mov exports, which write to the stream directly, similarly left it open. On failure the export now stops the encoder, drains in-flight muxer writes, cancels the output (closing its writer-locked stream target), and closes the directly-owned stream before showing the error.

Known residual gap: if `output.finalize()` itself throws mid-write, mediabunny's `cancel()` early-returns without closing targets, so the stream stays locked — not fixable from the application side.

## Verification
- `npm run lint`
- `npm run lint:locales`
- `npm run build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
