### PR TITLE
Add 8K render resolutions

### DIFF
--- a/src/render.ts
+++ b/src/render.ts
@@ -100,6 +100,10 @@ const registerRenderEvents = (scene: Scene, events: Events) => {
 
     events.function('render.baseFilename', baseFilename);
 
+    // largest render target dimension the device supports; used by the render
+    // dialogs to disable resolutions the gpu cannot produce
+    events.function('render.maxTextureSize', () => scene.graphicsDevice.maxTextureSize);
+
     // wait for postrender to fire
     const postRender = () => {
         return new Promise<boolean>((resolve, reject) => {

--- a/src/ui/image-settings-dialog.ts
+++ b/src/ui/image-settings-dialog.ts
@@ -60,14 +60,15 @@ class ImageSettingsDialog extends Container {
 
         // preset
 
-        // 360 output is 2:1 equirectangular, capped at 4096 wide to stay
-        // within common encoder dimension limits (mirrors video's presets)
+        // 360 output is 2:1 equirectangular (mirrors video's presets)
         const buildPresetOptions = () => {
             return projectionSelect.value === 'equirect' ? [
                 { v: '360-1k', t: '1024x512' },
                 { v: '360-2k', t: '2048x1024' },
                 { v: '360-4k', t: '3840x1920' },
                 { v: '360-4096', t: '4096x2048' },
+                { v: '360-8k', t: '7680x3840' },
+                { v: '360-8192', t: '8192x4096' },
                 { v: 'custom', t: i18n.t('popup.render-image.resolution.custom') }
             ] : [
                 { v: 'viewport', t: i18n.t('popup.render-image.resolution.current') },
@@ -218,7 +219,9 @@ class ImageSettingsDialog extends Container {
                 '360-1k': 1024,
                 '360-2k': 2048,
                 '360-4k': 3840,
-                '360-4096': 4096
+                '360-4096': 4096,
+                '360-8k': 7680,
+                '360-8192': 8192
             };
 
             const heights: Record<string, number> = {
@@ -229,7 +232,9 @@ class ImageSettingsDialog extends Container {
                 '360-1k': 512,
                 '360-2k': 1024,
                 '360-4k': 1920,
-                '360-4096': 2048
+                '360-4096': 2048,
+                '360-8k': 3840,
+                '360-8192': 4096
             };
 
             resolutionValue.value = [

--- a/src/ui/video-settings-dialog.ts
+++ b/src/ui/video-settings-dialog.ts
@@ -15,7 +15,8 @@ const standardResolutions: ResolutionOption[] = [
     { v: '720', t: '1280x720' },
     { v: '1080', t: '1920x1080' },
     { v: '1440', t: '2560x1440' },
-    { v: '4k', t: '3840x2160' }
+    { v: '4k', t: '3840x2160' },
+    { v: '8k', t: '7680x4320' }
 ];
 
 // 360 output is 2:1 equirectangular. Encoder support for each preset is
@@ -24,7 +25,9 @@ const equirectResolutions: ResolutionOption[] = [
     { v: '360-1k', t: '1024x512' },
     { v: '360-2k', t: '2048x1024' },
     { v: '360-4k', t: '3840x1920' },
-    { v: '360-4096', t: '4096x2048' }
+    { v: '360-4096', t: '4096x2048' },
+    { v: '360-8k', t: '7680x3840' },
+    { v: '360-8192', t: '8192x4096' }
 ];
 
 const widths: Record<string, number> = {
@@ -33,10 +36,13 @@ const widths: Record<string, number> = {
     '1080': 1920,
     '1440': 2560,
     '4k': 3840,
+    '8k': 7680,
     '360-1k': 1024,
     '360-2k': 2048,
     '360-4k': 3840,
-    '360-4096': 4096
+    '360-4096': 4096,
+    '360-8k': 7680,
+    '360-8192': 8192
 };
 
 const heights: Record<string, number> = {
@@ -45,10 +51,13 @@ const heights: Record<string, number> = {
     '1080': 1080,
     '1440': 1440,
     '4k': 2160,
+    '8k': 4320,
     '360-1k': 512,
     '360-2k': 1024,
     '360-4k': 1920,
-    '360-4096': 2048
+    '360-4096': 2048,
+    '360-8k': 3840,
+    '360-8192': 4096
 };
 
 const frameRates: Record<string, number> = {
@@ -77,10 +86,13 @@ const bppfFactors: Record<string, number> = {
     '1080': 1 / 3,
     '1440': 1 / 4,
     '4k': 1 / 5,
+    '8k': 1 / 7,
     '360-1k': 1,
     '360-2k': 1 / 3,
     '360-4k': 1 / 5,
-    '360-4096': 1 / 5
+    '360-4096': 1 / 5,
+    '360-8k': 1 / 7,
+    '360-8192': 1 / 7
 };
 
 const codecNames: Record<VideoCodecChoice, string> = {
@@ -576,7 +588,17 @@ class VideoSettingsDialog extends Container {
             }, 150);
 
             try {
+                // the offscreen and equirect render targets allocate textures
+                // at the output size, so resolutions beyond the device texture
+                // limit can never render even when the encoder supports them
+                const maxTextureSize = (events.invoke('render.maxTextureSize') as number) ?? Infinity;
+
                 const results = await Promise.all(activeResolutionOptions().map(async (option) => {
+                    const { width, height } = dimensionsFor(option.v);
+                    if (Math.max(width, height) > maxTextureSize) {
+                        return [option.v, false] as const;
+                    }
+
                     const config = buildVideoEncoderConfig(encodingSettingsFor(option.v));
                     const support = await VideoEncoder.isConfigSupported(config);
                     return [option.v, support.supported] as const;

--- a/src/video-config.ts
+++ b/src/video-config.ts
@@ -17,11 +17,114 @@ type VideoSettings = {
 
 type MuxerVideoCodec = 'avc' | 'hevc' | 'vp9' | 'av1';
 
-const CODEC_CONFIG: Record<VideoCodecChoice, { type: MuxerVideoCodec; codec: (height: number) => string }> = {
-    h264: { type: 'avc', codec: h => (h < 1080 ? 'avc1.420028' : 'avc1.640033') }, // H.264 Constrained Baseline/High profile
-    h265: { type: 'hevc', codec: () => 'hev1.1.6.L120.B0' },                       // H.265 Main profile, Level 4.0
-    vp9: { type: 'vp9', codec: () => 'vp09.00.10.08' },                            // VP9 Profile 0, Level 1.0
-    av1: { type: 'av1', codec: () => 'av01.0.05M.08' }                             // AV1 Main Profile, Level 3.1
+type EncoderParams = {
+    width: number;
+    height: number;
+    frameRate: number;
+};
+
+// Each codec string declares a level, and levels cap the frame size and
+// pixel rate a stream may carry. Declaring a level too low for the requested
+// dimensions makes VideoEncoder.isConfigSupported() reject configurations the
+// hardware could otherwise encode (notably 8K), so pick the smallest level
+// from the spec tables that covers the requested resolution and frame rate.
+
+// h.264: [level_idc, max frame size in 16x16 macroblocks, max macroblocks/s]
+// (Rec. ITU-T H.264 Table A-1)
+const H264_LEVELS: [number, number, number][] = [
+    [40, 8192, 245760],
+    [42, 8704, 522240],
+    [50, 22080, 589824],
+    [51, 36864, 983040],
+    [52, 36864, 2073600],
+    [60, 139264, 4177920],
+    [61, 139264, 8355840],
+    [62, 139264, 16711680]
+];
+
+// h.265: [level_idc, max luma picture size, max luma samples/s]
+// (Rec. ITU-T H.265 Table A.8)
+const HEVC_LEVELS: [number, number, number][] = [
+    [120, 2228224, 66846720],
+    [123, 2228224, 133693440],
+    [150, 8912896, 267386880],
+    [153, 8912896, 534773760],
+    [156, 8912896, 1069547520],
+    [180, 35651584, 1069547520],
+    [183, 35651584, 2139095040],
+    [186, 35651584, 4278190080]
+];
+
+// vp9: [level, max luma picture size, max luma samples/s]
+// (VP9 Bitstream & Decoding Process Specification, Annex A)
+const VP9_LEVELS: [number, number, number][] = [
+    [10, 36864, 829440],
+    [11, 73728, 2764800],
+    [20, 122880, 4608000],
+    [21, 245760, 9216000],
+    [30, 552960, 20736000],
+    [31, 983040, 36864000],
+    [40, 2228224, 83558400],
+    [41, 2228224, 160432128],
+    [50, 8912896, 311951360],
+    [51, 8912896, 588251136],
+    [52, 8912896, 1176502272],
+    [60, 35651584, 1176502272],
+    [61, 35651584, 2353004544],
+    [62, 35651584, 4706009088]
+];
+
+// av1: [seq_level_idx, max picture size, max display rate, max width, max height]
+// (AV1 Bitstream & Decoding Process Specification, Annex A); starts at level
+// 3.1, the historical floor
+const AV1_LEVELS: [number, number, number, number, number][] = [
+    [5, 1065024, 31950720, 5504, 3096],
+    [8, 2359296, 70778880, 6144, 3456],
+    [9, 2359296, 141557760, 6144, 3456],
+    [12, 8912896, 267386880, 8192, 4352],
+    [13, 8912896, 534773760, 8192, 4352],
+    [14, 8912896, 1069547520, 8192, 4352],
+    [16, 35651584, 1069547520, 16384, 8704],
+    [17, 35651584, 2139095040, 16384, 8704],
+    [18, 35651584, 4278190080, 16384, 8704]
+];
+
+const h264Codec = ({ width, height, frameRate }: EncoderParams) => {
+    const macroblocks = Math.ceil(width / 16) * Math.ceil(height / 16);
+    // constrained baseline profile level 4.0 for sub-1080 frames, high
+    // profile level 5.1 otherwise; raise the level only when the frame size
+    // or macroblock rate demands it
+    const [profile, minLevel] = height < 1080 ? ['4200', 40] : ['6400', 51];
+    const level = H264_LEVELS.find(([idc, maxFs, maxRate]) => idc >= minLevel && macroblocks <= maxFs && macroblocks * frameRate <= maxRate)?.[0] ?? 62;
+    return `avc1.${profile}${level.toString(16).padStart(2, '0')}`;
+};
+
+// h.265 main profile, main tier
+const h265Codec = ({ width, height, frameRate }: EncoderParams) => {
+    const samples = width * height;
+    const level = HEVC_LEVELS.find(([, maxPs, maxSr]) => samples <= maxPs && samples * frameRate <= maxSr)?.[0] ?? 186;
+    return `hev1.1.6.L${level}.B0`;
+};
+
+// vp9 profile 0, 8-bit
+const vp9Codec = ({ width, height, frameRate }: EncoderParams) => {
+    const samples = width * height;
+    const level = VP9_LEVELS.find(([, maxPs, maxSr]) => samples <= maxPs && samples * frameRate <= maxSr)?.[0] ?? 62;
+    return `vp09.00.${level}.08`;
+};
+
+// av1 main profile, main tier, 8-bit
+const av1Codec = ({ width, height, frameRate }: EncoderParams) => {
+    const samples = width * height;
+    const levelIdx = AV1_LEVELS.find(([, maxPs, maxRate, maxWidth, maxHeight]) => samples <= maxPs && samples * frameRate <= maxRate && width <= maxWidth && height <= maxHeight)?.[0] ?? 18;
+    return `av01.0.${String(levelIdx).padStart(2, '0')}M.08`;
+};
+
+const CODEC_CONFIG: Record<VideoCodecChoice, { type: MuxerVideoCodec; codec: (params: EncoderParams) => string }> = {
+    h264: { type: 'avc', codec: h264Codec },
+    h265: { type: 'hevc', codec: h265Codec },
+    vp9: { type: 'vp9', codec: vp9Codec },
+    av1: { type: 'av1', codec: av1Codec }
 };
 
 const getVideoCodecType = (codecChoice: VideoCodecChoice): MuxerVideoCodec => {
@@ -35,7 +138,7 @@ const buildVideoEncoderConfig = (
     const codecConfig = CODEC_CONFIG[codecChoice] ?? CODEC_CONFIG.h264;
 
     return {
-        codec: codecConfig.codec(height),
+        codec: codecConfig.codec({ width, height, frameRate }),
         width,
         height,
         bitrate,


### PR DESCRIPTION
Fixes #989

Adds 8K output support to the video render dialog, plus matching 360 presets in the image render dialog.

### New presets

| Dialog | Projection | Added |
|---|---|---|
| Render Video | Standard | 7680x4320 |
| Render Video | 360 Equirectangular | 7680x3840, 8192x4096 |
| Render Image | 360 Equirectangular | 7680x3840, 8192x4096 |

### Codec levels are now computed instead of fixed

The codec strings previously hard-coded levels (H.264 `5.1`, HEVC `4.0`, VP9 `1.0`, AV1 `3.1`). Levels cap the frame size and pixel rate a stream may carry, so an under-declared level can make `VideoEncoder.isConfigSupported()` reject configurations the hardware could otherwise encode -- 8K exceeds all of the old levels. `video-config.ts` now picks the smallest level from the spec tables (H.264 Table A-1, H.265 Table A.8, VP9/AV1 Annex A) that covers the requested resolution and frame rate, e.g. 8K30 HEVC yields `hev1.1.6.L180.B0` (level 6.0). Sub-1080 H.264 keeps its historical Constrained Baseline 4.0 string and AV1 keeps its 3.1 floor, so existing low-resolution outputs are unchanged.

### Device capability gating

- Encoder support continues to be probed per preset when the dialog opens, so 8K options are automatically disabled (with the existing explanatory message) on devices whose encoders cannot handle them. In practice: 8K H.264 is unavailable nearly everywhere, 8K HEVC requires capable hardware, and 8K VP9/AV1 are widely available via software encoders.
- Resolutions larger than the device maximum texture size are now also disabled, via a new `render.maxTextureSize` query. The offscreen and equirect render targets allocate textures at the output size, and the engine does not clamp them, so these presets could never render regardless of encoder support.

No changes to the render pipeline itself were needed: the equirect cube faces already clamp to `maxTextureSize` (4096px faces for an 8192-wide target, preserving the existing ~1.8x equator supersampling ratio) and spherical metadata injection is resolution-independent.

### Testing

- `npm run lint` and `npm run build` pass.
- Codec level computation verified against a 32-case expected-string matrix plus an exhaustive preset x frame-rate sweep (no undefined/NaN leakage).
- End-to-end 8K 360 render verified in Chrome on Windows: 8192x4096 AV1/WebM renders, muxes, and decodes back at full resolution with correct content (verified against a bright background color).
- Probed old-vs-new codec strings for every existing preset whose string changed (e.g. 4K HEVC `L120` -> `L150`): no supported -> unsupported regressions.
- Confirmed the dialog correctly lists the new presets and disables 8K H.264/HEVC on hardware that cannot encode them, while leaving 8K VP9/AV1 selectable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)