### PR TITLE
Fix saving or exporting over a file the scene is still reading from

### DIFF
--- a/src/doc.ts
+++ b/src/doc.ts
@@ -5,7 +5,7 @@ import { decodeInstances, encodeInstances, restorePalettes } from './doc-instanc
 import type { EditorSplatResource } from './editor-splat-resource';
 import { Events } from './events';
 import { GaussianInstances } from './gaussian-instances';
-import { BrowserFileSystem, BlobReadSource } from './io';
+import { BrowserFileSystem, BlobReadSource, loadSplatSource, readsFromFile } from './io';
 import { recentFiles } from './recent-files';
 import { Scene } from './scene';
 import { Splat } from './splat';
@@ -70,6 +70,12 @@ const registerDocEvents = (scene: Scene, events: Events) => {
     // opened document fail with 'Source has been closed'.
     let documentFs: ZipReadFileSystem = null;
 
+    // the file the archive reads from, and the resources reading from it. The
+    // browser invalidates a File once its file changes, so saving over that file
+    // has to move them all onto the new archive afterwards (see rebindDocument)
+    let documentSource: BlobReadSource = null;
+    let documentResources = new Set<EditorSplatResource>();
+
     // show the user a reset confirmation popup
     const getResetConfirmation = async () => {
         const result = await events.invoke('showPopup', {
@@ -95,14 +101,17 @@ const registerDocEvents = (scene: Scene, events: Events) => {
         documentFileHandle = null;
         documentFs?.close();
         documentFs = null;
+        documentSource = null;
+        documentResources = new Set();
     };
 
-    // load the document from the given file
-    const loadDocument = async (file: File) => {
+    // load the document from the given file. `handle` is the file's handle when
+    // known, so a later save over the same file can be recognised
+    const loadDocument = async (file: File, handle?: FileSystemFileHandle) => {
         events.fire('startSpinner');
 
         // Create streaming ZIP reader from the file
-        const blobSource = new BlobReadSource(file);
+        const blobSource = new BlobReadSource(file, handle ?? null);
         const zipFs = new ZipReadFileSystem(blobSource);
 
         try {
@@ -124,6 +133,7 @@ const registerDocEvents = (scene: Scene, events: Events) => {
             // adopt this one only afterwards
             resetScene();
             documentFs = zipFs;
+            documentSource = blobSource;
 
             // read document.json via streaming (only reads what's needed)
             const docSource = await zipFs.createSource('document.json');
@@ -138,7 +148,9 @@ const registerDocEvents = (scene: Scene, events: Events) => {
                 // beyond its list.
                 const assets: { asset: Asset, rotation: Quat }[] = [];
                 for (const resource of document.resources) {
-                    assets.push(await scene.assetLoader.loadAsset(resource.filename, zipFs, false, true));
+                    const loaded = await scene.assetLoader.loadAsset(resource.filename, zipFs, false, true);
+                    documentResources.add(loaded.asset.resource as EditorSplatResource);
+                    assets.push(loaded);
                 }
 
                 for (const splatSettings of document.splats) {
@@ -168,6 +180,7 @@ const registerDocEvents = (scene: Scene, events: Events) => {
                     // load splat directly from the zip filesystem (streams on-demand)
                     // skipReorder=true because ssproj PLY files are already in morton order
                     const splat = await scene.assetLoader.load(filename, zipFs, false, true);
+                    documentResources.add(splat.resource);
 
                     await scene.add(splat);
 
@@ -220,7 +233,12 @@ const registerDocEvents = (scene: Scene, events: Events) => {
     // optimisation: if one layer deleted rows another still references, dropping
     // them would corrupt that other layer. Rows nothing references are dropped, so
     // deletions become permanent at save - as they already were.
-    const groupByResource = (splats: Splat[]) => {
+    //
+    // `compact` false keeps every row instead, so the written resource is an
+    // identical view of the live one. Used when saving over the file the document
+    // is open from, where the resources are then re-read from what was written
+    // (see rebindDocument) and an undo must still find its rows.
+    const groupByResource = (splats: Splat[], compact: boolean) => {
         const groups: { resource: EditorSplatResource, layers: Splat[] }[] = [];
         const index = new Map<EditorSplatResource, number>();
         for (const splat of splats) {
@@ -235,6 +253,7 @@ const registerDocEvents = (scene: Scene, events: Events) => {
 
         return groups.map(({ resource, layers }) => {
             const referenced = new Uint8Array(resource.numRows);
+            if (!compact) referenced.fill(1);
             for (const layer of layers) {
                 const { sourceRow, count } = layer.instances;
                 for (let i = 0; i < count; ++i) {
@@ -263,12 +282,14 @@ const registerDocEvents = (scene: Scene, events: Events) => {
         });
     };
 
-    const saveDocument = async (options: { stream?: FileSystemWritableFileStream, filename?: string }) => {
+    // returns the resource groups written, in resource file order, or null if
+    // the save failed
+    const saveDocument = async (options: { stream?: FileSystemWritableFileStream, filename?: string, compact?: boolean }) => {
         events.fire('startSpinner');
 
         try {
             const splats = events.invoke('scene.allSplats') as Splat[];
-            const groups = groupByResource(splats);
+            const groups = groupByResource(splats, options.compact ?? true);
 
             // layer -> the resource file it reads from, and its remapped records
             const layerInfo = new Map<Splat, { resource: number, records: ArrayBuffer }>();
@@ -322,15 +343,65 @@ const registerDocEvents = (scene: Scene, events: Events) => {
 
             // Close zip (also closes underlying browser writer)
             await zipFs.close();
+
+            return groups;
         } catch (error) {
             await events.invoke('showPopup', {
                 type: 'error',
                 header: i18n.t('doc.save-failed'),
                 message: `'${error.message ?? error}'`
             });
+            return null;
         } finally {
             events.fire('stopSpinner');
         }
+    };
+
+    // The document was just written over the file it is open from. The browser
+    // invalidates a File once its file changes, so the archive and every resource
+    // reading from it are moved onto the freshly written file. The rows were
+    // written verbatim (see writeDocument), so each resource's new entry is an
+    // identical view of its rows: nothing is copied or re-uploaded.
+    const rebindDocument = async (handle: FileSystemFileHandle, groups: { resource: EditorSplatResource }[]) => {
+        const blobSource = new BlobReadSource(await handle.getFile(), handle);
+        const zipFs = new ZipReadFileSystem(blobSource);
+        const rebound = new Set<EditorSplatResource>();
+        for (let i = 0; i < groups.length; ++i) {
+            const { resource } = groups[i];
+            if (!documentResources.has(resource)) continue;
+            const loaded = await loadSplatSource(`resource_${i}.ply`, zipFs, true);
+            await resource.rebind(loaded.source);
+            rebound.add(resource);
+        }
+        documentFs?.close();
+        documentFs = zipFs;
+        documentSource = blobSource;
+        documentResources = rebound;
+    };
+
+    // write the document to `handle`, which may be the file it is open from.
+    // returns false if nothing was written
+    const writeDocument = async (handle: FileSystemFileHandle) => {
+        // a file an imported splat still streams from can't be overwritten: the
+        // exported data is baked, so there is no way to read it back afterwards
+        if (await events.invoke('scene.readsFromFile', handle)) {
+            await events.invoke('showPopup', {
+                type: 'error',
+                header: i18n.t('doc.save-failed'),
+                message: i18n.t('popup.overwrite-source')
+            });
+            return false;
+        }
+
+        const inPlace = documentSource && await readsFromFile([documentSource], handle);
+        const groups = await saveDocument({ stream: await handle.createWritable(), compact: !inPlace });
+        if (!groups) {
+            return false;
+        }
+        if (inPlace) {
+            await rebindDocument(handle, groups);
+        }
+        return true;
     };
 
     // handle user requesting a new document
@@ -354,7 +425,7 @@ const registerDocEvents = (scene: Scene, events: Events) => {
             return false;
         }
 
-        await loadDocument(file);
+        await loadDocument(file, handle);
 
         events.fire('doc.setName', file.name);
 
@@ -387,7 +458,7 @@ const registerDocEvents = (scene: Scene, events: Events) => {
                     const fileHandle = fileHandles[0];
 
                     // null file handle incase loadDocument fails
-                    await loadDocument(await fileHandle.getFile());
+                    await loadDocument(await fileHandle.getFile(), fileHandle);
 
                     // store file handle for subsequent saves
                     documentFileHandle = fileHandle;
@@ -414,7 +485,7 @@ const registerDocEvents = (scene: Scene, events: Events) => {
                 }
             }
 
-            await loadDocument(await fileHandle.getFile());
+            await loadDocument(await fileHandle.getFile(), fileHandle);
 
             // store file handle for subsequent saves
             documentFileHandle = fileHandle;
@@ -435,10 +506,9 @@ const registerDocEvents = (scene: Scene, events: Events) => {
     events.function('doc.save', async () => {
         if (documentFileHandle) {
             try {
-                await saveDocument({
-                    stream: await documentFileHandle.createWritable()
-                });
-                events.fire('doc.saved');
+                if (await writeDocument(documentFileHandle)) {
+                    events.fire('doc.saved');
+                }
             } catch (error) {
                 if (error.name !== 'AbortError' && error.name !== 'NotAllowedError') {
                     console.error(error);
@@ -457,7 +527,9 @@ const registerDocEvents = (scene: Scene, events: Events) => {
                     types: SuperFileType,
                     suggestedName: 'scene.ssproj'
                 });
-                await saveDocument({ stream: await handle.createWritable() });
+                if (!await writeDocument(handle)) {
+                    return false;
+                }
                 documentFileHandle = handle;
                 events.fire('doc.setName', handle.name);
                 events.fire('doc.saved');

--- a/src/drop-handler.ts
+++ b/src/drop-handler.ts
@@ -55,6 +55,23 @@ const resolveDirectories = (entries: Array<FileSystemEntry>): Promise<Array<File
     });
 };
 
+// collect the files under a dropped handle, named by their path relative to the
+// drop (so a dropped folder 'foo' yields 'foo/a.ply', matching resolveDirectories)
+const resolveHandles = async (handle: FileSystemHandle, prefix: string, result: Array<DroppedFile>) => {
+    if (handle.name === '.DS_Store') {
+        return;
+    }
+
+    if (handle.kind === 'file') {
+        const fileHandle = handle as FileSystemFileHandle;
+        result.push(new DroppedFile(prefix + handle.name, await fileHandle.getFile(), fileHandle));
+    } else {
+        for await (const child of (handle as FileSystemDirectoryHandle).values()) {
+            await resolveHandles(child, `${prefix}${handle.name}${path.delimiter}`, result);
+        }
+    }
+};
+
 const removeCommonPrefix = (urls: Array<DroppedFile>) => {
     const split = (pathname: string) => {
         const parts = pathname.split(path.delimiter);
@@ -99,19 +116,26 @@ const CreateDropHandler = (target: HTMLElement, dropHandler: DropHandlerFunc) =>
 
         const items = Array.from(ev.dataTransfer.items);
 
-        // handle single file drops so documents can propagate the filesystemfilehandle
-        if (items.length === 1) {
-            const item = items[0];
-            if (item.getAsFileSystemHandle && item.webkitGetAsEntry()?.isFile) {
-                const handle = await item.getAsFileSystemHandle();
-                if (handle?.kind === 'file') {
-                    const fileHandle = handle as FileSystemFileHandle;
-                    const file = await fileHandle.getFile();
-                    const droppedFile = new DroppedFile(file.name, file, fileHandle);
-                    dropHandler([droppedFile], ev.shiftKey);
-                    return;
+        // Prefer file system handles where the browser provides them (Chromium):
+        // a document keeps its handle for later saves, and every imported file
+        // keeps one so a save can recognise a file the scene still reads from.
+        // The handles must be requested before the handler first yields, after
+        // which the items are no longer readable.
+        if (items.every(item => item.getAsFileSystemHandle)) {
+            const handles = await Promise.all(items.map(item => item.getAsFileSystemHandle()));
+            const files: Array<DroppedFile> = [];
+            for (const handle of handles) {
+                if (handle) {
+                    await resolveHandles(handle, '', files);
                 }
             }
+
+            if (files.length > 1) {
+                removeCommonPrefix(files);
+            }
+
+            dropHandler(files, ev.shiftKey);
+            return;
         }
 
         // Map to entries first

--- a/src/editor-splat-resource.ts
+++ b/src/editor-splat-resource.ts
@@ -20,7 +20,7 @@ import {
     Vec3
 } from 'playcanvas';
 
-import { PermutedChunkSource } from './io';
+import { type BlobReadSource, PermutedChunkSource } from './io';
 
 const SH_REST_COUNTS = [0, 9, 24, 45];
 
@@ -42,7 +42,11 @@ const acquire = (pool: ChunkDataPool, source: ChunkSource, layer: ChunkLayer, co
 };
 
 class EditorSplatResource extends GSplatContainer {
-    readonly source: ChunkSource;
+    // the lazily-read static data. replaced only by rebind()
+    source: ChunkSource;
+    // the local files `source` lazily reads through, when it was loaded from
+    // any. Saves must not overwrite them (see scene.readsFromFile)
+    fileSources: BlobReadSource[] = [];
     readonly sourcePool: ChunkDataPool;
     readonly shBands: SHBands;
     // the state column as loaded from file. read-only after upload: the live
@@ -350,6 +354,19 @@ class EditorSplatResource extends GSplatContainer {
     release() {
         this.layerRefs--;
         return this.layerRefs <= 0;
+    }
+
+    // Read from `source` instead: an identical view of the same rows, in the
+    // same order, from elsewhere. Used after the document is saved over the file
+    // this resource was loaded from, when the freshly written archive replaces
+    // the now-invalid original (see doc.ts). The GPU data is untouched.
+    async rebind(source: ChunkSource) {
+        if (source.meta.numGaussians !== this.numRows) {
+            throw new Error(`Cannot rebind resource: expected ${this.numRows} rows, got ${source.meta.numGaussians}`);
+        }
+        const previous = this.source;
+        this.source = source;
+        await previous.close();
     }
 
     async close() {

--- a/src/file-handler.ts
+++ b/src/file-handler.ts
@@ -4,7 +4,7 @@ import type { Pose } from './camera-poses';
 import { CreateDropHandler } from './drop-handler';
 import { ElementType } from './element';
 import { Events } from './events';
-import { BrowserFileSystem, MappedReadFileSystem } from './io';
+import { BrowserFileSystem, MappedReadFileSystem, readsFromFile } from './io';
 import { Scene } from './scene';
 import { Splat } from './splat';
 import { SerializeSettings, serializeSog, serializeSpz, serializeViewer, SogSettings, SpzSettings, ViewerExportSettings, WebGPUUnavailableError, writeSplatFile } from './splat-serialize';
@@ -296,7 +296,7 @@ const initFileHandler = (scene: Scene, events: Events, dropTarget: HTMLElement) 
             // Create file system with all local files, falling back to URL loading
             const fileSystem = new MappedReadFileSystem(baseUrl);
             files.forEach((f) => {
-                if (f.contents) fileSystem.addFile(f.filename, f.contents);
+                if (f.contents) fileSystem.addFile(f.filename, f.contents, f.handle ?? null);
             });
 
             // Multi-file container formats must load by their relative name so the
@@ -315,6 +315,7 @@ const initFileHandler = (scene: Scene, events: Events, dropTarget: HTMLElement) 
                 // user cancelled the load
                 return null;
             }
+            model.resource.fileSources = fileSystem.sources;
             await scene.add(model);
             return model;
         } catch (error) {
@@ -431,6 +432,15 @@ const initFileHandler = (scene: Scene, events: Events, dropTarget: HTMLElement) 
         return getSplats().length === 0;
     });
 
+    // true if a resource in the scene still streams from the file behind
+    // `handle`. Overwriting that file would invalidate its File object and every
+    // later read - so every later save or export - would fail, so writes to it
+    // are refused
+    events.function('scene.readsFromFile', (handle: FileSystemFileHandle) => {
+        const splats = scene.getElementsByType(ElementType.splat) as Splat[];
+        return readsFromFile(new Set(splats.flatMap(splat => splat.resource.fileSources)), handle);
+    });
+
     events.function('scene.import', async () => {
         if (fileSelector) {
             fileSelector.click();
@@ -457,7 +467,8 @@ const initFileHandler = (scene: Scene, events: Events, dropTarget: HTMLElement) 
                 for (let i = 0; i < handles.length; i++) {
                     files.push({
                         filename: handles[i].name,
-                        contents: await handles[i].getFile()
+                        contents: await handles[i].getFile(),
+                        handle: handles[i]
                     });
                 }
 
@@ -525,6 +536,14 @@ const initFileHandler = (scene: Scene, events: Events, dropTarget: HTMLElement) 
                     types: [filePickerTypes[fileType]],
                     suggestedName: options.filename
                 });
+                if (await events.invoke('scene.readsFromFile', fileHandle)) {
+                    await events.invoke('showPopup', {
+                        type: 'error',
+                        header: i18n.t('popup.error'),
+                        message: i18n.t('popup.overwrite-source')
+                    });
+                    return;
+                }
                 await events.invoke('scene.write', fileType, options, await fileHandle.createWritable());
             } catch (error) {
                 if (error.name !== 'AbortError') {

--- a/src/io/index.ts
+++ b/src/io/index.ts
@@ -6,6 +6,7 @@
 export {
     BlobReadSource,
     MappedReadFileSystem,
+    readsFromFile,
     defaultLodIndex,
     loadSplatSource,
     PermutedChunkSource,

--- a/src/io/read/file-systems.ts
+++ b/src/io/read/file-systems.ts
@@ -51,11 +51,17 @@ class BlobReadSource implements ReadSource {
     readonly size: number;
     readonly seekable: boolean = true;
 
+    // the on-disk file `blob` came from, when known. The browser invalidates a
+    // File object once its file changes, so writes to it are refused while the
+    // source is in use (see readsFromFile)
+    readonly handle: FileSystemFileHandle | null;
+
     private blob: Blob;
     private closed: boolean = false;
 
-    constructor(blob: Blob) {
+    constructor(blob: Blob, handle: FileSystemFileHandle | null = null) {
         this.blob = blob;
+        this.handle = handle;
         this.size = blob.size;
     }
 
@@ -77,33 +83,48 @@ class BlobReadSource implements ReadSource {
     }
 }
 
+// true if any of `sources` reads from the file behind `handle`
+const readsFromFile = async (sources: Iterable<BlobReadSource>, handle: FileSystemFileHandle) => {
+    for (const source of sources) {
+        if (source.handle && await handle.isSameEntry(source.handle)) {
+            return true;
+        }
+    }
+    return false;
+};
+
 /**
  * ReadFileSystem for reading from browser File/Blob objects.
  * Used for drag & drop and file picker scenarios.
  */
 class BlobReadFileSystem implements ReadFileSystem {
-    private files: Map<string, Blob> = new Map();
+    private files: Map<string, { blob: Blob, handle: FileSystemFileHandle | null }> = new Map();
+
+    // every source handed out, so the owner knows which files are in use
+    readonly sources: BlobReadSource[] = [];
 
     /**
      * Add a file to the file system.
      */
-    set(name: string, blob: Blob): void {
-        this.files.set(name.toLowerCase(), blob);
+    set(name: string, blob: Blob, handle: FileSystemFileHandle | null = null): void {
+        this.files.set(name.toLowerCase(), { blob, handle });
     }
 
     /**
      * Get a file by name.
      */
     get(name: string): Blob | undefined {
-        return this.files.get(name.toLowerCase());
+        return this.files.get(name.toLowerCase())?.blob;
     }
 
     createSource(filename: string): Promise<ReadSource> {
-        const blob = this.files.get(filename.toLowerCase());
-        if (!blob) {
+        const entry = this.files.get(filename.toLowerCase());
+        if (!entry) {
             return Promise.reject(new Error(`File not found: ${filename}`));
         }
-        return Promise.resolve(new BlobReadSource(blob));
+        const source = new BlobReadSource(entry.blob, entry.handle);
+        this.sources.push(source);
+        return Promise.resolve(source);
     }
 }
 
@@ -124,15 +145,19 @@ class MappedReadFileSystem implements ReadFileSystem {
     /**
      * Add a local file.
      */
-    addFile(name: string, blob: Blob): void {
-        this.blobFs.set(name, blob);
+    addFile(name: string, blob: Blob, handle: FileSystemFileHandle | null = null): void {
+        this.blobFs.set(name, blob, handle);
+    }
+
+    // the sources handed out over local files
+    get sources(): BlobReadSource[] {
+        return this.blobFs.sources;
     }
 
     async createSource(filename: string): Promise<ReadSource> {
         // First check if we have a local blob
-        const localBlob = this.blobFs.get(filename);
-        if (localBlob) {
-            return new BlobReadSource(localBlob);
+        if (this.blobFs.get(filename)) {
+            return await this.blobFs.createSource(filename);
         }
 
         // Fall back to URL loading
@@ -142,5 +167,6 @@ class MappedReadFileSystem implements ReadFileSystem {
 
 export {
     BlobReadSource,
-    MappedReadFileSystem
+    MappedReadFileSystem,
+    readsFromFile
 };

--- a/src/io/read/index.ts
+++ b/src/io/read/index.ts
@@ -5,7 +5,8 @@
 // File system implementations
 export {
     BlobReadSource,
-    MappedReadFileSystem
+    MappedReadFileSystem,
+    readsFromFile
 } from './file-systems';
 
 // Loading functions

--- a/src/main.ts
+++ b/src/main.ts
@@ -305,7 +305,8 @@ const main = async () => {
             for (const file of launchParams.files) {
                 await events.invoke('import', [{
                     filename: file.name,
-                    contents: await file.getFile()
+                    contents: await file.getFile(),
+                    handle: file
                 }]);
             }
         });

--- a/static/locales/de.json
+++ b/static/locales/de.json
@@ -166,6 +166,7 @@
     "popup.error": "Fehler",
     "popup.error-loading": "Fehler beim Laden der Datei",
     "popup.webgpu-unavailable": "Dieser Export erfordert WebGPU, das in diesem Browser nicht verfügbar ist. Bitte verwenden Sie eine aktuelle Version von Chrome, Edge oder Safari.",
+    "popup.overwrite-source": "Diese Datei wird von der aktuellen Szene verwendet und kann nicht überschrieben werden. Bitte wählen Sie einen anderen Dateinamen.",
     "startup.failed": "SuperSplat konnte nicht gestartet werden. Details finden Sie in der Browser-Konsole.",
     "startup.webgpu-unavailable": "SuperSplat erfordert WebGPU, das in diesem Browser nicht verfügbar ist. Bitte verwenden Sie eine aktuelle Version von Chrome, Edge oder Safari.",
     "popup.load-options-header": "Ladeoptionen",

--- a/static/locales/en.json
+++ b/static/locales/en.json
@@ -166,6 +166,7 @@
     "popup.error": "Error",
     "popup.error-loading": "Error Loading File",
     "popup.webgpu-unavailable": "This export requires WebGPU, which is not available in this browser. Please try a recent version of Chrome, Edge or Safari.",
+    "popup.overwrite-source": "This file is in use by the current scene and can't be overwritten. Choose a different filename.",
     "startup.failed": "SuperSplat failed to start. See the browser console for details.",
     "startup.webgpu-unavailable": "SuperSplat requires WebGPU, which this browser does not support. Please try the latest Chrome, Edge or Safari.",
     "popup.load-options-header": "Load Options",

--- a/static/locales/es.json
+++ b/static/locales/es.json
@@ -166,6 +166,7 @@
     "popup.error": "Error",
     "popup.error-loading": "Error al cargar archivo",
     "popup.webgpu-unavailable": "Esta exportación requiere WebGPU, que no está disponible en este navegador. Pruebe con una versión reciente de Chrome, Edge o Safari.",
+    "popup.overwrite-source": "Este archivo está en uso por la escena actual y no se puede sobrescribir. Elige otro nombre de archivo.",
     "startup.failed": "SuperSplat no se pudo iniciar. Consulte la consola del navegador para más detalles.",
     "startup.webgpu-unavailable": "SuperSplat requiere WebGPU, que no está disponible en este navegador. Pruebe con una versión reciente de Chrome, Edge o Safari.",
     "popup.load-options-header": "Opciones de carga",

--- a/static/locales/fr.json
+++ b/static/locales/fr.json
@@ -166,6 +166,7 @@
     "popup.error": "Erreur",
     "popup.error-loading": "Erreur de chargement du fichier",
     "popup.webgpu-unavailable": "Cette exportation nécessite WebGPU, qui n'est pas disponible dans ce navigateur. Veuillez essayer une version récente de Chrome, Edge ou Safari.",
+    "popup.overwrite-source": "Ce fichier est utilisé par la scène actuelle et ne peut pas être écrasé. Choisissez un autre nom de fichier.",
     "startup.failed": "SuperSplat n'a pas pu démarrer. Consultez la console du navigateur pour plus de détails.",
     "startup.webgpu-unavailable": "SuperSplat nécessite WebGPU, qui n'est pas disponible dans ce navigateur. Veuillez essayer une version récente de Chrome, Edge ou Safari.",
     "popup.load-options-header": "Options de chargement",

--- a/static/locales/ja.json
+++ b/static/locales/ja.json
@@ -166,6 +166,7 @@
     "popup.error": "エラー",
     "popup.error-loading": "ファイルの読み込みエラー",
     "popup.webgpu-unavailable": "このエクスポートにはWebGPUが必要ですが、このブラウザでは利用できません。Chrome、Edge、Safariの最新バージョンをお試しください。",
+    "popup.overwrite-source": "このファイルは現在のシーンで使用中のため上書きできません。別のファイル名を選択してください。",
     "startup.failed": "SuperSplatを起動できませんでした。詳細はブラウザのコンソールをご覧ください。",
     "startup.webgpu-unavailable": "SuperSplatにはWebGPUが必要ですが、このブラウザでは利用できません。Chrome、Edge、Safariの最新バージョンをお試しください。",
     "popup.load-options-header": "読み込みオプション",

--- a/static/locales/ko.json
+++ b/static/locales/ko.json
@@ -166,6 +166,7 @@
     "popup.error": "오류",
     "popup.error-loading": "파일 로드 오류",
     "popup.webgpu-unavailable": "이 내보내기에는 WebGPU가 필요하지만 이 브라우저에서는 사용할 수 없습니다. 최신 버전의 Chrome, Edge 또는 Safari를 사용해 보세요.",
+    "popup.overwrite-source": "이 파일은 현재 씬에서 사용 중이므로 덮어쓸 수 없습니다. 다른 파일 이름을 선택하세요.",
     "startup.failed": "SuperSplat을 시작하지 못했습니다. 자세한 내용은 브라우저 콘솔을 확인하세요.",
     "startup.webgpu-unavailable": "SuperSplat에는 WebGPU가 필요하지만 이 브라우저에서는 사용할 수 없습니다. 최신 버전의 Chrome, Edge 또는 Safari를 사용해 보세요.",
     "popup.load-options-header": "불러오기 옵션",

--- a/static/locales/pt-BR.json
+++ b/static/locales/pt-BR.json
@@ -166,6 +166,7 @@
     "popup.error": "Erro",
     "popup.error-loading": "Erro ao Carregar Arquivo",
     "popup.webgpu-unavailable": "Esta exportação requer WebGPU, que não está disponível neste navegador. Tente uma versão recente do Chrome, Edge ou Safari.",
+    "popup.overwrite-source": "Este arquivo está em uso pela cena atual e não pode ser sobrescrito. Escolha outro nome de arquivo.",
     "startup.failed": "O SuperSplat não conseguiu iniciar. Consulte o console do navegador para mais detalhes.",
     "startup.webgpu-unavailable": "O SuperSplat requer WebGPU, que não está disponível neste navegador. Tente uma versão recente do Chrome, Edge ou Safari.",
     "popup.load-options-header": "Opções de Carregamento",

--- a/static/locales/ru.json
+++ b/static/locales/ru.json
@@ -166,6 +166,7 @@
     "popup.error": "Ошибка",
     "popup.error-loading": "Ошибка загрузки файла",
     "popup.webgpu-unavailable": "Для этого экспорта требуется WebGPU, который недоступен в этом браузере. Попробуйте последнюю версию Chrome, Edge или Safari.",
+    "popup.overwrite-source": "Этот файл используется текущей сценой и не может быть перезаписан. Выберите другое имя файла.",
     "startup.failed": "Не удалось запустить SuperSplat. Подробности см. в консоли браузера.",
     "startup.webgpu-unavailable": "Для SuperSplat требуется WebGPU, который недоступен в этом браузере. Попробуйте последнюю версию Chrome, Edge или Safari.",
     "popup.load-options-header": "Параметры загрузки",

--- a/static/locales/zh-CN.json
+++ b/static/locales/zh-CN.json
@@ -166,6 +166,7 @@
     "popup.error": "错误",
     "popup.error-loading": "加载文件错误",
     "popup.webgpu-unavailable": "此导出需要 WebGPU，但当前浏览器不支持。请尝试使用最新版本的 Chrome、Edge 或 Safari。",
+    "popup.overwrite-source": "该文件正被当前场景使用，无法覆盖。请选择其他文件名。",
     "startup.failed": "SuperSplat 启动失败。详情请查看浏览器控制台。",
     "startup.webgpu-unavailable": "SuperSplat 需要 WebGPU，但当前浏览器不支持。请尝试使用最新版本的 Chrome、Edge 或 Safari。",
     "popup.load-options-header": "加载选项",


### PR DESCRIPTION
Loaded splat data is streamed lazily from the original File object rather than copied into memory. Chrome invalidates that File as soon as the file on disk changes, so saving a project over its own .ssproj, or exporting a PLY over the file it was imported from, succeeded once and then every subsequent save or export failed with NotReadableError.

Saving a project over its own file now works in place: the resources' rows are written verbatim (not compacted, so undo after save still finds its rows), and once the write completes each document resource is rebound to its entry in the freshly written archive. Nothing is copied or re-uploaded, so this works at any file size.

Exporting over a file an imported splat still reads from cannot be recovered the same way, since exports bake transforms and palettes, so it is now refused with a message asking for a different filename. To make that check complete, file handles are kept for every import path, including the file picker, the PWA launch queue, and drag and drop of multiple files and folders, which previously dropped them.