### PR TITLE
Fix orthographic splat rendering and picking

### DIFF
--- a/src/camera.ts
+++ b/src/camera.ts
@@ -763,17 +763,23 @@ class Camera extends Element {
         const screenY = y * scene.canvas.clientHeight;
 
         // Calculate world position from ray and depth. linearDepth is the view
-        // depth measured from the camera, but the ray origin differs by
-        // projection: perspective starts at the camera (depth 0), ortho on the
-        // near plane (depth = near). Offset the along-ray parameter by the
-        // origin's depth so the point lands on the surface, while distance stays
-        // camera-relative for the caller's dolly/zoom.
+        // depth from the camera, but getRay seeds the ray origin differently per
+        // projection: at the camera for perspective, on (just behind) the near
+        // plane for ortho. Measure the origin's own view depth and offset by it,
+        // rather than assuming near, so the point lands exactly on the surface.
         this.getRay(screenX, screenY, ray);
-        const cosAngle = ray.direction.dot(this.mainCamera.forward);
-        const distance = linearDepth / cosAngle;
-        const t = (linearDepth - (this.ortho ? this.near : 0)) / cosAngle;
+        const cameraPos = this.mainCamera.getPosition();
+        const forward = this.mainCamera.forward;
+        const cosAngle = ray.direction.dot(forward);
+        const originDepth = vecb.sub2(ray.origin, cameraPos).dot(forward);
+        const t = (linearDepth - originDepth) / cosAngle;
         const position = new Vec3();
         position.copy(ray.origin).add(vec.copy(ray.direction).mulScalar(t));
+
+        // distance from the camera to the picked point, always positive: a
+        // behind-camera ortho splat has negative view depth, and passing that
+        // straight to setDistance() would clamp to minZoom and collapse the view.
+        const distance = position.distance(cameraPos);
 
         return {
             splat: closestSplat,

--- a/src/camera.ts
+++ b/src/camera.ts
@@ -776,10 +776,14 @@ class Camera extends Element {
         const position = new Vec3();
         position.copy(ray.origin).add(vec.copy(ray.direction).mulScalar(t));
 
-        // distance from the camera to the picked point, always positive: a
-        // behind-camera ortho splat has negative view depth, and passing that
-        // straight to setDistance() would clamp to minZoom and collapse the view.
-        const distance = position.distance(cameraPos);
+        // dolly distance for the caller: the along-view distance to the surface,
+        // |linearDepth| / cosAngle. abs keeps behind-camera ortho depths positive
+        // (a negative distance would clamp to minZoom and collapse the view), and
+        // dividing by cosAngle reproduces perspective's ray distance unchanged.
+        // Deliberately the along-view distance, not position.distance(cameraPos):
+        // the latter includes the lateral offset for an off-axis ortho pick, which
+        // would couple orthoHeight to where in the viewport the click landed.
+        const distance = Math.abs(linearDepth) / cosAngle;
 
         return {
             splat: closestSplat,

--- a/src/camera.ts
+++ b/src/camera.ts
@@ -655,11 +655,21 @@ class Camera extends Element {
         vec.sub2(bound.center, cameraPosition);
         const dist = vec.dot(forwardVec);
 
-        const far = Math.max(dist + boundRadius, 1e-2);
-        const near = Math.max(dist - boundRadius, far / (1024 * 16));
+        if (this.ortho) {
+            // orthographic has no perspective divide, so the near plane can sit
+            // behind the camera. Span the whole scene bound (near goes negative
+            // when the camera is inside it) so scene content is never clipped in
+            // front of or behind the camera.
+            const radius = Math.max(boundRadius, 1e-2);
+            this.far = dist + radius;
+            this.near = dist - radius;
+        } else {
+            const far = Math.max(dist + boundRadius, 1e-2);
+            const near = Math.max(dist - boundRadius, far / (1024 * 16));
 
-        this.far = far;
-        this.near = Math.min(1.0, near);
+            this.far = far;
+            this.near = Math.min(1.0, near);
+        }
     }
 
     onPreRender() {
@@ -752,16 +762,23 @@ class Camera extends Element {
         const screenX = x * scene.canvas.clientWidth;
         const screenY = y * scene.canvas.clientHeight;
 
-        // Calculate world position from ray and depth
+        // Calculate world position from ray and depth. linearDepth is the view
+        // depth measured from the camera, but the ray origin differs by
+        // projection: perspective starts at the camera (depth 0), ortho on the
+        // near plane (depth = near). Offset the along-ray parameter by the
+        // origin's depth so the point lands on the surface, while distance stays
+        // camera-relative for the caller's dolly/zoom.
         this.getRay(screenX, screenY, ray);
-        const t = linearDepth / ray.direction.dot(this.mainCamera.forward);
+        const cosAngle = ray.direction.dot(this.mainCamera.forward);
+        const distance = linearDepth / cosAngle;
+        const t = (linearDepth - (this.ortho ? this.near : 0)) / cosAngle;
         const position = new Vec3();
         position.copy(ray.origin).add(vec.copy(ray.direction).mulScalar(t));
 
         return {
             splat: closestSplat,
             position: position,
-            distance: t
+            distance: distance
         };
     }
 

--- a/src/projected-splat-renderer.ts
+++ b/src/projected-splat-renderer.ts
@@ -364,7 +364,9 @@ class ProjectedSplatRenderer {
             new UniformFormat('visible', UNIFORMTYPE_UINT),
             new UniformFormat('selectionEnabled', UNIFORMTYPE_UINT),
             new UniformFormat('pickOp', UNIFORMTYPE_INT),
-            new UniformFormat('minPixelSize', UNIFORMTYPE_FLOAT)
+            new UniformFormat('minPixelSize', UNIFORMTYPE_FLOAT),
+            new UniformFormat('near', UNIFORMTYPE_FLOAT),
+            new UniformFormat('far', UNIFORMTYPE_FLOAT)
         ]);
         const bindGroupFormat = new BindGroupFormat(this.device, [
             new BindStorageBufferFormat('sortKeys', SHADERSTAGE_COMPUTE),
@@ -710,6 +712,8 @@ class ProjectedSplatRenderer {
             compute.setParameter('selectionEnabled', selectionEnabled ? 1 : 0);
             compute.setParameter('pickOp', -1);
             compute.setParameter('minPixelSize', minPixelSize);
+            compute.setParameter('near', cameraComponent.nearClip);
+            compute.setParameter('far', cameraComponent.farClip);
 
             const workgroups = Math.ceil(placement.entryCapacity / WORKGROUP_SIZE);
             Compute.calcDispatchSize(workgroups, this.dispatchSize);

--- a/src/shaders/projected-splat-projector.ts
+++ b/src/shaders/projected-splat-projector.ts
@@ -114,7 +114,10 @@ struct ProjectorUniforms {
     visible: u32,
     selectionEnabled: u32,
     pickOp: i32,
-    minPixelSize: f32
+    minPixelSize: f32,
+    // camera clip planes, used to linearly normalize view depth for the sort key
+    near: f32,
+    far: f32
 }
 
 // compaction output: surviving splats are appended to a dense list, so the sort
@@ -282,7 +285,16 @@ fn main(
         return;
     }
 
-    let direction = normalize(vec2f(cov01, lambda1 - cov00));
+    // principal-axis direction. When the projected covariance is (near-)circular
+    // the eigenvector is undefined and vec2f(cov01, lambda1 - cov00) collapses to
+    // zero, so normalize() would yield NaN and poison the whole quad. Isotropic
+    // gaussians project to exact circles under an orthographic camera (the
+    // perspective Jacobian never breaks the symmetry), so this is the common case
+    // for spherical skybox splats, not a corner case - fall back to an arbitrary
+    // axis, which is correct for a circle.
+    let eigenVec = vec2f(cov01, lambda1 - cov00);
+    let eigenLen = length(eigenVec);
+    let direction = select(vec2f(1.0, 0.0), eigenVec / eigenLen, eigenLen > 1e-9);
     let axis1 = 2.0 * min(sqrt(2.0 * lambda1), maxRadius) * direction;
     let len2 = 2.0 * min(sqrt(2.0 * lambda2), maxRadius);
     let axis2 = len2 * vec2f(direction.y, -direction.x);
@@ -360,7 +372,14 @@ fn main(
     // survivor: claim a slot in the compact list. Only surviving threads contend,
     // which is 0.1-10% of the dispatch in practice
     let slot = atomicAdd(&splatCounter[0], 1u);
-    sortKeys[slot] = (~bitcast<u32>(depth)) >> 12u;
+    // depth sort key, back-to-front: linearly normalize view depth to [0,1] over
+    // the clip range and invert so the farthest splat gets the smallest key and
+    // composites first. Linear in both projections (ortho's clip.z is this same
+    // ratio; perspective's clip.z would be hyperbolic, so we normalize the raw
+    // view depth instead). near may be negative in ortho (the camera sits inside
+    // the bound); the subtraction handles that with no sign special-case.
+    let normDepth = (depth - uniforms.near) / (uniforms.far - uniforms.near);
+    sortKeys[slot] = u32(saturate(1.0 - normDepth) * f32((1u << 20u) - 1u));
     compactEntries[slot] = entry;
 }
 `;

--- a/src/shaders/projected-splat-shader.ts
+++ b/src/shaders/projected-splat-shader.ts
@@ -153,7 +153,11 @@ fn vertexMain(input: VertexInput) -> VertexOutput {
     output.selectedRingColor = vec4f(prepareOutputFromGamma(selectedRingRgb, clip.w), 1.0);
     output.gaussianFlags = flags;
     output.gaussianId = entry - uniform.pickBase;
-    output.gaussianDepth = clip.w;
+    // linear view depth for the depth pick (fragment normalizes it by near/far).
+    // clip.w carries this for perspective but is a constant 1 in ortho, which
+    // collapsed every ortho pick to the same depth; the stored view depth works
+    // for both (it equals clip.w under perspective).
+    output.gaussianDepth = depth;
     return output;
 }
 `;


### PR DESCRIPTION
Fix orthographic clipping, depth sorting, and depth picking so splats render and focus correctly when the camera is inside the scene bounds.