### PR TITLE
Use shared viewer settings from splat-transform's viewer-settings subpath

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
             "devDependencies": {
                 "@playcanvas/eslint-config": "2.1.0",
                 "@playcanvas/pcui": "6.1.4",
-                "@playcanvas/splat-transform": "3.3.1",
+                "@playcanvas/splat-transform": "3.3.2",
                 "@rollup/plugin-alias": "6.0.0",
                 "@rollup/plugin-image": "3.0.3",
                 "@rollup/plugin-json": "6.1.0",
@@ -325,9 +325,6 @@
                 "x64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -820,9 +817,9 @@
             }
         },
         "node_modules/@playcanvas/splat-transform": {
-            "version": "3.3.1",
-            "resolved": "https://registry.npmjs.org/@playcanvas/splat-transform/-/splat-transform-3.3.1.tgz",
-            "integrity": "sha512-y7q8hMt4pyarcMXoDrE83QyZR0tZtLl67X6NarpW2KKwjYhtwCmBCFEQ4j+9SDWdfXcE+UOKgY6rxOV2zTr3cw==",
+            "version": "3.3.2",
+            "resolved": "https://registry.npmjs.org/@playcanvas/splat-transform/-/splat-transform-3.3.2.tgz",
+            "integrity": "sha512-CCDZXiwowQ9efFv/okkZSZ9J4EH2wS8z+BrLRdDhDSeXsZJeYSaopoiIm6O1NLI94UrpepAhA4utnTXbl0h6ag==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -1113,9 +1110,6 @@
                 "arm"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1130,9 +1124,6 @@
                 "arm"
             ],
             "dev": true,
-            "libc": [
-                "musl"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1147,9 +1138,6 @@
                 "arm64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1164,9 +1152,6 @@
                 "arm64"
             ],
             "dev": true,
-            "libc": [
-                "musl"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1181,9 +1166,6 @@
                 "loong64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1198,9 +1180,6 @@
                 "loong64"
             ],
             "dev": true,
-            "libc": [
-                "musl"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1215,9 +1194,6 @@
                 "ppc64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1232,9 +1208,6 @@
                 "ppc64"
             ],
             "dev": true,
-            "libc": [
-                "musl"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1249,9 +1222,6 @@
                 "riscv64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1266,9 +1236,6 @@
                 "riscv64"
             ],
             "dev": true,
-            "libc": [
-                "musl"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1283,9 +1250,6 @@
                 "s390x"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1300,9 +1264,6 @@
                 "x64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1317,9 +1278,6 @@
                 "x64"
             ],
             "dev": true,
