### PR TITLE
Fix crashes from stale references and racing clicks in tools, data panel, tooltips and drop handler

### DIFF
--- a/src/drop-handler.ts
+++ b/src/drop-handler.ts
@@ -102,7 +102,7 @@ const CreateDropHandler = (target: HTMLElement, dropHandler: DropHandlerFunc) =>
         // handle single file drops so documents can propagate the filesystemfilehandle
         if (items.length === 1) {
             const item = items[0];
-            if (item.getAsFileSystemHandle && item.webkitGetAsEntry().isFile) {
+            if (item.getAsFileSystemHandle && item.webkitGetAsEntry()?.isFile) {
                 const handle = await item.getAsFileSystemHandle();
                 if (handle?.kind === 'file') {
                     const fileHandle = handle as FileSystemFileHandle;

--- a/src/tools/measure-tool.ts
+++ b/src/tools/measure-tool.ts
@@ -340,7 +340,7 @@ class MeasureTool {
                     const target = splat;
                     const result = await scene.camera.intersect(clickX / canvasContainer.dom.clientWidth, clickY / canvasContainer.dom.clientHeight);
                     // another click may have landed a point while the pick was in flight
-                    if (result && splat === target && splat.measurePoints.length < 2) {
+                    if (result && active && splat === target && splat.measurePoints.length < 2) {
                         mat.invert(splat.worldTransform);
                         mat.transformPoint(result.position, p);
                         splat.measureSelection = splat.measurePoints.length;

--- a/src/tools/measure-tool.ts
+++ b/src/tools/measure-tool.ts
@@ -337,8 +337,10 @@ class MeasureTool {
 
                 // place at the pointer-down position: that is where the user aimed
                 if (splat.measurePoints.length < 2) {
+                    const target = splat;
                     const result = await scene.camera.intersect(clickX / canvasContainer.dom.clientWidth, clickY / canvasContainer.dom.clientHeight);
-                    if (result) {
+                    // another click may have landed a point while the pick was in flight
+                    if (result && splat === target && splat.measurePoints.length < 2) {
                         mat.invert(splat.worldTransform);
                         mat.transformPoint(result.position, p);
                         splat.measureSelection = splat.measurePoints.length;

--- a/src/tools/orient-tool.ts
+++ b/src/tools/orient-tool.ts
@@ -378,7 +378,8 @@ class OrientTool {
         const placePoint = async (offsetX: number, offsetY: number) => {
             const target = splat;
             const picked = new Vec3();
-            if (!await pickSplatSurfacePoint(scene, target, offsetX, offsetY, picked) || !active || splat !== target) {
+            // another click may have landed a point while the pick was in flight
+            if (!await pickSplatSurfacePoint(scene, target, offsetX, offsetY, picked) || !active || splat !== target || splat.orientPoints.length >= 3) {
                 return false;
             }
             splat.orientSelection = splat.orientPoints.length;

--- a/src/ui/data-panel.ts
+++ b/src/ui/data-panel.ts
@@ -644,6 +644,8 @@ class DataPanel extends Container {
                 tick();
             } else {
                 splat = null;
+                // invalidate any histogram task already queued against it
+                pendingToken++;
             }
         });
 

--- a/src/ui/data-panel.ts
+++ b/src/ui/data-panel.ts
@@ -558,7 +558,8 @@ class DataPanel extends Container {
         refreshRange();
 
         const tick = () => {
-            if (!splat || this.hidden) return;
+            // a splat removed from the scene has no scene to query
+            if (!splat?.scene || this.hidden) return;
             const h = hashInputs(inputs);
             if (h === lastHash) return;
             lastHash = h;
@@ -641,6 +642,8 @@ class DataPanel extends Container {
                 inputs.mode = propModeFor(selectedDataProp) ?? 0;
                 populateDataSelector(splat);
                 tick();
+            } else {
+                splat = null;
             }
         });
 

--- a/src/ui/tooltips.ts
+++ b/src/ui/tooltips.ts
@@ -117,7 +117,6 @@ class Tooltips extends Container {
             target.dom.addEventListener('pointerleave', leave);
 
             target.on('destroy', () => {
-                cancelTimer();
                 this.unregister(target);
             });
 

--- a/src/ui/tooltips.ts
+++ b/src/ui/tooltips.ts
@@ -34,6 +34,10 @@ class Tooltips extends Container {
         this.register = (target: Element, textString: TooltipText, direction: Direction = 'bottom') => {
 
             const activate = () => {
+                // the target may have been destroyed while the show timer ran
+                if (!target.dom) {
+                    return;
+                }
                 const rect = target.dom.getBoundingClientRect();
                 const midx = Math.floor((rect.left + rect.right) * 0.5);
                 const midy = Math.floor((rect.top + rect.bottom) * 0.5);
@@ -113,6 +117,7 @@ class Tooltips extends Container {
             target.dom.addEventListener('pointerleave', leave);
 
             target.on('destroy', () => {
+                cancelTimer();
                 this.unregister(target);
             });
 


### PR DESCRIPTION
Fixes five unhandled exceptions seen in production, all in the editor UI.

Measure and orient tools: the click handler checked the point count, awaited the surface pick, then pushed the point. A second click while a pick was in flight passed the check too, leaving the measure tool with three points and the orient tool with four, and the overlay provider then indexed past its scratch vectors and threw on every frame. The count is now re-checked after the await, alongside the existing check that the splat is unchanged.

Splat data panel: the panel kept its reference to the selected splat after the selection went away, so opening it after File > New or deleting the last splat ran the histogram against a splat with no scene. The reference is cleared when the selection is no longer a splat, and the update bails on a splat that has left the scene.

Tooltips: the 250 ms show timer could fire after its target element was destroyed, reading the bounding rect of a null DOM node. The timer is cancelled on destroy and activation bails if the target has no DOM.

Drop handler: dragging anything that is not a file, such as text, a URL or an image from another tab, produced a null entry and threw on the file check. The entry is now optional-chained.