### PR TITLE
Choose output folders from save and export dialogs

### DIFF
--- a/src/doc.ts
+++ b/src/doc.ts
@@ -515,7 +515,6 @@ const registerDocEvents = (scene: Scene, events: Events) => {
         try {
             const hasFilePicker = !!window.showDirectoryPicker;
             const directory = hasFilePicker ? await events.invoke('scene.getExportDirectory') : undefined;
-            if (hasFilePicker && !directory) return false;
 
             const options = await events.invoke('show.savePopup', events.invoke('doc.name') || 'scene.ssproj', directory, documentSource);
             if (!options) return false;

--- a/src/file-handler.ts
+++ b/src/file-handler.ts
@@ -573,8 +573,7 @@ const initFileHandler = (scene: Scene, events: Events, dropTarget: HTMLElement) 
         let directory = exportSettings.directory;
         if (directory) {
             try {
-                if (await directory.queryPermission({ mode: 'readwrite' }) !== 'granted' &&
-                    await directory.requestPermission({ mode: 'readwrite' }) !== 'granted') {
+                if (await directory.queryPermission({ mode: 'readwrite' }) !== 'granted') {
                     directory = undefined;
                 } else {
                     // A saved handle can outlive the folder it refers to.
@@ -588,7 +587,7 @@ const initFileHandler = (scene: Scene, events: Events, dropTarget: HTMLElement) 
                 await persistExportSettings();
             }
         }
-        return directory ?? await events.invoke('scene.pickExportDirectory');
+        return directory;
     });
 
     events.function('scene.export', async (exportType: ExportType) => {
@@ -597,7 +596,6 @@ const initFileHandler = (scene: Scene, events: Events, dropTarget: HTMLElement) 
 
         await exportSettingsReady;
         const directory = hasFilePicker ? await events.invoke('scene.getExportDirectory') : undefined;
-        if (hasFilePicker && !directory) return;
 
         const options = await events.invoke('show.exportPopup', exportType, splats.map(s => s.name), { directory }) as SceneExportOptions;
 

--- a/src/file-handler.ts
+++ b/src/file-handler.ts
@@ -443,13 +443,12 @@ const initFileHandler = (scene: Scene, events: Events, dropTarget: HTMLElement) 
     // Shared by document and splat writes. The document may exclude
     // its own archive source because an in-place save rebinds it afterwards.
     events.function('scene.pickWriteTarget', async (
-        location: string | FileSystemDirectoryHandle,
+        location: FileSystemDirectoryHandle,
         filename: string,
         confirm: (handle: FileSystemFileHandle) => Promise<boolean>,
         exclude?: BlobReadSource
     ) => {
         const target = await pickWriteTarget(location, filename);
-        if (!target) return null;
         if (target.exists) {
             const sources = (await events.invoke('scene.sourcesOf', target.handle) as BlobReadSource[])
             .filter(source => source !== exclude);
@@ -546,9 +545,14 @@ const initFileHandler = (scene: Scene, events: Events, dropTarget: HTMLElement) 
         console.warn('Export settings could not be saved', error);
     });
 
-    events.function('scene.pickExportDirectory', async () => {
+    events.function('scene.pickExportDirectory', async (reuse = false) => {
         await exportSettingsReady;
         try {
+            if (reuse && exportSettings.directory) {
+                await exportSettings.directory.requestPermission({ mode: 'readwrite' });
+                return await events.invoke('scene.getExportDirectory');
+            }
+
             exportSettings.directory = await window.showDirectoryPicker({
                 id: 'SuperSplatFileExport',
                 mode: 'readwrite',
@@ -573,7 +577,10 @@ const initFileHandler = (scene: Scene, events: Events, dropTarget: HTMLElement) 
         let directory = exportSettings.directory;
         if (directory) {
             try {
-                if (await directory.queryPermission({ mode: 'readwrite' }) !== 'granted') {
+                const permission = await directory.queryPermission({ mode: 'readwrite' });
+                // Keep the handle so the folder button can restore access.
+                if (permission === 'prompt') return undefined;
+                if (permission !== 'granted') {
                     directory = undefined;
                 } else {
                     // A saved handle can outlive the folder it refers to.

--- a/src/io/write/pick-target.ts
+++ b/src/io/write/pick-target.ts
@@ -7,15 +7,7 @@ interface WriteTarget {
 
 // Resolve a filename in a chosen folder without modifying an existing file.
 // showSaveFilePicker can truncate the selection before we can protect sources.
-const pickWriteTarget = async (location: string | FileSystemDirectoryHandle, filename: string): Promise<WriteTarget | null> => {
-    let dir: FileSystemDirectoryHandle;
-    try {
-        dir = typeof location === 'string' ? await window.showDirectoryPicker({ id: location, mode: 'readwrite' }) : location;
-    } catch (error) {
-        if (error.name === 'AbortError') return null;
-        throw error;
-    }
-
+const pickWriteTarget = async (dir: FileSystemDirectoryHandle, filename: string): Promise<WriteTarget> => {
     try {
         return { handle: await dir.getFileHandle(filename), exists: true };
     } catch (error) {

--- a/src/ui/export-popup.ts
+++ b/src/ui/export-popup.ts
@@ -68,6 +68,8 @@ class ExportPopup extends Container {
 
         super(args);
 
+        const hasFilePicker = !!window.showDirectoryPicker;
+
         // UI
 
         const dialog = new Container({
@@ -278,7 +280,6 @@ class ExportPopup extends Container {
         const locationValue = new Container({ class: 'location' });
         const locationName = new Label({ class: 'location-name' });
         const changeLocationButton = new Button({ class: 'change-location' });
-        i18n.bindText(changeLocationButton, 'popup.export.change-location');
         locationValue.append(locationName);
         locationValue.append(changeLocationButton);
         locationRow.append(locationLabel);
@@ -370,6 +371,10 @@ class ExportPopup extends Container {
             const filename = getFilename();
             const actionKey = saveProject ? 'menu.file.save' : 'popup.export';
             headerText.text = i18n.t(saveProject ? 'popup.save-as' : 'popup.export.header');
+            locationName.hidden = !directory;
+            locationName.text = directory ? `…/${directory.name}` : '';
+            locationName.dom.title = locationName.text;
+            changeLocationButton.text = i18n.t(directory ? 'popup.export.change-location' : 'popup.export.choose-location');
             exportButton.enabled = false;
             exportButton.text = i18n.t(actionKey);
 
@@ -447,7 +452,7 @@ class ExportPopup extends Container {
             filenameMessage.dom.classList.toggle('error', !!message);
             filenameEntry.input.setAttribute('aria-invalid', String(!!message));
             exportButton.text = i18n.t(handle && !message ? 'popup.export.overwrite' : actionKey);
-            exportButton.enabled = !message && changeLocationButton.enabled && !submitting;
+            exportButton.enabled = !message && (!hasFilePicker || !!directory) && changeLocationButton.enabled && !submitting;
         };
 
         i18n.onChange(validateFilename, this);
@@ -460,8 +465,6 @@ class ExportPopup extends Container {
             const selected = await events.invoke('scene.pickExportDirectory');
             if (selected) {
                 directory = selected;
-                locationName.text = `…/${directory.name}`;
-                locationName.dom.title = locationName.text;
             }
             changeLocationButton.enabled = true;
             validateFilename();
@@ -588,9 +591,7 @@ class ExportPopup extends Container {
             reset(exportType, splatNames, orderedPoses.length > 0);
 
             directory = settings.directory;
-            locationRow.hidden = !directory;
-            locationName.text = directory ? `…/${directory.name}` : '';
-            locationName.dom.title = locationName.text;
+            locationRow.hidden = !hasFilePicker;
 
             filenameMessage.text = '';
             filenameMessage.hidden = true;

--- a/src/ui/export-popup.ts
+++ b/src/ui/export-popup.ts
@@ -462,12 +462,12 @@ class ExportPopup extends Container {
             validationId++;
             changeLocationButton.enabled = false;
             exportButton.enabled = false;
-            const selected = await events.invoke('scene.pickExportDirectory');
+            const selected = await events.invoke('scene.pickExportDirectory', !directory);
             if (selected) {
                 directory = selected;
             }
             changeLocationButton.enabled = true;
-            validateFilename();
+            validateFilename(!!selected);
         });
 
         cancelButton.on('click', () => onCancel());

--- a/src/ui/scss/export-popup.scss
+++ b/src/ui/scss/export-popup.scss
@@ -116,6 +116,12 @@
                         height: 24px;
                         line-height: 22px;
                     }
+
+                    .location-name.pcui-hidden + .change-location {
+                        flex-grow: 1;
+                        margin-left: 0;
+                        text-align: left;
+                    }
                 }
             }
         }

--- a/static/locales/de.json
+++ b/static/locales/de.json
@@ -286,6 +286,7 @@
     "popup.export.spz-version.3": "SPZ 3 (Legacy-gzip)",
     "popup.export.location": "Speicherort",
     "popup.export.change-location": "Ändern…",
+    "popup.export.choose-location": "Ausgabeordner wählen…",
     "popup.export.filename": "Dateiname",
     "popup.export.overwrite": "Überschreiben",
     "popup.export.overwrite-message": "Diese Datei existiert bereits. Überschreiben Sie sie oder wählen Sie einen anderen Dateinamen.",

--- a/static/locales/en.json
+++ b/static/locales/en.json
@@ -286,6 +286,7 @@
     "popup.export.spz-version.3": "SPZ 3 (legacy gzip)",
     "popup.export.location": "Location",
     "popup.export.change-location": "Change…",
+    "popup.export.choose-location": "Choose output folder…",
     "popup.export.filename": "Filename",
     "popup.export.overwrite": "Overwrite",
     "popup.export.overwrite-message": "This file already exists. Overwrite it or choose a different filename.",

--- a/static/locales/es.json
+++ b/static/locales/es.json
@@ -286,6 +286,7 @@
     "popup.export.spz-version.3": "SPZ 3 (gzip heredado)",
     "popup.export.location": "Ubicación",
     "popup.export.change-location": "Cambiar…",
+    "popup.export.choose-location": "Elegir carpeta de salida…",
     "popup.export.filename": "Nombre de archivo",
     "popup.export.overwrite": "Sobrescribir",
     "popup.export.overwrite-message": "Este archivo ya existe. Sobrescríbelo o elige otro nombre de archivo.",

--- a/static/locales/fr.json
+++ b/static/locales/fr.json
@@ -286,6 +286,7 @@
     "popup.export.spz-version.3": "SPZ 3 (gzip hérité)",
     "popup.export.location": "Emplacement",
     "popup.export.change-location": "Modifier…",
+    "popup.export.choose-location": "Choisir un dossier de sortie…",
     "popup.export.filename": "Nom de fichier",
     "popup.export.overwrite": "Écraser",
     "popup.export.overwrite-message": "Ce fichier existe déjà. Écrasez-le ou choisissez un autre nom de fichier.",

--- a/static/locales/ja.json
+++ b/static/locales/ja.json
@@ -286,6 +286,7 @@
     "popup.export.spz-version.3": "SPZ 3（レガシー gzip）",
     "popup.export.location": "保存先",
     "popup.export.change-location": "変更…",
+    "popup.export.choose-location": "出力先フォルダーを選択…",
     "popup.export.filename": "ファイル名",
     "popup.export.overwrite": "上書き",
     "popup.export.overwrite-message": "このファイルは既に存在します。上書きするか、別のファイル名を選択してください。",

--- a/static/locales/ko.json
+++ b/static/locales/ko.json
@@ -286,6 +286,7 @@
     "popup.export.spz-version.3": "SPZ 3 (레거시 gzip)",
     "popup.export.location": "저장 위치",
     "popup.export.change-location": "변경…",
+    "popup.export.choose-location": "출력 폴더 선택…",
     "popup.export.filename": "파일 이름",
     "popup.export.overwrite": "덮어쓰기",
     "popup.export.overwrite-message": "이 파일이 이미 존재합니다. 덮어쓰거나 다른 파일 이름을 선택하세요.",

--- a/static/locales/pt-BR.json
+++ b/static/locales/pt-BR.json
@@ -286,6 +286,7 @@
     "popup.export.spz-version.3": "SPZ 3 (gzip legado)",
     "popup.export.location": "Local",
     "popup.export.change-location": "Alterar…",
+    "popup.export.choose-location": "Escolher pasta de saída…",
     "popup.export.filename": "Nome do Arquivo",
     "popup.export.overwrite": "Sobrescrever",
     "popup.export.overwrite-message": "Este arquivo já existe. Sobrescreva-o ou escolha outro nome de arquivo.",

--- a/static/locales/ru.json
+++ b/static/locales/ru.json
@@ -286,6 +286,7 @@
     "popup.export.spz-version.3": "SPZ 3 (устаревший gzip)",
     "popup.export.location": "Папка",
     "popup.export.change-location": "Изменить…",
+    "popup.export.choose-location": "Выбрать папку вывода…",
     "popup.export.filename": "Имя файла",
     "popup.export.overwrite": "Перезаписать",
     "popup.export.overwrite-message": "Этот файл уже существует. Перезапишите его или выберите другое имя файла.",

--- a/static/locales/zh-CN.json
+++ b/static/locales/zh-CN.json
@@ -286,6 +286,7 @@
     "popup.export.spz-version.3": "SPZ 3（旧版 gzip）",
     "popup.export.location": "保存位置",
     "popup.export.change-location": "更改…",
+    "popup.export.choose-location": "选择输出文件夹…",
     "popup.export.filename": "文件名",
     "popup.export.overwrite": "覆盖",
     "popup.export.overwrite-message": "此文件已存在。请覆盖它或选择其他文件名。",


### PR DESCRIPTION
Show the save/export dialog first with a “Choose output folder…” button, keeping Save/Export disabled until a folder is selected. Reuse accessible remembered folders and require explicit selection when access is lost, avoiding unexpected browser prompts. Add translations for all supported languages. Validated with lint, TypeScript, locale checks, production build, and browser and regression checks.