### PR TITLE
feat(measure): use ID picking for more accurate measurement points

### DIFF
--- a/src/camera.ts
+++ b/src/camera.ts
@@ -18,6 +18,7 @@ import {
     Color,
     Entity,
     Mat4,
+    Plane,
     Quat,
     Ray,
     RenderPass,
@@ -746,6 +747,48 @@ class Camera extends Element {
             splat: closestSplat,
             position: position,
             distance: t
+        };
+    }
+
+    // intersect the scene at the given normalized screen coordinate (0-1 range)
+    // using ID picking. Returns the world position of the front-most gaussian
+    // at that pixel, refined by ray-plane intersection. More accurate than
+    // depth picking for measurement because it targets the actual gaussian
+    // center rather than an alpha-weighted depth average.
+    async intersectById(x: number, y: number, splat: Splat) {
+        const { scene } = this;
+
+        // build the pick ray in world space (screenToWorld expects CSS pixels)
+        const screenX = x * scene.canvas.clientWidth;
+        const screenY = y * scene.canvas.clientHeight;
+        this.getRay(screenX, screenY, ray);
+
+        // render the splat's ID channel and read the front-most gaussian ID
+        this.pickPrep(splat, 'set');
+        const pickId = await this.pick(x, y);
+        if (pickId === -1) {
+            return null;
+        }
+
+        // get the gaussian center world position
+        const worldPos = new Vec3();
+        if (!splat.calcSplatWorldPosition(pickId, worldPos)) {
+            return null;
+        }
+
+        // refine: intersect the pick ray with a plane through the gaussian
+        // center facing the camera, so the result lies on the ray
+        const plane = new Plane();
+        plane.setFromPointNormal(worldPos, this.mainCamera.forward);
+        if (!plane.intersectsRay(ray, worldPos)) {
+            return null;
+        }
+
+        const distance = new Vec3().sub2(worldPos, ray.origin).length();
+        return {
+            splat: splat,
+            position: worldPos,
+            distance: distance
         };
     }
 

