### PR TITLE
Add selective transform copy and paste controls

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -77,6 +77,8 @@ SuperSplat can translate, rotate and scale splats. To do this, select a splat in
 
 To achieve fine grain control over the transform of the selected splat, you can use the TRANSFORM panel (below the SCENE MANAGER panel).
 
+Use the copy menu in the TRANSFORM panel to copy position, rotation, both position and rotation, or the complete transform. Select another splat and use the paste button to apply the copied properties.
+
 To set the origin of the currently active gizmo, double click anywhere in the 3D view.
 
 ## Merging Splats

--- a/src/ui/scene-panel.ts
+++ b/src/ui/scene-panel.ts
@@ -2,7 +2,9 @@ import { Button, Container, Element, Label } from '@playcanvas/pcui';
 
 import { Events } from '../events';
 import { i18n } from './localization';
+import { MenuPanel } from './menu-panel';
 import { SplatList } from './splat-list';
+import arrowSvg from './svg/arrow.svg';
 import copyTransformSvg from './svg/copy-transform.svg';
 import sceneImportSvg from './svg/import.svg';
 import sceneNewSvg from './svg/new.svg';
@@ -113,11 +115,12 @@ class ScenePanel extends Container {
         });
         i18n.bindText(transformLabel, 'panel.scene.transform');
 
