### PR TITLE
Add Min Splat Size control to Settings panel

### DIFF
--- a/src/preferences.ts
+++ b/src/preferences.ts
@@ -93,6 +93,7 @@ const registerPreferences = (events: Events, config: SceneConfig, urlArgs: any) 
         { key: 'camera.fovDolly', setCommand: 'camera.setFovDolly', getDefault: () => false, validate: isBool, group: 'preferences' },
         { key: 'camera.fov', setCommand: 'camera.setFov', urlPath: 'camera.fov', getDefault: () => config.camera.fov, validate: isNumber(10, 120), group: 'preferences' },
         { key: 'view.bands', setCommand: 'view.setBands', urlPath: 'show.shBands', getDefault: () => config.show.shBands, validate: v => typeof v === 'number' && Number.isInteger(v) && v >= 0 && v <= 3, group: 'preferences' },
+        { key: 'view.minPixelSize', setCommand: 'view.setMinPixelSize', getDefault: () => 2, validate: isNumber(0, 20), group: 'preferences' },
         { key: 'camera.flySpeed', setCommand: 'camera.setFlySpeed', getDefault: () => 1, validate: isNumber(0.1, 30), group: 'preferences' },
         { key: 'view.centerSize', setCommand: 'view.setCenterSize', getDefault: () => 2, validate: isNumber(0, 10), group: 'appearance' },
         // the editor skips its footprint-crossing profile swap while preference