--- a/src/tools/measure-tool.ts
+++ b/src/tools/measure-tool.ts
@@ -97,18 +97,23 @@ class MeasureTool {
         // the measurement points and line render in the scene via the shared
         // tool overlay (occluded by gaussians, with a faint ghost showing through)
         const overlay = new ToolOverlay();
+        const overlayPts: Vec3[] = [p0, p1];
         overlay.provider = (writer: OverlayWriter) => {
             if (!active || !splat) {
                 return;
             }
             const count = splat.measurePoints.length;
-            const pts = [p0, p1];
-            for (let i = 0; i < count; i++) {
-                getPoint(i, pts[i]);
-                writer.dot(pts[i]);
+            // ensure we have enough temp vectors
+            while (overlayPts.length < count) {
+                overlayPts.push(new Vec3());
             }
-            if (count === 2) {
-                writer.segment(p0, p1);
+            for (let i = 0; i < count; i++) {
+                getPoint(i, overlayPts[i]);
+                writer.dot(overlayPts[i]);
+            }
+            // draw a segment between each consecutive pair of points
+            for (let i = 0; i < count - 1; i++) {
+                writer.segment(overlayPts[i], overlayPts[i + 1]);
             }
         };
 
@@ -123,13 +128,17 @@ class MeasureTool {
                 gizmo.attach(entity);
             }
 
-            if (splat && splat.measurePoints.length === 2) {
-                getPoint(0, p0);
-                getPoint(1, p1);
-                const len = p0.distance(p1);
+            if (splat && splat.measurePoints.length >= 2) {
+                // total length across all segments
+                let totalLen = 0;
+                for (let i = 0; i < splat.measurePoints.length - 1; i++) {
+                    getPoint(i, p0);
+                    getPoint(i + 1, p1);
+                    totalLen += p0.distance(p1);
+                }
 
                 suppressUI++;
-                lengthInput.value = len;
+                lengthInput.value = totalLen;
                 lengthInput.enabled = true;
                 suppressUI--;
             } else {
@@ -340,19 +349,17 @@ class MeasureTool {
                 }
 
                 // place at the pointer-down position: that is where the user aimed
-                if (splat.measurePoints.length < 2) {
-                    const result = await scene.camera.intersectById(
-                        clickX / canvasContainer.dom.clientWidth,
-                        clickY / canvasContainer.dom.clientHeight,
-                        splat
-                    );
-                    if (result) {
-                        mat.invert(splat.worldTransform);
-                        mat.transformPoint(result.position, p);
-                        splat.measureSelection = splat.measurePoints.length;
-                        splat.measurePoints.push(p.clone());
-                        updateVisuals();
-                    }
+                const result = await scene.camera.intersectById(
+                    clickX / canvasContainer.dom.clientWidth,
+                    clickY / canvasContainer.dom.clientHeight,
+                    splat
+                );
+                if (result) {
+                    mat.invert(splat.worldTransform);
+                    mat.transformPoint(result.position, p);
+                    splat.measureSelection = splat.measurePoints.length;
+                    splat.measurePoints.push(p.clone());
+                    updateVisuals();
                 }
 
                 e.preventDefault();
@@ -360,21 +367,27 @@ class MeasureTool {
             }
         };
 
-        // length label along the measured line
+        // length labels along each measured segment
         events.on('postrender', () => {
             // the svg is hidden while the tool is inactive, so skip the work
             if (!active || !splat) {
                 return;
             }
 
-            if (splat.measurePoints.length !== 2 || !events.invoke('camera.boundDimensions')) {
-                dimLabels.hideLabel(0);
+            const segCount = splat.measurePoints.length - 1;
+
+            if (segCount < 1 || !events.invoke('camera.boundDimensions')) {
+                dimLabels.hideExtra(0);
                 return;
             }
 
-            getPoint(0, p0);
-            getPoint(1, p1);
-            dimLabels.setLabel(0, p0, p1);
+            dimLabels.ensureCount(segCount);
+            for (let i = 0; i < segCount; i++) {
+                getPoint(i, p0);
+                getPoint(i + 1, p1);
+                dimLabels.setLabel(i, p0, p1);
+            }
+            dimLabels.hideExtra(segCount);
         });
 
         // re-render so the label reacts to the setting while the tool is active

--- a/src/tools/measure-tool.ts
+++ b/src/tools/measure-tool.ts
@@ -341,7 +341,11 @@ class MeasureTool {
 
                 // place at the pointer-down position: that is where the user aimed
                 if (splat.measurePoints.length < 2) {
-                    const result = await scene.camera.intersect(clickX / canvasContainer.dom.clientWidth, clickY / canvasContainer.dom.clientHeight);
+                    const result = await scene.camera.intersectById(
+                        clickX / canvasContainer.dom.clientWidth,
+                        clickY / canvasContainer.dom.clientHeight,
+                        splat
+                    );
                     if (result) {
                         mat.invert(splat.worldTransform);
                         mat.transformPoint(result.position, p);

--- a/src/ui/dimension-labels.ts
+++ b/src/ui/dimension-labels.ts
@@ -17,6 +17,7 @@ class DimensionLabels {
 
     private scene: Scene;
     private viewport: HTMLElement;
+    private ns = 'http://www.w3.org/2000/svg';
 
     // the svg is appended to parent and sized by it; screen projections use
     // the viewport element's client size (the canvas container)
@@ -24,19 +25,29 @@ class DimensionLabels {
         this.scene = scene;
         this.viewport = viewport;
 
-        const ns = 'http://www.w3.org/2000/svg';
-        this.svg = document.createElementNS(ns, 'svg') as SVGSVGElement;
+        this.svg = document.createElementNS(this.ns, 'svg') as SVGSVGElement;
         this.svg.classList.add('tool-svg', 'dimension-labels-svg', 'hidden');
         this.svg.id = id;
         parent.appendChild(this.svg);
 
         this.labels = Array.from({ length: count }, () => {
-            const text = document.createElementNS(ns, 'text') as SVGTextElement;
+            const text = document.createElementNS(this.ns, 'text') as SVGTextElement;
             text.setAttribute('text-anchor', 'middle');
             text.setAttribute('dominant-baseline', 'middle');
             this.svg.appendChild(text);
             return text;
         });
+    }
+
+    // ensure at least `count` label elements exist, creating new ones as needed
+    ensureCount(count: number) {
+        while (this.labels.length < count) {
+            const text = document.createElementNS(this.ns, 'text') as SVGTextElement;
+            text.setAttribute('text-anchor', 'middle');
+            text.setAttribute('dominant-baseline', 'middle');
+            this.svg.appendChild(text);
+            this.labels.push(text);
+        }
     }
 
     show() {
@@ -48,7 +59,16 @@ class DimensionLabels {
     }
 
     hideLabel(index: number) {
-        this.labels[index].setAttribute('visibility', 'hidden');
+        if (this.labels[index]) {
+            this.labels[index].setAttribute('visibility', 'hidden');
+        }
+    }
+
+    // hide all labels beyond `count` (used when the number of segments shrinks)
+    hideExtra(count: number) {
+        for (let i = count; i < this.labels.length; i++) {
+            this.labels[i].setAttribute('visibility', 'hidden');
+        }
     }
 
     // place a label along the world-space edge a-b, showing its length. the


### PR DESCRIPTION
The measure tool's depth picking uses alpha-weighted average depth, which
drifts toward deeper gaussians in semi-transparent regions and causes
measurement points to consistently land below the clicked surface.

Replace it with ID picking: render the splat's ID channel, read the
front-most gaussian ID, get its exact world position, and refine via
ray-plane intersection. Points now match what the user sees on screen.

The existing [intersect](cci:1://file:///e:/ShanksLiu/PlayCanvas/supersplat/src/camera.ts:707:4-750:5) method is preserved for [pickFocalPoint](cci:1://file:///e:/ShanksLiu/PlayCanvas/supersplat/src/camera.ts:794:4-808:5) and
other callers — no impact on selection tools or other picking consumers.