### PR TITLE
Fix stale selection after deleting a splat, pointer capture errors in drag tools, rect picks past the canvas edge, and stalled publish uploads

### DIFF
--- a/src/controllers.ts
+++ b/src/controllers.ts
@@ -114,7 +114,7 @@ class PointerController {
                 }
             } else {
                 touches = touches.filter(touch => touch.id !== event.pointerId);
-                if (touches.length === 0) {
+                if (touches.length === 0 && target.hasPointerCapture(event.pointerId)) {
                     target.releasePointerCapture(event.pointerId);
                 }
             }
@@ -207,6 +207,11 @@ class PointerController {
                     }
                 } else if (touches.length === 2) {
                     const touch = touches[touches.map(t => t.id).indexOf(event.pointerId)];
+                    // a touch whose pointerdown landed elsewhere (a tool overlay
+                    // that was then hidden) is not one of ours
+                    if (!touch) {
+                        return;
+                    }
                     touch.x = event.offsetX;
                     touch.y = event.offsetY;
 
@@ -456,6 +461,9 @@ class PointerController {
 
         wrap(target, 'pointerdown', pointerdown);
         wrap(target, 'pointerup', pointerup);
+        // a cancelled touch gets no pointerup; without this its entry stays in
+        // `touches` and later gestures are misread
+        wrap(target, 'pointercancel', pointerup);
         wrap(target, 'pointermove', pointermove);
         wrap(target, 'wheel', wheel, { passive: false });
         wrap(target, 'dblclick', dblclick);

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -405,6 +405,8 @@ const registerEditorEvents = (events: Events, editHistory: EditHistory, scene: S
     // undo, drag-while-camera-settling, etc).
     const runSelectIntersect = (splat: Splat, op: 'add'|'remove'|'set'|'intersect', options: any) => {
         return scene.commandQueue.enqueue(async () => {
+            // the splat may have been deleted while the task was queued
+            if (!splat.scene) return;
             const data = await scene.dataProcessor.intersect(options, splat);
             // SelectOp consumes `data` synchronously in its constructor
             // (IndexRanges.fromPredicate iterates immediately), so we can
@@ -432,6 +434,7 @@ const registerEditorEvents = (events: Events, editHistory: EditHistory, scene: S
     // change an already-finished stroke's semantics
     const runFootprintSelect = (splat: Splat, op: 'add'|'remove'|'set'|'intersect', region: SelectRegion, footprint: number) => {
         return scene.commandQueue.enqueue(async () => {
+            if (!splat.scene) return;
             const data = await scene.projectedSplatRenderer.footprintIntersect(splat, region, footprint);
             if (data) {
                 events.fire('edit.add', new SelectOp(splat, op, data));
@@ -445,6 +448,7 @@ const registerEditorEvents = (events: Events, editHistory: EditHistory, scene: S
     // region. The centers test reuses the through-mode intersect compute
     const runVisibleCentersSelect = (splat: Splat, op: 'add'|'remove'|'set'|'intersect', visible: Set<number>, options: any) => {
         return scene.commandQueue.enqueue(async () => {
+            if (!splat.scene) return;
             const data = await scene.dataProcessor.intersect(options, splat);
             for (let i = 0; i < splat.instances.count; i++) {
                 if (data[i] && !visible.has(i)) {

--- a/src/io/write/writer.ts
+++ b/src/io/write/writer.ts
@@ -25,10 +25,18 @@ class GZipWriter implements Writer {
 
         // hook up the reader side of the compressed stream
         const reader = (async () => {
-            while (true) {
-                const { done, value } = await streamReader.read();
-                if (done) break;
-                await writer.write(value);
+            try {
+                while (true) {
+                    const { done, value } = await streamReader.read();
+                    if (done) break;
+                    await writer.write(value);
+                }
+            } catch (err) {
+                // fail the write side with the sink's error: with nothing draining
+                // the compressed stream, writes would otherwise stall on
+                // backpressure and the error would only surface as an unhandled
+                // rejection
+                await streamWriter.abort(err);
             }
         })();
 

--- a/src/selection.ts
+++ b/src/selection.ts
@@ -38,8 +38,11 @@ const registerSelectionEvents = (events: Events, scene: Scene) => {
 
     events.on('scene.elementRemoved', (element: Element) => {
         if (element === selection) {
+            // the removed splat is already out of the list. the candidate must be
+            // visible or setSelection ignores it and the selection is left
+            // pointing at a splat that is no longer in the scene
             const splats = scene.getElementsByType(ElementType.splat) as Splat[];
-            setSelection(splats.length === 1 ? null : splats.find(v => v !== element));
+            setSelection(splats.find(v => v.visible) ?? null);
         }
     });
 

--- a/src/tools/brush-selection.ts
+++ b/src/tools/brush-selection.ts
@@ -98,7 +98,11 @@ class BrushSelection {
         };
 
         const dragEnd = () => {
-            parent.releasePointerCapture(dragId);
+            // a touch that has lifted, or was cancelled, no longer holds the
+            // capture and releasing it throws
+            if (parent.hasPointerCapture(dragId)) {
+                parent.releasePointerCapture(dragId);
+            }
             dragId = undefined;
             canvas.style.display = 'none';
         };
@@ -126,6 +130,14 @@ class BrushSelection {
             }
         };
 
+        // a cancelled touch gets no pointerup, and a drag left open blocks
+        // every later one
+        const pointercancel = (e: PointerEvent) => {
+            if (e.pointerId === dragId) {
+                dragEnd();
+            }
+        };
+
         const wheel = (e: WheelEvent) => {
             if (e.altKey || e.metaKey) {
                 const { deltaX, deltaY } = e;
@@ -144,6 +156,7 @@ class BrushSelection {
             parent.addEventListener('pointerdown', pointerdown);
             parent.addEventListener('pointermove', pointermove);
             parent.addEventListener('pointerup', pointerup);
+            parent.addEventListener('pointercancel', pointercancel);
             parent.addEventListener('wheel', wheel);
         };
 
@@ -157,6 +170,7 @@ class BrushSelection {
             parent.removeEventListener('pointerdown', pointerdown);
             parent.removeEventListener('pointermove', pointermove);
             parent.removeEventListener('pointerup', pointerup);
+            parent.removeEventListener('pointercancel', pointercancel);
             parent.removeEventListener('wheel', wheel);
         };
 

--- a/src/tools/lasso-selection.ts
+++ b/src/tools/lasso-selection.ts
@@ -109,7 +109,11 @@ class LassoSelection {
         };
 
         const dragEnd = () => {
-            parent.releasePointerCapture(dragId);
+            // a touch that has lifted, or was cancelled, no longer holds the
+            // capture and releasing it throws
+            if (parent.hasPointerCapture(dragId)) {
+                parent.releasePointerCapture(dragId);
+            }
             dragId = undefined;
         };
 
@@ -128,12 +132,23 @@ class LassoSelection {
             }
         };
 
+        // a cancelled touch gets no pointerup, and a drag left open blocks
+        // every later one
+        const pointercancel = (e: PointerEvent) => {
+            if (e.pointerId === dragId) {
+                dragEnd();
+                points = [];
+                paint();
+            }
+        };
+
         this.activate = () => {
             svg.classList.remove('hidden');
             parent.style.display = 'block';
             parent.addEventListener('pointerdown', pointerdown);
             parent.addEventListener('pointermove', pointermove);
             parent.addEventListener('pointerup', pointerup);
+            parent.addEventListener('pointercancel', pointercancel);
         };
 
         this.deactivate = () => {
@@ -146,6 +161,7 @@ class LassoSelection {
             parent.removeEventListener('pointerdown', pointerdown);
             parent.removeEventListener('pointermove', pointermove);
             parent.removeEventListener('pointerup', pointerup);
+            parent.removeEventListener('pointercancel', pointercancel);
         };
     }
 }

--- a/src/tools/polygon-selection.ts
+++ b/src/tools/polygon-selection.ts
@@ -94,6 +94,10 @@ class PolygonSelection {
                 e.preventDefault();
                 e.stopPropagation();
 
+                // a tap, or a click right after a keyboard tool switch, arrives
+                // without a preceding pointermove
+                currentPoint = { x: e.offsetX, y: e.offsetY };
+
                 if (isClosed()) {
                     await commitSelection(e);
                 } else if (points.length === 0 || dist(points[points.length - 1], currentPoint) > 0) {

--- a/src/tools/rect-selection.ts
+++ b/src/tools/rect-selection.ts
@@ -65,10 +65,17 @@ class RectSelection {
         };
 
         const dragEnd = () => {
-            parent.releasePointerCapture(dragId);
+            // a touch that has lifted, or was cancelled, no longer holds the
+            // capture and releasing it throws
+            if (parent.hasPointerCapture(dragId)) {
+                parent.releasePointerCapture(dragId);
+            }
             dragId = undefined;
             svg.classList.add('hidden');
         };
+
+        // the pointer is captured, so a drag can leave the canvas
+        const clamp01 = (v: number) => Math.min(1, Math.max(0, v));
 
         const pointerup = async (e: PointerEvent) => {
             if (e.pointerId === dragId) {
@@ -83,8 +90,8 @@ class RectSelection {
                     await events.invoke(
                         'select.rect',
                         opFromModifiers(e), {
-                            start: { x: Math.min(start.x, end.x) / w, y: Math.min(start.y, end.y) / h },
-                            end: { x: Math.max(start.x, end.x) / w, y: Math.max(start.y, end.y) / h }
+                            start: { x: clamp01(Math.min(start.x, end.x) / w), y: clamp01(Math.min(start.y, end.y) / h) },
+                            end: { x: clamp01(Math.max(start.x, end.x) / w), y: clamp01(Math.max(start.y, end.y) / h) }
                         });
                 } else {
                     // pick - wait for selection to complete before hiding rect
@@ -99,11 +106,20 @@ class RectSelection {
             }
         };
 
+        // a cancelled touch gets no pointerup, and a drag left open blocks
+        // every later one
+        const pointercancel = (e: PointerEvent) => {
+            if (e.pointerId === dragId) {
+                dragEnd();
+            }
+        };
+
         this.activate = () => {
             parent.style.display = 'block';
             parent.addEventListener('pointerdown', pointerdown);
             parent.addEventListener('pointermove', pointermove);
             parent.addEventListener('pointerup', pointerup);
+            parent.addEventListener('pointercancel', pointercancel);
         };
 
         this.deactivate = () => {
@@ -114,6 +130,7 @@ class RectSelection {
             parent.removeEventListener('pointerdown', pointerdown);
             parent.removeEventListener('pointermove', pointermove);
             parent.removeEventListener('pointerup', pointerup);
+            parent.removeEventListener('pointercancel', pointercancel);
         };
     }
 

--- a/src/tools/sphere-brush-selection.ts
+++ b/src/tools/sphere-brush-selection.ts
@@ -151,7 +151,11 @@ class SphereBrushSelection {
         };
 
         const dragEnd = () => {
-            parent.releasePointerCapture(dragId);
+            // a touch that has lifted, or was cancelled, no longer holds the
+            // capture and releasing it throws
+            if (parent.hasPointerCapture(dragId)) {
+                parent.releasePointerCapture(dragId);
+            }
             dragId = undefined;
             canvas.style.display = 'none';
         };
@@ -185,6 +189,14 @@ class SphereBrushSelection {
             }
         };
 
+        // a cancelled touch gets no pointerup, and a drag left open blocks
+        // every later one
+        const pointercancel = (e: PointerEvent) => {
+            if (e.pointerId === dragId) {
+                dragEnd();
+            }
+        };
+
         const wheel = (e: WheelEvent) => {
             if (e.altKey || e.metaKey) {
                 const { deltaX, deltaY } = e;
@@ -203,6 +215,7 @@ class SphereBrushSelection {
             parent.addEventListener('pointerdown', pointerdown);
             parent.addEventListener('pointermove', pointermove);
             parent.addEventListener('pointerup', pointerup);
+            parent.addEventListener('pointercancel', pointercancel);
             parent.addEventListener('wheel', wheel);
         };
 
@@ -216,6 +229,7 @@ class SphereBrushSelection {
             parent.removeEventListener('pointerdown', pointerdown);
             parent.removeEventListener('pointermove', pointermove);
             parent.removeEventListener('pointerup', pointerup);
+            parent.removeEventListener('pointercancel', pointercancel);
             parent.removeEventListener('wheel', wheel);
         };
 


### PR DESCRIPTION
Fixes several crashes seen in production.

Stale selection after delete: deleting the selected splat while another remaining splat was hidden left the selection pointing at the removed splat, since `setSelection` refuses hidden candidates and never fired `selection.changed`. The transform gizmo, histogram range select and queued intersects then dereferenced a splat with no scene. The removal handler now selects the first visible remaining splat, or nothing, and queued select tasks bail if their splat has left the scene. Side effect: deleting the selected splat with exactly one other remaining now selects that one instead of clearing the selection, matching the behaviour with two or more remaining.

Pointer capture in drag tools: rect and lasso released pointer capture after awaiting the selection. For touch input the pointer is gone by then and `releasePointerCapture` throws, which also skipped clearing `dragId` and left the tool dead until the next tool switch. All four drag tools and the camera controller now check `hasPointerCapture` before releasing and handle `pointercancel`.

Rect select past the canvas edge: a captured drag can leave the canvas, producing a negative pick origin in the depth pick path. The rect is now clamped to the canvas.

Polygon tap: a pointerup with no preceding pointermove used a null current point. It is now taken from the event.

Publish upload failures: a failed S3 part upload rejected inside the gzip drain loop with nobody listening, and the remaining writes stalled on backpressure so publish hung. The drain loop now aborts the writable with the error, so the existing publish error popup is shown.

Verified in the browser for the selection, rect, polygon and touch cases, and in Node for the gzip writer (previously an unhandled rejection followed by a hang, now a caught error).