--- a/src/ui/settings-panel.ts
+++ b/src/ui/settings-panel.ts
@@ -208,6 +208,28 @@ class SettingsPanel extends Container {
         shBandsRow.append(shBandsLabel);
         shBandsRow.append(shBandsSlider);
 
+        // minimum projected splat size
+
+        const minSplatSizeRow = new Container({
+            class: 'settings-panel-row'
+        });
+
+        const minSplatSizeLabel = new Label({
+            class: 'settings-panel-row-label'
+        });
+        i18n.bindText(minSplatSizeLabel, 'panel.settings.min-splat-size');
+
+        const minSplatSizeSlider = new SliderInput({
+            class: 'settings-panel-row-slider',
+            min: 0,
+            max: 20,
+            precision: 1,
+            value: 2
+        });
+
+        minSplatSizeRow.append(minSplatSizeLabel);
+        minSplatSizeRow.append(minSplatSizeSlider);
+
         // camera fly speed
 
         const cameraFlySpeedRow = new Container({
@@ -263,6 +285,7 @@ class SettingsPanel extends Container {
         this.append(stochasticRow);
         this.append(tonemappingRow);
         this.append(shBandsRow);
+        this.append(minSplatSizeRow);
         this.append(sectionHeader('panel.settings.section-camera'));
         this.append(cameraFlySpeedRow);
         this.append(fovRow);
@@ -309,6 +332,16 @@ class SettingsPanel extends Container {
 
         shBandsSlider.on('change', (value: number) => {
             events.fire('view.setBands', value);
+        });
+
+        // minimum projected splat size
+
+        events.on('view.minPixelSize', (value: number) => {
+            minSplatSizeSlider.value = value;
+        });
+
+        minSplatSizeSlider.on('change', (value: number) => {
+            events.fire('view.setMinPixelSize', value);
         });
 
         // camera speed

--- a/static/locales/de.json
+++ b/static/locales/de.json
@@ -74,6 +74,7 @@
     "panel.settings.fov": "Sichtfeld (FoV)",
     "panel.settings.fov-dolly": "FOV-Auto-Dolly",
     "panel.settings.sh-bands": "SH Bänder",
+    "panel.settings.min-splat-size": "Min Splat Size",
     "panel.settings.fly-speed": "Kamera Geschwindigkeit",
     "panel.settings.stochastic-alpha": "Stochastisches Alpha",
     "panel.settings.stochastic-alpha.disabled": "Deaktiviert",

--- a/static/locales/en.json
+++ b/static/locales/en.json
@@ -74,6 +74,7 @@
     "panel.settings.fov": "Field of View",
     "panel.settings.fov-dolly": "FOV Auto Dolly",
     "panel.settings.sh-bands": "SH Bands",
+    "panel.settings.min-splat-size": "Min Splat Size",
     "panel.settings.fly-speed": "Fly Speed",
     "panel.settings.stochastic-alpha": "Stochastic Alpha",
     "panel.settings.stochastic-alpha.disabled": "Disabled",

--- a/static/locales/es.json
+++ b/static/locales/es.json
@@ -74,6 +74,7 @@
     "panel.settings.fov": "Campo de visión",
     "panel.settings.fov-dolly": "Auto dolly de FOV",
     "panel.settings.sh-bands": "Bandas SH",
+    "panel.settings.min-splat-size": "Min Splat Size",
     "panel.settings.fly-speed": "Velocidad de vuelo",
     "panel.settings.stochastic-alpha": "Alfa estocástico",
     "panel.settings.stochastic-alpha.disabled": "Desactivado",

--- a/static/locales/fr.json
+++ b/static/locales/fr.json
@@ -74,6 +74,7 @@
     "panel.settings.fov": "Champ de vision",
     "panel.settings.fov-dolly": "Dolly auto du FOV",
     "panel.settings.sh-bands": "Ordres d'HS",
+    "panel.settings.min-splat-size": "Min Splat Size",
     "panel.settings.fly-speed": "Vitesse de vol",
     "panel.settings.stochastic-alpha": "Alpha stochastique",
     "panel.settings.stochastic-alpha.disabled": "Désactivé",

--- a/static/locales/ja.json
+++ b/static/locales/ja.json
@@ -74,6 +74,7 @@
     "panel.settings.fov": "視野 ( FOV )",
     "panel.settings.fov-dolly": "FOV自動ドリー",
     "panel.settings.sh-bands": "球面調和関数のバンド",
+    "panel.settings.min-splat-size": "Min Splat Size",
     "panel.settings.fly-speed": "カメラの移動速度",
     "panel.settings.stochastic-alpha": "確率的アルファ",
     "panel.settings.stochastic-alpha.disabled": "無効",

--- a/static/locales/ko.json
+++ b/static/locales/ko.json
@@ -74,6 +74,7 @@
     "panel.settings.fov": "시야각",
     "panel.settings.fov-dolly": "FOV 자동 달리",
     "panel.settings.sh-bands": "SH 밴드",
+    "panel.settings.min-splat-size": "Min Splat Size",
     "panel.settings.fly-speed": "카메라 이동 속도",
     "panel.settings.stochastic-alpha": "확률적 알파",
     "panel.settings.stochastic-alpha.disabled": "비활성",

--- a/static/locales/pt-BR.json
+++ b/static/locales/pt-BR.json
@@ -74,6 +74,7 @@
     "panel.settings.fov": "Campo de Visão",
     "panel.settings.fov-dolly": "Dolly Automático de FOV",
     "panel.settings.sh-bands": "Bandas SH",
+    "panel.settings.min-splat-size": "Min Splat Size",
     "panel.settings.fly-speed": "Velocidade de Voo",
     "panel.settings.stochastic-alpha": "Alfa Estocástico",
     "panel.settings.stochastic-alpha.disabled": "Desativado",

--- a/static/locales/ru.json
+++ b/static/locales/ru.json
@@ -74,6 +74,7 @@
     "panel.settings.fov": "Поле зрения",
     "panel.settings.fov-dolly": "Авто-долли FOV",
     "panel.settings.sh-bands": "Полосы SH",
+    "panel.settings.min-splat-size": "Min Splat Size",
     "panel.settings.fly-speed": "Скорость полёта",
     "panel.settings.stochastic-alpha": "Стохастическая альфа",
     "panel.settings.stochastic-alpha.disabled": "Отключено",

--- a/static/locales/zh-CN.json
+++ b/static/locales/zh-CN.json
@@ -74,6 +74,7 @@
     "panel.settings.fov": "视野角",
     "panel.settings.fov-dolly": "FOV 自动推轨",
     "panel.settings.sh-bands": "SH 带",
+    "panel.settings.min-splat-size": "Min Splat Size",
     "panel.settings.fly-speed": "相机飞行速度",
     "panel.settings.stochastic-alpha": "随机 Alpha",
     "panel.settings.stochastic-alpha.disabled": "禁用",


### PR DESCRIPTION
The projected-splat-size cull threshold was hardcoded to 2px in editor.ts with no UI to change it. Scenes with small or thin gaussians lose visible points once the camera is far enough that splats project under this threshold, with no way to disable or tune it.

Adds a "Min Splat Size" slider (0-20px) to Preferences > Rendering, next to SH Bands, wired the same way as the existing sliders there.