-            "libc": [
-                "musl"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     },
     "devDependencies": {
         "@playcanvas/eslint-config": "2.1.0",
-        "@playcanvas/splat-transform": "3.3.1",
+        "@playcanvas/splat-transform": "3.3.2",
         "@playcanvas/pcui": "6.1.4",
         "@rollup/plugin-alias": "6.0.0",
         "@rollup/plugin-image": "3.0.3",

--- a/src/splat-serialize.ts
+++ b/src/splat-serialize.ts
@@ -21,6 +21,15 @@ import {
     type Writer
 } from '@playcanvas/splat-transform';
 import {
+    defaultPostEffectSettings,
+    type AnimTrack,
+    type Annotation,
+    type Camera,
+    type CameraPose,
+    type ExperienceSettings,
+    type PostEffectSettings
+} from '@playcanvas/splat-transform/viewer-settings';
+import {
     GSplatData,
     Mat3,
     Mat4,
@@ -50,95 +59,6 @@ type SerializeSettings = {
     keepStateData?: boolean;        // keep the state data array
     keepWorldTransform?: boolean;   // don't apply the world transform when resolving splat transforms
     keepColorTint?: boolean;        // refrain from applying color tints
-};
-
-type AnimTrack = {
-    name: string,
-    duration: number,
-    frameRate: number,
-    loopMode: 'none' | 'repeat' | 'pingpong',
-    interpolation: 'step' | 'spline',
-    smoothness: number,
-    keyframes: {
-        times: number[],
-        values: {
-            position: number[],
-            target: number[],
-            fov: number[],
-        }
-    }
-};
-
-type CameraPose = {
-    position: [number, number, number],
-    target: [number, number, number],
-    fov: number
-};
-
-type Camera = {
-    initial: CameraPose,
-};
-
-type Annotation = {
-    position: [number, number, number],
-    title: string,
-    text: string,
-    extras: any,
-    camera: Camera
-};
-
-type PostEffectSettings = {
-    sharpness: {
-        enabled: boolean,
-        amount: number,
-    },
-    bloom: {
-        enabled: boolean,
-        intensity: number,
-        blurLevel: number,
-    },
-    grading: {
-        enabled: boolean,
-        brightness: number,
-        contrast: number,
-        saturation: number,
-        tint: [number, number, number],
-    },
-    vignette: {
-        enabled: boolean,
-        intensity: number,
-        inner: number,
-        outer: number,
-        curvature: number,
-    },
-    fringing: {
-        enabled: boolean,
-        intensity: number
-    }
-};
-
-const defaultPostEffectSettings: PostEffectSettings = {
-    sharpness: { enabled: false, amount: 0 },
-    bloom: { enabled: false, intensity: 1, blurLevel: 2 },
-    grading: { enabled: false, brightness: 1, contrast: 1, saturation: 1, tint: [1, 1, 1] },
-    vignette: { enabled: false, intensity: 0.5, inner: 0.3, outer: 0.75, curvature: 1 },
-    fringing: { enabled: false, intensity: 0.5 }
-};
-
-type ExperienceSettings = {
-    version: 2,
-    tonemapping: 'none' | 'linear' | 'filmic' | 'hejl' | 'aces' | 'aces2' | 'neutral',
-    highPrecisionRendering: boolean,
-    soundUrl?: string,
-    background: {
-        color: [number, number, number],
-        skyboxUrl?: string
-    },
-    postEffectSettings: PostEffectSettings,
-    animTracks: AnimTrack[],
-    cameras: Camera[],
-    annotations: Annotation[],
-    startMode: 'default' | 'animTrack' | 'annotation'
 };
 
 type ViewerExportSettings = {
@@ -589,6 +509,9 @@ class SuperSplatChunkSource implements ChunkSource {
             chunkSize: EXPORT_CHUNK_SIZE,
             numChunks: [numChunks],
             shBands: outputBands as SHBands,
+            // supersplat's edit pipeline doesn't carry the trained-model tag
+            // (antialiased / 2dgs) through load, so exports are untagged
+            model: 'default',
             extraColumns: [],
             transform: Transform.PLY,
             availableLayers: new Set<ChunkLayer>(['position', 'geometric', 'color']),

--- a/src/ui/export-popup.ts
+++ b/src/ui/export-popup.ts
@@ -523,7 +523,7 @@ class ExportPopup extends Container {
                     tonemapping: 'none',
                     highPrecisionRendering: false,
                     background: { color: bgColor },
-                    postEffectSettings: defaultPostEffectSettings,
+                    postEffectSettings: defaultPostEffectSettings(),
                     animTracks,
                     cameras,
                     annotations: [],

--- a/src/ui/publish-settings-dialog.ts
+++ b/src/ui/publish-settings-dialog.ts
@@ -380,7 +380,7 @@ class PublishSettingsDialog extends Container {
                         tonemapping: 'none',
                         highPrecisionRendering: false,
                         background: { color: bgColor },
-                        postEffectSettings: defaultPostEffectSettings,
+                        postEffectSettings: defaultPostEffectSettings(),
                         animTracks,
                         cameras,
                         annotations: [],


### PR DESCRIPTION
Bumps `@playcanvas/splat-transform` to 3.3.2 and replaces the local experience settings types and drifted defaults (bloom.intensity 1, outside the viewer's 0–0.1 authoring range) with the shared api from the new `viewer-settings` subpath — `defaultPostEffectSettings` is now a factory, so each export gets a fresh object instead of a shared mutable one. Also sets the now-required `model: 'default'` on export metadata (splat-transform 3.2 carries the trained-model tag through to writers; supersplat's load path doesn't retain it), which fixes the build break from the 3.3.1 bump in #1008.