### PR TITLE
Optimize camera pose imports

### DIFF
--- a/src/camera-poses.ts
+++ b/src/camera-poses.ts
@@ -204,8 +204,10 @@ class CameraAnimTrack implements AnimTrack {
      * Load poses from serialized data.
      */
     loadPoses(posesData: Pose[]): void {
+        const defaultFov = this.events.invoke('camera.fov');
         this.poses.length = 0;
         posesData.forEach((pose) => {
+            pose.fov ??= defaultFov;
             this.poses.push(pose);
         });
         this.rebuildSpline();
@@ -284,6 +286,10 @@ const registerCameraPosesEvents = (events: Events) => {
     // Legacy support: add pose directly
     events.on('camera.addPose', (pose: Pose) => {
         track.addPose(pose);
+    });
+
+    events.on('camera.loadPoses', (poses: Pose[]) => {
+        track.loadPoses(poses);
     });
 
     // Serialization

--- a/src/camera-poses.ts
+++ b/src/camera-poses.ts
@@ -207,8 +207,10 @@ class CameraAnimTrack implements AnimTrack {
         const defaultFov = this.events.invoke('camera.fov');
         this.poses.length = 0;
         posesData.forEach((pose) => {
-            pose.fov ??= defaultFov;
-            this.poses.push(pose);
+            this.poses.push({
+                ...pose,
+                fov: pose.fov ?? defaultFov
+            });
         });
         this.rebuildSpline();
         this.events.fire('track.keysLoaded');

--- a/src/file-handler.ts
+++ b/src/file-handler.ts
@@ -1,5 +1,6 @@
 import { path, Quat, Vec3 } from 'playcanvas';
 
+import type { Pose } from './camera-poses';
 import { CreateDropHandler } from './drop-handler';
 import { ElementType } from './element';
 import { Events } from './events';
@@ -168,6 +169,7 @@ const loadCameraPoses = async (file: ImportFile, events: Events) => {
             return (avalue && bvalue) ? parseInt(avalue, 10) - parseInt(bvalue, 10) : 0;
         };
 
+        const poses: Pose[] = [];
         json.sort(sorter).forEach((pose: any, i: number) => {
             if (pose.hasOwnProperty('position') && pose.hasOwnProperty('rotation')) {
                 const p = new Vec3(pose.position);
@@ -177,14 +179,14 @@ const loadCameraPoses = async (file: ImportFile, events: Events) => {
                 vec.copy(z).mulScalar(10).add(p);
 
                 // compute max FOV from intrinsics (vertical or horizontal, whichever is larger)
-                let fov = 60;
+                let fov: number | undefined;
                 if (pose.fx && pose.fy && pose.width && pose.height) {
                     const fovX = 2 * Math.atan(pose.width / (2 * pose.fx)) * (180 / Math.PI);
                     const fovY = 2 * Math.atan(pose.height / (2 * pose.fy)) * (180 / Math.PI);
                     fov = Math.max(fovX, fovY);
                 }
 
-                events.fire('camera.addPose', {
+                poses.push({
                     name: pose.img_name ?? `${file.filename}_${i}`,
                     frame: i,
                     position: new Vec3(-p.x, -p.y, p.z),
@@ -193,6 +195,10 @@ const loadCameraPoses = async (file: ImportFile, events: Events) => {
                 });
             }
         });
+
+        if (poses.length > 0) {
+            events.fire('camera.loadPoses', poses);
+        }
     }
 };
 
@@ -235,7 +241,7 @@ const loadImagesTxt = async (file: ImportFile, events: Events) => {
     const q = new Quat();
     const t = new Vec3();
 
-    poses.forEach((pose, i) => {
+    const cameraPoses = poses.map((pose, i) => {
         const { w, x, y, z, tx, ty, tz } = pose;
 
         q.set(x, y, z, w).normalize().invert();
@@ -245,13 +251,17 @@ const loadImagesTxt = async (file: ImportFile, events: Events) => {
         q.transformVector(Vec3.BACK, vec);
         vec.mulScalar(10).add(t);
 
-        events.fire('camera.addPose', {
+        return {
             name: pose.name,
             frame: i,
             position: new Vec3(-t.x, -t.y, t.z),
             target: new Vec3(-vec.x, -vec.y, vec.z)
-        });
+        };
     });
+
+    if (cameraPoses.length > 0) {
+        events.fire('camera.loadPoses', cameraPoses);
+    }
 };
 
 // initialize file handler events


### PR DESCRIPTION
Batch-load JSON and COLMAP camera poses so the animation spline and timeline rebuild only once per import, while preserving the current camera FOV when imported poses omit it. Tested with `npm run lint` and `npm run build`.