### PR TITLE
Fix build against engine 2.22.0

### DIFF
--- a/src/camera.ts
+++ b/src/camera.ts
@@ -520,7 +520,6 @@ class Camera extends Element {
             this.mainTarget = new RenderTarget({
                 colorBuffer,
                 depthBuffer,
-                flipY: false,
                 autoResolve: false
             });
 
@@ -531,7 +530,6 @@ class Camera extends Element {
                     workBuffer          // RT1: overlay output (shared with workTarget)
                 ],
                 depthBuffer,
-                flipY: false,
                 autoResolve: false
             });
 

--- a/src/scene.ts
+++ b/src/scene.ts
@@ -10,7 +10,8 @@ import {
     Layer,
     GraphicsDevice,
     MeshInstance,
-    Vec3
+    Vec3,
+    WireRenderer
 } from 'playcanvas';
 
 import { AssetLoader } from './asset-loader';
@@ -81,6 +82,7 @@ class Scene {
     config: SceneConfig;
     canvas: HTMLCanvasElement;
     app: PCApp;
+    wire: WireRenderer;
     worldLayer: Layer;
     splatLayer: Layer;
     overlayLayer: Layer;
@@ -201,6 +203,7 @@ class Scene {
         // configure the playcanvas application. we render to an offscreen buffer so require
         // only the simplest of backbuffers.
         this.app = new PCApp(canvas, { graphicsDevice });
+        this.wire = new WireRenderer(this.app);
 
         // only render the scene when instructed
         this.app.autoRender = false;
@@ -297,6 +300,7 @@ class Scene {
 
         // get the world layer
         this.worldLayer = this.app.scene.layers.getLayerByName('World');
+        this.wire.layer = this.worldLayer;
 
         // splat layer - dedicated layer for splat rendering with MRT
         this.splatLayer = new Layer({
@@ -599,24 +603,20 @@ class Scene {
                     const splat = e as Splat;
 
                     const local = splat.localBound;
-                    this.app.drawWireAlignedBox(
-                        local.getMin(),
-                        local.getMax(),
-                        Color.RED,
-                        true,
-                        undefined,
-                        splat.entity.getWorldTransform());
+                    this.wire.color = Color.RED;
+                    this.wire.transform = splat.entity.getWorldTransform();
+                    this.wire.boxMinMax(local.getMin(), local.getMax());
 
                     const world = splat.worldBound;
-                    this.app.drawWireAlignedBox(
-                        world.getMin(),
-                        world.getMax(),
-                        Color.GREEN);
+                    this.wire.color = Color.GREEN;
+                    this.wire.transform = null;
+                    this.wire.boxMinMax(world.getMin(), world.getMax());
                 }
             });
 
             // draw scene bound
-            this.app.drawWireAlignedBox(this.bound.getMin(), this.bound.getMax(), Color.BLUE);
+            this.wire.color = Color.BLUE;
+            this.wire.boxMinMax(this.bound.getMin(), this.bound.getMax());
         }
     }
 


### PR DESCRIPTION
Follow-up to #1034 (engine 2.21.4 → 2.22.0). Two engine breaking changes broke the TypeScript build.

- **Debug bound overlay uses `WireRenderer`.** The wire drawing methods were removed from `AppBase` (playcanvas/engine#9289), leaving `drawWireAlignedBox` as an empty stub. The `debug.showBound` boxes in `scene.ts` now go through a `WireRenderer` on the World layer. The engine default is the immediate layer, which the editor camera never renders, so this also makes the overlay visible for the first time on v3.
- **Dropped deprecated `flipY: false` on the main and splat render targets.** Superseded by `origin` (playcanvas/engine#9101). `false` was the default and maps to `RENDERTARGET_ORIGIN_NATIVE`, so no behaviour change.

The radix sort needs no changes: the API is unchanged, and the only engine fix there (playcanvas/engine#9276, initial-values buffer no longer overwritten by intermediate passes) was harmless for us since `compactEntries` is rebuilt every frame.

Verified: `tsc`, lint and build clean; hog.sog renders sorted with working picks and no console errors; `?debug.showBound=true` draws the scene bound.