### PR TITLE
Make stochastic auto mode adaptive, match rings in stochastic frames, fix document load rendering

### DIFF
--- a/src/doc.ts
+++ b/src/doc.ts
@@ -112,6 +112,14 @@ const registerDocEvents = (scene: Scene, events: Events) => {
             // below so a failed load can't leave capture suspended.
             events.fire('preferences.suspend');
 
+            // the document is applied piecewise: each layer becomes visible
+            // before its saved transform is applied (scene.add awaits a GPU
+            // bound readback in between) and the camera pose is restored last,
+            // so frames rendered mid-load would show a half-assembled scene.
+            // Suspend viewport rendering until the load settles; the finally
+            // below resumes it and forces a render of the final state.
+            scene.suspendRender = true;
+
             // reset the scene. This closes the *previous* document's archive, so
             // adopt this one only afterwards
             resetScene();
@@ -196,6 +204,8 @@ const registerDocEvents = (scene: Scene, events: Events) => {
                 message: `'${error.message ?? error}'`
             });
         } finally {
+            scene.suspendRender = false;
+            scene.forceRender = true;
             events.fire('preferences.resume');
             events.fire('stopSpinner');
         }

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -845,7 +845,7 @@ const registerEditorEvents = (events: Events, editHistory: EditHistory, scene: S
     // 'disabled' never uses it, 'enabled' always does, 'movement' uses it only
     // while the scene is changing - trading the sort for speed exactly when the
     // eye is least able to see the sampling noise - and 'auto' behaves like
-    // 'movement' but only once a sorted frame has proven slow (see
+    // 'movement' while the last sorted frame proved slow (see
     // Scene.autoEngageMs).
 
     let stochastic = 'auto';

--- a/src/file-handler.ts
+++ b/src/file-handler.ts
@@ -341,8 +341,11 @@ const initFileHandler = (scene: Scene, events: Events, dropTarget: HTMLElement) 
                 const filename = filenames[i].toLowerCase();
 
                 if (filename.endsWith('.ssproj')) {
-                    // load ssproj document
-                    await events.invoke('doc.load', files[i].contents ?? (await fetch(files[i].url)).arrayBuffer(), files[i].handle);
+                    // load ssproj document. doc.load expects a File (the zip
+                    // reader needs its size), so wrap url fetches in one
+                    const contents = files[i].contents ??
+                        new File([await (await fetch(files[i].url)).blob()], files[i].filename);
+                    await events.invoke('doc.load', contents, files[i].handle);
                 } else if (['.ply', '.splat', '.sog', '.ksplat', '.spz'].some(ext => filename.endsWith(ext))) {
                     // load gaussian splat model
                     const model = await importSplatModel([files[i]], animationFrame);

--- a/src/scene.ts
+++ b/src/scene.ts
@@ -108,16 +108,21 @@ class Scene {
     movingRender = false;
     pendingResolve = false;
 
-    // 'auto' stochastic mode renders sorted until a sorted frame's GPU span
-    // exceeds autoEngageMs, then latches to stochastic-during-movement for the
-    // rest of the session. While unengaged every rendered frame is sorted, so
-    // the profiler's async report - whichever recent frame it came from - is a
-    // sorted frame's span and can be compared against the threshold directly.
-    // The threshold is tweakable from the console as `scene.autoEngageMs = 5`
-    // to exercise the switch on scenes that are not actually slow.
+    // 'auto' stochastic mode follows the timing of the last rendered sorted
+    // frame: engaged (stochastic-during-movement) while that frame's GPU span
+    // exceeded autoEngageMs, disengaged once a later sorted frame - at minimum
+    // the clean resolve frame on every settle - comes in under it, so hiding
+    // content or moving to a lighter view drops back to sorted. Stochastic
+    // frames say nothing about the cost of sorting, so they never update the
+    // decision: profiler reports resolve asynchronously, and frameModes
+    // records each profiled frame's mode by renderVersion so reports can be
+    // attributed (see onGpuReport). The threshold is tweakable from the
+    // console as `scene.autoEngageMs = 5` to exercise the switch on scenes
+    // that are not actually slow.
     autoEngageMs = 60;
     autoEngaged = false;
     private autoSampling = false;
+    private frameModes = new Map<number, boolean>();
 
     lockedRenderMode = false;
     lockedRender = false;
@@ -257,6 +262,17 @@ class Scene {
 
         this.frameTimings.gpuSupported = !!(this.app.graphicsDevice as any).supportsTimestampQuery;
         events.function('scene.frameTimings', () => this.frameTimings);
+
+        // the profiler's report callback carries the renderVersion of the frame
+        // the timings belong to, but the engine discards it before the value
+        // lands in _frameTime. Wrap it so reports can be attributed to the mode
+        // the frame rendered with (see onGpuReport).
+        const profiler = this.app.graphicsDevice.gpuProfiler as any;
+        const originalReport = profiler.report.bind(profiler);
+        profiler.report = (renderVersion: number, timings: number[] | null, frameTime?: number) => {
+            originalReport(renderVersion, timings, frameTime);
+            this.onGpuReport(renderVersion, timings, frameTime);
+        };
 
         // force render on device restored
         this.app.graphicsDevice.on('devicerestored', () => {
@@ -466,13 +482,13 @@ class Scene {
         // 'movement' takes the fast no-sort stochastic path only while actively
         // interacting, so settled frames get the clean sorted & blended one;
         // 'enabled' stays stochastic even once the scene settles. 'auto' acts
-        // like 'disabled' until a sorted frame proves slower than autoEngageMs
-        // (latched in onPostRender), then like 'movement'; without
-        // timestamp-query support it can never measure, so it falls back to
-        // 'movement' rather than leave heavy scenes janky. Locked-mode captures
-        // always use the sorted path.
+        // like 'movement' while the last sorted frame's GPU span exceeded
+        // autoEngageMs and like 'disabled' otherwise (updated per report in
+        // onGpuReport); without timestamp-query support it can never measure,
+        // so it falls back to 'movement' rather than leave heavy scenes janky.
+        // Locked-mode captures always use the sorted path.
         const auto = stochastic === 'auto';
-        this.autoSampling = auto && !this.autoEngaged && this.frameTimings.gpuSupported;
+        this.autoSampling = auto && this.frameTimings.gpuSupported;
         const adaptive = stochastic === 'movement' ||
             (auto && (this.autoEngaged || !this.frameTimings.gpuSupported));
         this.movingRender = !this.lockedRenderMode &&
@@ -566,12 +582,14 @@ class Scene {
 
         const gpuTime = (this.app.graphicsDevice.gpuProfiler as any)?._frameTime ?? 0;
 
-        // latch 'auto' stochastic mode once a sorted frame exceeds the
-        // threshold. Locked-mode frames are excluded: offline captures can
-        // render at a much higher resolution than the editor view, so they
-        // are never timed at all (see onUpdate).
-        if (this.autoSampling && !this.lockedRenderMode && gpuTime > this.autoEngageMs) {
-            this.autoEngaged = true;
+        // record the mode this frame rendered with, keyed by its renderVersion,
+        // so the frame's asynchronously resolving profiler report can be
+        // attributed in onGpuReport. Only profiled frames get reports (this
+        // also excludes locked-mode frames, which are never timed - see
+        // onUpdate), so only those are recorded.
+        const device = this.app.graphicsDevice as any;
+        if (device.gpuProfiler._enabled) {
+            this.frameModes.set(device.renderVersion, this.movingRender);
         }
 
         const timings = this.frameTimings;
@@ -584,6 +602,27 @@ class Scene {
         timings.width = this.targetSize.width;
         timings.height = this.targetSize.height;
         timings.stochastic = this.movingRender;
+    }
+
+    // handle an asynchronously resolved gpu timing report. Only sorted frames
+    // measure the cost 'auto' mode trades away, so only their spans update the
+    // engage decision; stochastic-frame reports are ignored. timings is null
+    // when the backend discards a frame (e.g. a disjoint timer event).
+    private onGpuReport(renderVersion: number, timings: number[] | null, frameTime?: number) {
+        const moving = this.frameModes.get(renderVersion);
+
+        // reports resolve in order, so drop this frame's entry and any older
+        // ones a discarded report left behind
+        this.frameModes.forEach((_, version) => {
+            if (version <= renderVersion) {
+                this.frameModes.delete(version);
+            }
+        });
+
+        if (moving === false && timings && timings.length > 0) {
+            const gpuTime = frameTime ?? timings.reduce((sum, t) => sum + t, 0);
+            this.autoEngaged = gpuTime > this.autoEngageMs;
+        }
     }
 }
 

--- a/src/scene.ts
+++ b/src/scene.ts
@@ -127,6 +127,12 @@ class Scene {
     lockedRenderMode = false;
     lockedRender = false;
 
+    // viewport rendering is suspended while a document load applies its pieces:
+    // layers become visible before their saved transforms arrive and the camera
+    // pose is restored last, so intermediate frames would show a half-assembled
+    // scene. Set by doc.ts, which forces a render once the load completes.
+    suspendRender = false;
+
     // devtools switch for the stochastic resolve, set from the console as
     // `scene.resolveMode = 'old'`. 'new' is the masked quad+bilinear filter that
     // ships; 'old' is the original aligned 2x2 block average, held across the quad
@@ -504,7 +510,9 @@ class Scene {
         this.app.graphicsDevice.gpuProfiler.enabled =
             (profiling || this.autoSampling) && !this.lockedRenderMode;
 
-        if (this.lockedRenderMode) {
+        if (this.suspendRender) {
+            this.app.renderNextFrame = false;
+        } else if (this.lockedRenderMode) {
             this.app.renderNextFrame = this.lockedRender;
             this.lockedRender = false;
         } else if (!this.app.renderNextFrame) {

--- a/src/shaders/projected-splat-shader.ts
+++ b/src/shaders/projected-splat-shader.ts
@@ -150,6 +150,20 @@ fn fragmentMain(input: FragmentInput) -> FragmentOutput {
             output.color = vec4f(vec4u(id, id >> 8u, id >> 16u, id >> 24u) & vec4u(255u)) / 255.0;
         }
     #else
+        let selected = (gaussianFlags & 1u) != 0u;
+        let locked = (gaussianFlags & 2u) != 0u;
+        let norm = normExp(radius);
+        var alpha = norm * gaussianColor.a;
+        // rings apply only to the selected splat's gaussians (gaussianId is the
+        // cache entry index in the forward pass, where pickBase is 0). The
+        // reshaped alpha feeds both paths: the sorted blend directly, and the
+        // stochastic coverage test as its probability, so the ring edge dithers
+        // at ~60% coverage and the interior at ~5% and the resolve filter
+        // averages that back to roughly the sorted look.
+        let rings = gaussianId >= uniform.ringsBase && gaussianId < uniform.ringsBase + uniform.ringsCount;
+        if (!locked && rings && uniform.ringSize > 0.0) {
+            alpha = select(0.6, max(0.05, alpha), radius < 1.0 - uniform.ringSize);
+        }
       #ifdef STOCHASTIC
         // 1 spp stochastic transparency (StochasticSplats, Listing 1): keep this
         // fragment with raw probability alpha, write it opaque; the depth test
@@ -163,8 +177,6 @@ fn fragmentMain(input: FragmentInput) -> FragmentOutput {
         // splat id keeps overlapping splats decorrelated and each pixel's
         // threshold marginally uniform. The settle still renders the exact
         // sorted blend.
-        let norm = normExp(radius);
-        let alpha = norm * gaussianColor.a;
         let pix = vec2u(pcPosition.xy);
         let quad = pix >> vec2u(1u);
         // WGSL requires parentheses when mixing bitwise (^) with arithmetic (*)
@@ -182,16 +194,6 @@ fn fragmentMain(input: FragmentInput) -> FragmentOutput {
         output.color = vec4f(gaussianColor.rgb, 2.0);
         output.color1 = vec4f(0.0);
       #else
-        let selected = (gaussianFlags & 1u) != 0u;
-        let locked = (gaussianFlags & 2u) != 0u;
-        let norm = normExp(radius);
-        var alpha = norm * gaussianColor.a;
-        // rings apply only to the selected splat's gaussians (gaussianId is the
-        // cache entry index in the forward pass, where pickBase is 0)
-        let rings = gaussianId >= uniform.ringsBase && gaussianId < uniform.ringsBase + uniform.ringsCount;
-        if (!locked && rings && uniform.ringSize > 0.0) {
-            alpha = select(0.6, max(0.05, alpha), radius < 1.0 - uniform.ringSize);
-        }
         if (uniform.outlineMode != 0u) {
             output.color = vec4f(gaussianColor.rgb * alpha, alpha);
             output.color1 = vec4f(0.0, 0.0, 0.0, select(0.0, norm, selected));


### PR DESCRIPTION
Changes:
- Stochastic Alpha 'auto' no longer latches permanently on one slow frame: the decision now follows the GPU timing of the last rendered sorted frame, with async profiler reports attributed to the frame they measured via renderVersion, so hiding content or moving to a lighter view drops back to sorted rendering.
- Rings mode now renders in stochastic frames: the ring alpha reshaping is shared between the sorted blend and the stochastic coverage test, so the two paths match. The selection underlay and outline remain sorted-only.
- Document loads no longer flash half-assembled frames: the viewport stops rendering while a project is applied (layers appear before their saved transforms, and the camera pose is restored last), then renders the final state once on completion.
- Fixed loading .ssproj files from a URL: the fetched contents were passed to the loader as an unresolved promise, failing with "Cannot read zip from source with unknown size".