### PR TITLE
Follow-ups to #1032

### DIFF
--- a/src/controllers.ts
+++ b/src/controllers.ts
@@ -103,14 +103,17 @@ class PointerController {
 
         const pointerup = (event: PointerEvent) => {
             if (event.pointerType === 'mouse') {
-                // Only release if this is the button that was initially pressed
-                if (event.button === pressedButton) {
+                // Only release if this is the button that was initially pressed.
+                // pointercancel carries button -1, so it releases whatever is held
+                if (event.button === pressedButton || event.type === 'pointercancel') {
                     // MMB tap (no significant movement) -> focus on cursor point (orbit only; fly uses MMB for zoom)
-                    if (pressedButton === 1 && camera.controlMode === 'orbit' && !mmbDragged) {
+                    if (pressedButton === 1 && camera.controlMode === 'orbit' && !mmbDragged && event.type === 'pointerup') {
                         pickFocalPoint(event);
                     }
                     pressedButton = -1;
-                    target.releasePointerCapture(event.pointerId);
+                    if (target.hasPointerCapture(event.pointerId)) {
+                        target.releasePointerCapture(event.pointerId);
+                    }
                 }
             } else {
                 touches = touches.filter(touch => touch.id !== event.pointerId);
@@ -195,6 +198,11 @@ class PointerController {
             } else {
                 if (touches.length === 1) {
                     const touch = touches[0];
+                    // a touch whose pointerdown landed elsewhere (a tool overlay
+                    // that was then hidden) is not one of ours
+                    if (touch.id !== event.pointerId) {
+                        return;
+                    }
                     const dx = event.offsetX - touch.x;
                     const dy = event.offsetY - touch.y;
                     touch.x = event.offsetX;

--- a/src/io/write/writer.ts
+++ b/src/io/write/writer.ts
@@ -37,8 +37,16 @@ class GZipWriter implements Writer {
                 // backpressure and the error would only surface as an unhandled
                 // rejection
                 await streamWriter.abort(err);
+                // aborting an already-closed writable resolves, so the error must
+                // be rethrown or a sink failure on the final chunk would be lost
+                throw err;
             }
         })();
+
+        // close() awaits reader and surfaces its error; this handler only keeps
+        // the rejection from being reported as unhandled when the caller aborts
+        // instead of closing
+        reader.catch(() => {});
 
         this.write = async (data: Uint8Array) => {
             this.cursor += data.byteLength;


### PR DESCRIPTION
## Summary

- **GZipWriter swallowed a sink failure on the final chunk.** Aborting an already-closed writable resolves, and `streamWriter.close()` resolves before the reader has drained the gzip trailer, so a sink error on that last write was lost and `close()` reported success. The reader now rethrows after aborting. Reproduced in Node 22: the previous code resolved `close()`, this code rejects it with the sink error.
- **Mouse pointercancel did not reset controller state.** `pointercancel` carries `button === -1`, so it never matched `pressedButton`. The mouse branch now also matches on `pointercancel`, skips focal-point picking for it, and guards the capture release with `hasPointerCapture`.
- **Single-touch moves ignored the pointer id.** The one-touch branch applied every touch `pointermove` to `touches[0]`, so a finger that landed elsewhere and slid onto the canvas jumped the camera. It now checks the id like the two-touch branch does since #1032.