### PR TITLE
Use public layer clear API for PlayCanvas 2.21

### DIFF
--- a/src/camera.ts
+++ b/src/camera.ts
@@ -556,18 +556,13 @@ class Camera extends Element {
             this.splatPass.addLayer(this.camera, scene.splatLayer, false, false);
             this.splatPass.addLayer(this.camera, scene.splatLayer, true, false);
 
-            // configure gizmo pass. the depth clear is attached to the first
-            // render action, which is the tool overlay layer: its ghost
-            // materials ignore depth entirely, so the clear effectively
-            // belongs to the gizmo layers that follow
+            // configure gizmo pass. the gizmo layer clears depth and stencil
+            // before its opaque step, after the depth-independent tool overlay
             this.gizmoPass.init(this.mainTarget);
             this.gizmoPass.addLayer(this.camera, scene.overlayLayer, false, false);
             this.gizmoPass.addLayer(this.camera, scene.overlayLayer, true, false);
-            this.gizmoPass.addLayer(this.camera, scene.gizmoLayer, false, false);
+            this.gizmoPass.addLayer(this.camera, scene.gizmoLayer, false, true);
             this.gizmoPass.addLayer(this.camera, scene.gizmoLayer, true, false);
-            const firstGizmoStep = (this.gizmoPass as any).layerRenderSteps[0];
-            firstGizmoStep.clearDepth = true;
-            firstGizmoStep.clearStencil = true;
 
             this.finalPass.init(null);
 

--- a/src/camera.ts
+++ b/src/camera.ts
@@ -565,8 +565,9 @@ class Camera extends Element {
             this.gizmoPass.addLayer(this.camera, scene.overlayLayer, true, false);
             this.gizmoPass.addLayer(this.camera, scene.gizmoLayer, false, false);
             this.gizmoPass.addLayer(this.camera, scene.gizmoLayer, true, false);
-            this.gizmoPass.renderActions[0].clearDepth = true;
-            this.gizmoPass.renderActions[0].clearStencil = true;
+            const firstGizmoStep = (this.gizmoPass as any).layerRenderSteps[0];
+            firstGizmoStep.clearDepth = true;
+            firstGizmoStep.clearStencil = true;
 
             this.finalPass.init(null);
 

--- a/src/scene.ts
+++ b/src/scene.ts
@@ -207,8 +207,12 @@ class Scene {
         // measure/orient tool overlays, which show through occluding gaussians)
         this.overlayLayer = new Layer({ name: 'ToolOverlay' });
 
-        // gizmo layer
-        this.gizmoLayer = new Layer({ name: 'Gizmo' });
+        // gizmo layer - clear scene depth before drawing gizmos so they remain visible
+        this.gizmoLayer = new Layer({
+            name: 'Gizmo',
+            clearDepthBuffer: true,
+            clearStencilBuffer: true
+        });
 
         const layers = this.app.scene.layers;
         layers.push(this.splatLayer);


### PR DESCRIPTION
## Summary
- Configure depth and stencil clearing on the Gizmo layer.
- Enable automatic clearing only for the opaque gizmo render step.
- Remove reliance on the retired private `renderActions` API.

## Testing
- `npm run build`
- `npm run lint`
- `npx tsc --noEmit`
- Verified runtime gizmo clear configuration.