### PR TITLE
Fix camera pose import memory leak

### DIFF
--- a/src/camera-poses.ts
+++ b/src/camera-poses.ts
@@ -204,8 +204,10 @@ class CameraAnimTrack implements AnimTrack {
      * Load poses from serialized data.
      */
     loadPoses(posesData: Pose[]): void {
+        const defaultFov = this.events.invoke('camera.fov') ?? 60;
         this.poses.length = 0;
         posesData.forEach((pose) => {
+            pose.fov ??= defaultFov;
             this.poses.push(pose);
         });
         this.rebuildSpline();
@@ -284,6 +286,10 @@ const registerCameraPosesEvents = (events: Events) => {
     // Legacy support: add pose directly
     events.on('camera.addPose', (pose: Pose) => {
         track.addPose(pose);
+    });
+
+    events.on('camera.loadPoses', (poses: Pose[]) => {
+        track.loadPoses(poses);
     });
 
     // Serialization

--- a/src/file-handler.ts
+++ b/src/file-handler.ts
@@ -1,5 +1,6 @@
 import { path, Quat, Vec3 } from 'playcanvas';
 
+import type { Pose } from './camera-poses';
 import { CreateDropHandler } from './drop-handler';
 import { ElementType } from './element';
 import { Events } from './events';
@@ -168,6 +169,7 @@ const loadCameraPoses = async (file: ImportFile, events: Events) => {
             return (avalue && bvalue) ? parseInt(avalue, 10) - parseInt(bvalue, 10) : 0;
         };
 
+        const poses: Pose[] = [];
         json.sort(sorter).forEach((pose: any, i: number) => {
             if (pose.hasOwnProperty('position') && pose.hasOwnProperty('rotation')) {
                 const p = new Vec3(pose.position);
@@ -184,7 +186,7 @@ const loadCameraPoses = async (file: ImportFile, events: Events) => {
                     fov = Math.max(fovX, fovY);
                 }
 
-                events.fire('camera.addPose', {
+                poses.push({
                     name: pose.img_name ?? `${file.filename}_${i}`,
                     frame: i,
                     position: new Vec3(-p.x, -p.y, p.z),
@@ -193,6 +195,10 @@ const loadCameraPoses = async (file: ImportFile, events: Events) => {
                 });
             }
         });
+
+        if (poses.length > 0) {
+            events.fire('camera.loadPoses', poses);
+        }
     }
 };
 
@@ -235,7 +241,7 @@ const loadImagesTxt = async (file: ImportFile, events: Events) => {
     const q = new Quat();
     const t = new Vec3();
 
-    poses.forEach((pose, i) => {
+    const cameraPoses = poses.map((pose, i) => {
         const { w, x, y, z, tx, ty, tz } = pose;
 
         q.set(x, y, z, w).normalize().invert();
@@ -245,13 +251,17 @@ const loadImagesTxt = async (file: ImportFile, events: Events) => {
         q.transformVector(Vec3.BACK, vec);
         vec.mulScalar(10).add(t);
 
-        events.fire('camera.addPose', {
+        return {
             name: pose.name,
             frame: i,
             position: new Vec3(-t.x, -t.y, t.z),
             target: new Vec3(-vec.x, -vec.y, vec.z)
-        });
+        };
     });
+
+    if (cameraPoses.length > 0) {
+        events.fire('camera.loadPoses', cameraPoses);
+    }
 };
 
 // initialize file handler events

--- a/src/ui/tooltips.ts
+++ b/src/ui/tooltips.ts
@@ -9,7 +9,7 @@ type TooltipText = string | (() => string);
 
 class Tooltips extends Container {
     register: (target: Element, text: TooltipText, direction?: Direction) => void;
-    unregister: (target: Element) => void;
+    unregister: (target: Element, dom?: HTMLElement) => void;
     destroy: () => void;
 
     constructor(args: any = {}) {
@@ -112,18 +112,18 @@ class Tooltips extends Container {
             target.dom.addEventListener('pointerenter', enter);
             target.dom.addEventListener('pointerleave', leave);
 
-            target.on('destroy', () => {
-                this.unregister(target);
+            target.on('destroy', (dom: HTMLElement) => {
+                this.unregister(target, dom);
             });
 
             targets.set(target, { enter, leave });
         };
 
-        this.unregister = (target: Element) => {
+        this.unregister = (target: Element, dom = target.dom) => {
             const value = targets.get(target);
             if (value) {
-                target.dom.removeEventListener('pointerenter', value.enter);
-                target.dom.removeEventListener('pointerleave', value.leave);
+                dom?.removeEventListener('pointerenter', value.enter);
+                dom?.removeEventListener('pointerleave', value.leave);
                 targets.delete(target);
             }
         };


### PR DESCRIPTION
## Summary

- Batch-load JSON and COLMAP camera poses instead of rebuilding the animation track for every pose.
- Preserve the default camera FOV when imported poses do not provide one.
- Correctly unregister tooltip listeners using the DOM element supplied by the destroy event.
- Release destroyed timeline key wrappers from the tooltip registry.

## Root cause

Camera imports emitted one `track.keyAdded` event per pose. Each event rebuilt every timeline key, resulting in O(n²) DOM allocation.

Destroyed PCUI elements clear `target.dom` before emitting `destroy`. Tooltip cleanup then attempted to access the cleared DOM, preventing entries from being removed from its internal map and retaining millions of destroyed wrappers.

## Testing

- `npm run lint`
- `npm run build`
- Verified that importing 3,000 poses emits one `track.keysLoaded` event and no per-pose `track.keyAdded` events.