-        const copyTransform = new Button({
-            class: 'panel-header-button',
+        const copyTransformOptions = new Button({
+            class: ['panel-header-button', 'transform-copy-options'],
             enabled: false
         });
-        copyTransform.dom.appendChild(createSvg(copyTransformSvg));
+        copyTransformOptions.dom.appendChild(createSvg(copyTransformSvg));
+        copyTransformOptions.dom.appendChild(createSvg(arrowSvg));
 
         const pasteTransform = new Button({
             class: 'panel-header-button',
@@ -127,40 +130,76 @@ class ScenePanel extends Container {
 
         let hasSelection = false;
         const updateTransformActions = () => {
-            copyTransform.enabled = hasSelection;
+            copyTransformOptions.enabled = hasSelection;
             pasteTransform.enabled = hasSelection && transform.hasCopiedTransform;
         };
+
+        const copyTransformMenu = new MenuPanel([{
+            text: () => i18n.t('menu.transform.copy-position'),
+            onSelect: () => {
+                transform.copyTransform({ position: true });
+                updateTransformActions();
+            }
+        }, {
+            text: () => i18n.t('menu.transform.copy-rotation'),
+            onSelect: () => {
+                transform.copyTransform({ rotation: true });
+                updateTransformActions();
+            }
+        }, {
+            text: () => i18n.t('menu.transform.copy-position-rotation'),
+            onSelect: () => {
+                transform.copyTransform({ position: true, rotation: true });
+                updateTransformActions();
+            }
+        }, {
+            text: () => i18n.t('menu.transform.copy-all'),
+            onSelect: () => {
+                transform.copyTransform({ position: true, rotation: true, scale: true });
+                updateTransformActions();
+            }
+        }]);
+        copyTransformMenu.class.add('transform-copy-menu');
+        document.body.appendChild(copyTransformMenu.dom);
 
         events.on('selection.changed', (selection) => {
             hasSelection = !!selection;
             updateTransformActions();
         });
 
-        copyTransform.on('click', () => {
-            if (transform.copyTransform()) {
-                updateTransformActions();
-            }
+        copyTransformOptions.on('click', () => {
+            copyTransformMenu.position(copyTransformOptions.dom, 'bottom', 2);
+            copyTransformMenu.hidden = !copyTransformMenu.hidden;
         });
 
         pasteTransform.on('click', () => {
             transform.pasteTransform();
         });
 
-        i18n.onChange(() => copyTransform.dom.setAttribute(
+        i18n.onChange(() => copyTransformOptions.dom.setAttribute(
             'aria-label',
-            i18n.t('tooltip.scene.copy-transform')
-        ), copyTransform);
+            i18n.t('tooltip.scene.copy-transform-options')
+        ), copyTransformOptions);
         i18n.onChange(() => pasteTransform.dom.setAttribute(
             'aria-label',
             i18n.t('tooltip.scene.paste-transform')
         ), pasteTransform);
-        tooltips.register(copyTransform, () => i18n.t('tooltip.scene.copy-transform'), 'top');
+        tooltips.register(copyTransformOptions, () => i18n.t('tooltip.scene.copy-transform-options'), 'top');
         tooltips.register(pasteTransform, () => i18n.t('tooltip.scene.paste-transform'), 'top');
 
         transformHeader.append(transformIcon);
         transformHeader.append(transformLabel);
-        transformHeader.append(copyTransform);
+        transformHeader.append(copyTransformOptions);
         transformHeader.append(pasteTransform);
+
+        const closeCopyTransformMenu = (event: PointerEvent) => {
+            if (!copyTransformMenu.dom.contains(event.target as Node) &&
+                !copyTransformOptions.dom.contains(event.target as Node)) {
+                copyTransformMenu.hidden = true;
+            }
+        };
+        window.addEventListener('pointerdown', closeCopyTransformMenu, true);
+        window.addEventListener('pointerup', closeCopyTransformMenu, true);
 
         this.append(sceneHeader);
         this.append(splatListContainer);

--- a/src/ui/scene-panel.ts
+++ b/src/ui/scene-panel.ts
@@ -1,10 +1,12 @@
-import { Container, Element, Label } from '@playcanvas/pcui';
+import { Button, Container, Element, Label } from '@playcanvas/pcui';
 
 import { Events } from '../events';
 import { i18n } from './localization';
 import { SplatList } from './splat-list';
+import copyTransformSvg from './svg/copy-transform.svg';
 import sceneImportSvg from './svg/import.svg';
 import sceneNewSvg from './svg/new.svg';
+import pasteTransformSvg from './svg/paste-transform.svg';
 import soloSvg from './svg/solo.svg';
 import { Tooltips } from './tooltips';
 import { Transform } from './transform';
@@ -95,6 +97,8 @@ class ScenePanel extends Container {
         });
         splatListContainer.append(splatList);
 
+        const transform = new Transform(events);
+
         const transformHeader = new Container({
             class: 'panel-header'
         });
@@ -109,13 +113,59 @@ class ScenePanel extends Container {
         });
         i18n.bindText(transformLabel, 'panel.scene.transform');
 
+        const copyTransform = new Button({
+            class: 'panel-header-button',
+            enabled: false
+        });
+        copyTransform.dom.appendChild(createSvg(copyTransformSvg));
+
+        const pasteTransform = new Button({
+            class: 'panel-header-button',
+            enabled: false
+        });
+        pasteTransform.dom.appendChild(createSvg(pasteTransformSvg));
+
+        let hasSelection = false;
+        const updateTransformActions = () => {
+            copyTransform.enabled = hasSelection;
+            pasteTransform.enabled = hasSelection && transform.hasCopiedTransform;
+        };
+
+        events.on('selection.changed', (selection) => {
+            hasSelection = !!selection;
+            updateTransformActions();
+        });
+
+        copyTransform.on('click', () => {
+            if (transform.copyTransform()) {
+                updateTransformActions();
+            }
+        });
+
+        pasteTransform.on('click', () => {
+            transform.pasteTransform();
+        });
+
+        i18n.onChange(() => copyTransform.dom.setAttribute(
+            'aria-label',
+            i18n.t('tooltip.scene.copy-transform')
+        ), copyTransform);
+        i18n.onChange(() => pasteTransform.dom.setAttribute(
+            'aria-label',
+            i18n.t('tooltip.scene.paste-transform')
+        ), pasteTransform);
+        tooltips.register(copyTransform, () => i18n.t('tooltip.scene.copy-transform'), 'top');
+        tooltips.register(pasteTransform, () => i18n.t('tooltip.scene.paste-transform'), 'top');
+
         transformHeader.append(transformIcon);
         transformHeader.append(transformLabel);
+        transformHeader.append(copyTransform);
+        transformHeader.append(pasteTransform);
 
         this.append(sceneHeader);
         this.append(splatListContainer);
         this.append(transformHeader);
-        this.append(new Transform(events));
+        this.append(transform);
         this.append(new Element({
             class: 'panel-header',
             height: 20

--- a/src/ui/scss/scene-panel.scss
+++ b/src/ui/scss/scene-panel.scss
@@ -19,6 +19,20 @@
     }
 }
 
+.transform-copy-options {
+    gap: 1px;
+
+    svg:last-child {
+        width: 10px;
+        height: 10px;
+        transform: rotate(90deg);
+    }
+}
+
+.transform-copy-menu {
+    z-index: 20;
+}
+
 .splat-list-container {
     max-height: 300px;
     overflow: auto;

--- a/src/ui/svg/copy-transform.svg
+++ b/src/ui/svg/copy-transform.svg
@@ -1,0 +1,4 @@
+<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+<rect x="6" y="6" width="7" height="7" rx="1.5" stroke="currentColor" stroke-width="1.25"/>
+<path d="M10 6V4.5C10 3.67157 9.32843 3 8.5 3H4.5C3.67157 3 3 3.67157 3 4.5V8.5C3 9.32843 3.67157 10 4.5 10H6" stroke="currentColor" stroke-width="1.25" stroke-linecap="round"/>
+</svg>

--- a/src/ui/svg/paste-transform.svg
+++ b/src/ui/svg/paste-transform.svg
@@ -1,0 +1,6 @@
+<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M6 3.5H10" stroke="currentColor" stroke-width="1.25" stroke-linecap="round"/>
+<path d="M5 5V4C5 3.44772 5.44772 3 6 3H10C10.5523 3 11 3.44772 11 4V5" stroke="currentColor" stroke-width="1.25"/>
+<path d="M11 4.5H12C12.5523 4.5 13 4.94772 13 5.5V12C13 12.5523 12.5523 13 12 13H6.5C5.94772 13 5.5 12.5523 5.5 12V10.5" stroke="currentColor" stroke-width="1.25" stroke-linecap="round"/>
+<path d="M3 8H9M7 6L9 8L7 10" stroke="currentColor" stroke-width="1.25" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/ui/transform.ts
+++ b/src/ui/transform.ts
@@ -2,12 +2,17 @@ import { Container, ContainerArgs, Label, NumericInput, VectorInput } from '@pla
 import { Quat, Vec3 } from 'playcanvas';
 
 import { Events } from '../events';
+import { Transform as TransformData } from '../transform';
 import { i18n } from './localization';
 import { Pivot } from '../pivot';
 
 const v = new Vec3();
 
 class Transform extends Container {
+    private events: Events;
+
+    private copiedTransform: TransformData | null = null;
+
     constructor(events: Events, args: ContainerArgs = {}) {
         args = {
             ...args,
@@ -15,6 +20,7 @@ class Transform extends Container {
         };
 
         super(args);
+        this.events = events;
 
         // position
         const position = new Container({
@@ -171,6 +177,32 @@ class Transform extends Container {
         events.on('pivot.ended', (pivot: Pivot) => {
             updateUI(pivot);
         });
+    }
+
+    copyTransform(): boolean {
+        if (!this.events.invoke('selection')) {
+            return false;
+        }
+
+        const pivot = this.events.invoke('pivot') as Pivot;
+        this.copiedTransform = pivot.transform.clone();
+        return true;
+    }
+
+    pasteTransform(): boolean {
+        if (!this.copiedTransform || !this.events.invoke('selection')) {
+            return false;
+        }
+
+        const pivot = this.events.invoke('pivot') as Pivot;
+        pivot.start();
+        pivot.move(this.copiedTransform);
+        pivot.end();
+        return true;
+    }
+
+    get hasCopiedTransform(): boolean {
+        return this.copiedTransform !== null;
     }
 }
 

--- a/src/ui/transform.ts
+++ b/src/ui/transform.ts
@@ -8,10 +8,19 @@ import { Pivot } from '../pivot';
 
 const v = new Vec3();
 
+type TransformComponents = {
+    position?: boolean;
+    rotation?: boolean;
+    scale?: boolean;
+};
+
 class Transform extends Container {
     private events: Events;
 
-    private copiedTransform: TransformData | null = null;
+    private copiedTransform: {
+        transform: TransformData;
+        components: TransformComponents;
+    } | null = null;
 
     constructor(events: Events, args: ContainerArgs = {}) {
         args = {
@@ -179,13 +188,16 @@ class Transform extends Container {
         });
     }
 
-    copyTransform(): boolean {
+    copyTransform(components: TransformComponents): boolean {
         if (!this.events.invoke('selection')) {
             return false;
         }
 
         const pivot = this.events.invoke('pivot') as Pivot;
-        this.copiedTransform = pivot.transform.clone();
+        this.copiedTransform = {
+            transform: pivot.transform.clone(),
+            components: { ...components }
+        };
         return true;
     }
 
@@ -195,8 +207,21 @@ class Transform extends Container {
         }
 
         const pivot = this.events.invoke('pivot') as Pivot;
+        const target = pivot.transform.clone();
+        const { transform, components } = this.copiedTransform;
+
+        if (components.position) {
+            target.position.copy(transform.position);
+        }
+        if (components.rotation) {
+            target.rotation.copy(transform.rotation);
+        }
+        if (components.scale) {
+            target.scale.copy(transform.scale);
+        }
+
         pivot.start();
-        pivot.move(this.copiedTransform);
+        pivot.move(target);
         pivot.end();
         return true;
     }

--- a/static/locales/de.json
+++ b/static/locales/de.json
@@ -345,6 +345,8 @@
     "tooltip.scene.solo": "Auswahl solo anzeigen",
     "tooltip.scene.import": "Szene importieren",
     "tooltip.scene.new": "Neue Szene",
+    "tooltip.scene.copy-transform": "Transformation kopieren",
+    "tooltip.scene.paste-transform": "Transformation einfügen",
 
     "tooltip.status-bar.timeline": "Zeitleisten-Panel umschalten",
     "tooltip.status-bar.splat-data": "Splat-Daten-Panel umschalten",

--- a/static/locales/de.json
+++ b/static/locales/de.json
@@ -17,6 +17,11 @@
     "menu.edit.duplicate": "Duplizieren",
     "menu.edit.separate": "Separieren",
 
+    "menu.transform.copy-position": "Position kopieren",
+    "menu.transform.copy-rotation": "Drehung kopieren",
+    "menu.transform.copy-position-rotation": "Position und Drehung kopieren",
+    "menu.transform.copy-all": "Alle Transformationen kopieren",
+
     "menu.select": "Auswahl",
     "menu.select.all": "Alles",
     "menu.select.none": "Aufheben",
@@ -345,7 +350,7 @@
     "tooltip.scene.solo": "Auswahl solo anzeigen",
     "tooltip.scene.import": "Szene importieren",
     "tooltip.scene.new": "Neue Szene",
-    "tooltip.scene.copy-transform": "Transformation kopieren",
+    "tooltip.scene.copy-transform-options": "Kopieroptionen für Transformation",
     "tooltip.scene.paste-transform": "Transformation einfügen",
 
     "tooltip.status-bar.timeline": "Zeitleisten-Panel umschalten",

--- a/static/locales/en.json
+++ b/static/locales/en.json
@@ -345,6 +345,8 @@
     "tooltip.scene.solo": "Solo Selected",
     "tooltip.scene.import": "Import Scene",
     "tooltip.scene.new": "New Scene",
+    "tooltip.scene.copy-transform": "Copy Transform",
+    "tooltip.scene.paste-transform": "Paste Transform",
 
     "tooltip.status-bar.timeline": "Toggle Timeline Panel",
     "tooltip.status-bar.splat-data": "Toggle Splat Data Panel",

--- a/static/locales/en.json
+++ b/static/locales/en.json
@@ -17,6 +17,11 @@
     "menu.edit.duplicate": "Duplicate",
     "menu.edit.separate": "Separate",
 
+    "menu.transform.copy-position": "Copy Position",
+    "menu.transform.copy-rotation": "Copy Rotation",
+    "menu.transform.copy-position-rotation": "Copy Position and Rotation",
+    "menu.transform.copy-all": "Copy All Transforms",
+
     "menu.select": "Select",
     "menu.select.all": "All",
     "menu.select.none": "None",
@@ -345,7 +350,7 @@
     "tooltip.scene.solo": "Solo Selected",
     "tooltip.scene.import": "Import Scene",
     "tooltip.scene.new": "New Scene",
-    "tooltip.scene.copy-transform": "Copy Transform",
+    "tooltip.scene.copy-transform-options": "Copy Transform Options",
     "tooltip.scene.paste-transform": "Paste Transform",
 
     "tooltip.status-bar.timeline": "Toggle Timeline Panel",

--- a/static/locales/es.json
+++ b/static/locales/es.json
@@ -17,6 +17,11 @@
     "menu.edit.duplicate": "Duplicar",
     "menu.edit.separate": "Separar",
 
+    "menu.transform.copy-position": "Copiar posición",
+    "menu.transform.copy-rotation": "Copiar rotación",
+    "menu.transform.copy-position-rotation": "Copiar posición y rotación",
+    "menu.transform.copy-all": "Copiar todas las transformaciones",
+
     "menu.select": "Seleccionar",
     "menu.select.all": "Todo",
     "menu.select.none": "Ninguno",
@@ -345,7 +350,7 @@
     "tooltip.scene.solo": "Solo seleccionado",
     "tooltip.scene.import": "Importar escena",
     "tooltip.scene.new": "Nueva escena",
-    "tooltip.scene.copy-transform": "Copiar transformación",
+    "tooltip.scene.copy-transform-options": "Opciones de copia de transformación",
     "tooltip.scene.paste-transform": "Pegar transformación",
 
     "tooltip.status-bar.timeline": "Alternar panel de Línea de tiempo",

--- a/static/locales/es.json
+++ b/static/locales/es.json
@@ -345,6 +345,8 @@
     "tooltip.scene.solo": "Solo seleccionado",
     "tooltip.scene.import": "Importar escena",
     "tooltip.scene.new": "Nueva escena",
+    "tooltip.scene.copy-transform": "Copiar transformación",
+    "tooltip.scene.paste-transform": "Pegar transformación",
 
     "tooltip.status-bar.timeline": "Alternar panel de Línea de tiempo",
     "tooltip.status-bar.splat-data": "Alternar panel de Datos de Splat",

--- a/static/locales/fr.json
+++ b/static/locales/fr.json
@@ -345,6 +345,8 @@
     "tooltip.scene.solo": "Solo sélectionné",
     "tooltip.scene.import": "Importer une scène",
     "tooltip.scene.new": "Nouvelle scène",
+    "tooltip.scene.copy-transform": "Copier la transformation",
+    "tooltip.scene.paste-transform": "Coller la transformation",
 
     "tooltip.status-bar.timeline": "Afficher/Masquer le panneau Chronologie",
     "tooltip.status-bar.splat-data": "Afficher/Masquer le panneau Données Splat",

--- a/static/locales/fr.json
+++ b/static/locales/fr.json
@@ -17,6 +17,11 @@
     "menu.edit.duplicate": "Dupliquer",
     "menu.edit.separate": "Séparer",
 
+    "menu.transform.copy-position": "Copier la position",
+    "menu.transform.copy-rotation": "Copier la rotation",
+    "menu.transform.copy-position-rotation": "Copier la position et la rotation",
+    "menu.transform.copy-all": "Copier toutes les transformations",
+
     "menu.select": "Sélection",
     "menu.select.all": "Tout",
     "menu.select.none": "Aucune",
@@ -345,7 +350,7 @@
     "tooltip.scene.solo": "Solo sélectionné",
     "tooltip.scene.import": "Importer une scène",
     "tooltip.scene.new": "Nouvelle scène",
-    "tooltip.scene.copy-transform": "Copier la transformation",
+    "tooltip.scene.copy-transform-options": "Options de copie de transformation",
     "tooltip.scene.paste-transform": "Coller la transformation",
 
     "tooltip.status-bar.timeline": "Afficher/Masquer le panneau Chronologie",

--- a/static/locales/ja.json
+++ b/static/locales/ja.json
@@ -345,6 +345,8 @@
     "tooltip.scene.solo": "選択をソロ表示",
     "tooltip.scene.import": "シーンをインポート",
     "tooltip.scene.new": "新規シーンを作成",
+    "tooltip.scene.copy-transform": "変換をコピー",
+    "tooltip.scene.paste-transform": "変換を貼り付け",
 
     "tooltip.status-bar.timeline": "タイムラインパネルの切り替え",
     "tooltip.status-bar.splat-data": "スプラットデータパネルの切り替え",

--- a/static/locales/ja.json
+++ b/static/locales/ja.json
@@ -17,6 +17,11 @@
     "menu.edit.duplicate": "複製",
     "menu.edit.separate": "分離",
 
+    "menu.transform.copy-position": "位置をコピー",
+    "menu.transform.copy-rotation": "回転をコピー",
+    "menu.transform.copy-position-rotation": "位置と回転をコピー",
+    "menu.transform.copy-all": "すべての変換をコピー",
+
     "menu.select": "選択",
     "menu.select.all": "全て",
     "menu.select.none": "選択を解除",
@@ -345,7 +350,7 @@
     "tooltip.scene.solo": "選択をソロ表示",
     "tooltip.scene.import": "シーンをインポート",
     "tooltip.scene.new": "新規シーンを作成",
-    "tooltip.scene.copy-transform": "変換をコピー",
+    "tooltip.scene.copy-transform-options": "変換コピーのオプション",
     "tooltip.scene.paste-transform": "変換を貼り付け",
 
     "tooltip.status-bar.timeline": "タイムラインパネルの切り替え",

--- a/static/locales/ko.json
+++ b/static/locales/ko.json
@@ -17,6 +17,11 @@
     "menu.edit.duplicate": "복제",
     "menu.edit.separate": "분리",
 
+    "menu.transform.copy-position": "위치 복사",
+    "menu.transform.copy-rotation": "회전 복사",
+    "menu.transform.copy-position-rotation": "위치 및 회전 복사",
+    "menu.transform.copy-all": "모든 변환 복사",
+
     "menu.select": "선택",
     "menu.select.all": "모두",
     "menu.select.none": "없음",
@@ -345,7 +350,7 @@
     "tooltip.scene.solo": "선택 항목 솔로",
     "tooltip.scene.import": "장면 가져오기",
     "tooltip.scene.new": "새 장면",
-    "tooltip.scene.copy-transform": "변환 복사",
+    "tooltip.scene.copy-transform-options": "변환 복사 옵션",
     "tooltip.scene.paste-transform": "변환 붙여넣기",
 
     "tooltip.status-bar.timeline": "타임라인 패널 전환",

--- a/static/locales/ko.json
+++ b/static/locales/ko.json
@@ -345,6 +345,8 @@
     "tooltip.scene.solo": "선택 항목 솔로",
     "tooltip.scene.import": "장면 가져오기",
     "tooltip.scene.new": "새 장면",
+    "tooltip.scene.copy-transform": "변환 복사",
+    "tooltip.scene.paste-transform": "변환 붙여넣기",
 
     "tooltip.status-bar.timeline": "타임라인 패널 전환",
     "tooltip.status-bar.splat-data": "스플랫 데이터 패널 전환",

--- a/static/locales/pt-BR.json
+++ b/static/locales/pt-BR.json
@@ -17,6 +17,11 @@
     "menu.edit.duplicate": "Duplicar",
     "menu.edit.separate": "Separar",
 
+    "menu.transform.copy-position": "Copiar posição",
+    "menu.transform.copy-rotation": "Copiar rotação",
+    "menu.transform.copy-position-rotation": "Copiar posição e rotação",
+    "menu.transform.copy-all": "Copiar todas as transformações",
+
     "menu.select": "Selecionar",
     "menu.select.all": "Todos",
     "menu.select.none": "Nenhum",
@@ -345,7 +350,7 @@
     "tooltip.scene.solo": "Solo selecionado",
     "tooltip.scene.import": "Importar Cena",
     "tooltip.scene.new": "Nova Cena",
-    "tooltip.scene.copy-transform": "Copiar transformação",
+    "tooltip.scene.copy-transform-options": "Opções de cópia de transformação",
     "tooltip.scene.paste-transform": "Colar transformação",
 
     "tooltip.status-bar.timeline": "Alternar painel de Linha do Tempo",

--- a/static/locales/pt-BR.json
+++ b/static/locales/pt-BR.json
@@ -345,6 +345,8 @@
     "tooltip.scene.solo": "Solo selecionado",
     "tooltip.scene.import": "Importar Cena",
     "tooltip.scene.new": "Nova Cena",
+    "tooltip.scene.copy-transform": "Copiar transformação",
+    "tooltip.scene.paste-transform": "Colar transformação",
 
     "tooltip.status-bar.timeline": "Alternar painel de Linha do Tempo",
     "tooltip.status-bar.splat-data": "Alternar painel de Dados de Splat",

--- a/static/locales/ru.json
+++ b/static/locales/ru.json
@@ -345,6 +345,8 @@
     "tooltip.scene.solo": "Соло выбранного",
     "tooltip.scene.import": "Импортировать сцену",
     "tooltip.scene.new": "Новая сцена",
+    "tooltip.scene.copy-transform": "Копировать трансформацию",
+    "tooltip.scene.paste-transform": "Вставить трансформацию",
 
     "tooltip.status-bar.timeline": "Переключить панель временной шкалы",
     "tooltip.status-bar.splat-data": "Переключить панель данных сплатов",

--- a/static/locales/ru.json
+++ b/static/locales/ru.json
@@ -17,6 +17,11 @@
     "menu.edit.duplicate": "Дублировать",
     "menu.edit.separate": "Разделить",
 
+    "menu.transform.copy-position": "Копировать позицию",
+    "menu.transform.copy-rotation": "Копировать вращение",
+    "menu.transform.copy-position-rotation": "Копировать позицию и вращение",
+    "menu.transform.copy-all": "Копировать все трансформации",
+
     "menu.select": "Выбор",
     "menu.select.all": "Все",
     "menu.select.none": "Ничего",
@@ -345,7 +350,7 @@
     "tooltip.scene.solo": "Соло выбранного",
     "tooltip.scene.import": "Импортировать сцену",
     "tooltip.scene.new": "Новая сцена",
-    "tooltip.scene.copy-transform": "Копировать трансформацию",
+    "tooltip.scene.copy-transform-options": "Параметры копирования трансформации",
     "tooltip.scene.paste-transform": "Вставить трансформацию",
 
     "tooltip.status-bar.timeline": "Переключить панель временной шкалы",

--- a/static/locales/zh-CN.json
+++ b/static/locales/zh-CN.json
@@ -17,6 +17,11 @@
     "menu.edit.duplicate": "复制",
     "menu.edit.separate": "分离",
 
+    "menu.transform.copy-position": "复制位置",
+    "menu.transform.copy-rotation": "复制旋转",
+    "menu.transform.copy-position-rotation": "复制位置和旋转",
+    "menu.transform.copy-all": "复制所有变换",
+
     "menu.select": "选择",
     "menu.select.all": "全部",
     "menu.select.none": "无",
@@ -345,7 +350,7 @@
     "tooltip.scene.solo": "独显所选",
     "tooltip.scene.import": "导入场景",
     "tooltip.scene.new": "新建场景",
-    "tooltip.scene.copy-transform": "复制变换",
+    "tooltip.scene.copy-transform-options": "变换复制选项",
     "tooltip.scene.paste-transform": "粘贴变换",
 
     "tooltip.status-bar.timeline": "切换时间线面板",

--- a/static/locales/zh-CN.json
+++ b/static/locales/zh-CN.json
@@ -345,6 +345,8 @@
     "tooltip.scene.solo": "独显所选",
     "tooltip.scene.import": "导入场景",
     "tooltip.scene.new": "新建场景",
+    "tooltip.scene.copy-transform": "复制变换",
+    "tooltip.scene.paste-transform": "粘贴变换",
 
     "tooltip.status-bar.timeline": "切换时间线面板",
     "tooltip.status-bar.splat-data": "切换高斯点数据面板",


### PR DESCRIPTION
## Summary

Adds copy and paste actions to the Transform panel so transform values can be transferred between splats.

The copy transform options dropdown supports copy/paste of:
  - Position
  - Rotation
  - Position and rotation
  - All transforms, including scale

Paste applies only the copied components and preserves the destination splat's remaining transform values. The operation uses the existing pivot transaction flow, so it can be undone and redone as a single edit.

The controls follow the existing Transform panel UI patterns, remain disabled when unavailable, and include accessible labels and translations for all supported locales.

## Motivation

Aligning or replacing related splats currently requires manually reproducing transform values. This leads to repetitive manual actions and math to snap assets in place. Copying selected transform components makes this workflow faster and less error-prone while retaining control over which destination properties are changed. This is a standard feature in most 3D authoring and editing tools.

  ## Validation

  - `npm run lint`
  - `npm run lint:locales`
  - `npm run build`
  - Verified selective position and rotation pasting
  - Verified complete-transform pasting
  - Verified repeated paste across multiple splats
  - Verified clipboard replacement
  - Verified undo and redo
  - Verified disabled states, dropdown positioning, pointer
  behavior, and accessible labels
  
## Screenshots

<img width="483" height="238" alt="copy-transform-options" src="https://github.com/user-attachments/assets/39970a58-7848-40bf-abc8-8343a9e04cf0" />

<img width="381" height="257" alt="paste-transforms" src="https://github.com/user-attachments/assets/4217ef7d-61ff-4824-97bf-5d125b75801a" />

Closes #1001
