### PR TITLE
Fix oversized gaussian footprints

### DIFF
--- a/src/shaders/footprint-intersect-shader.ts
+++ b/src/shaders/footprint-intersect-shader.ts
@@ -50,7 +50,7 @@ fn main(
 
     // decode the projected ellipse exactly as the render shader does
     let maxRadius = min(1024.0, min(uniforms.viewport.x, uniforms.viewport.y));
-    let ndcRange = vec2f(1.0) + vec2f(8.0 * maxRadius) / uniforms.viewport;
+    let ndcRange = vec2f(1.0) + vec2f(4.0 * maxRadius) / uniforms.viewport;
     let ndc = unpack2x16snorm(a.x) * ndcRange;
     // ndc y is up, target rows run down
     let center = (vec2f(ndc.x, -ndc.y) * 0.5 + 0.5) * uniforms.viewport;

--- a/src/shaders/projected-splat-projector-shader.ts
+++ b/src/shaders/projected-splat-projector-shader.ts
@@ -266,15 +266,6 @@ fn main(
         return;
     }
 
-    let maxRadius = min(1024.0, min(viewport.x, viewport.y));
-    let radiusXUncapped = sqrt(2.0 * cov00);
-    let radiusYUncapped = sqrt(2.0 * cov11);
-    let capScale = max(1.0, max(radiusXUncapped, radiusYUncapped) / maxRadius);
-    let invCapScale2 = 1.0 / (capScale * capScale);
-    cov00 *= invCapScale2;
-    cov01 *= invCapScale2;
-    cov11 *= invCapScale2;
-
     let mid = 0.5 * (cov00 + cov11);
     let radius = length(vec2f(0.5 * (cov00 - cov11), cov01));
     let lambda1 = mid + radius;
@@ -295,8 +286,13 @@ fn main(
     let eigenVec = vec2f(cov01, lambda1 - cov00);
     let eigenLen = length(eigenVec);
     let direction = select(vec2f(1.0, 0.0), eigenVec / eigenLen, eigenLen > 1e-9);
-    let axis1 = 2.0 * min(sqrt(2.0 * lambda1), maxRadius) * direction;
-    let len2 = 2.0 * min(sqrt(2.0 * lambda2), maxRadius);
+    // Cap the longest radius in screen pixels and scale both axes equally
+    // to preserve the ellipse's aspect ratio.
+    let maxRadius = min(1024.0, min(viewport.x, viewport.y));
+    let len1 = 2.0 * sqrt(2.0 * lambda1);
+    let radiusScale = min(1.0, maxRadius / len1);
+    let axis1 = len1 * radiusScale * direction;
+    let len2 = 2.0 * sqrt(2.0 * lambda2) * radiusScale;
     let axis2 = len2 * vec2f(direction.y, -direction.x);
 
     let ndc = clip.xy / clip.w;
@@ -352,9 +348,9 @@ fn main(
     let rgb = vec3u(clamp(color.rgb / f32(1u << exponent), vec3f(0.0), vec3f(1.0)) * 1023.0 + 0.5);
 
     // center: ndc as snorm16. The offscreen cull above bounds visible centers to
-    // |ndc| <= 1 + 2 * extentMax / viewport with extentMax = 4 * maxRadius; the
+    // |ndc| <= 1 + 2 * extentMax / viewport with extentMax = 2 * maxRadius; the
     // render shader derives the same range from its viewport uniform
-    let ndcRange = vec2f(1.0) + vec2f(8.0 * maxRadius) / viewport;
+    let ndcRange = vec2f(1.0) + vec2f(4.0 * maxRadius) / viewport;
 
     let cacheUv = cacheCoord(entry);
     textureStore(cacheA, cacheUv, vec4u(

--- a/src/shaders/projected-splat-shader.ts
+++ b/src/shaders/projected-splat-shader.ts
@@ -108,7 +108,7 @@ fn vertexMain(input: VertexInput) -> VertexOutput {
     // reconstruct clip position: ndc from snorm16 over the projector's range,
     // w = view depth (1 for ortho), z affine in view depth via clipZParams.xy
     let maxRadius = min(1024.0, min(uniform.viewportSize.x, uniform.viewportSize.y));
-    let ndcRange = vec2f(1.0) + vec2f(8.0 * maxRadius) / uniform.viewportSize.xy;
+    let ndcRange = vec2f(1.0) + vec2f(4.0 * maxRadius) / uniform.viewportSize.xy;
     let ndc = unpack2x16snorm(a.x) * ndcRange;
     let depth = bitcast<f32>(a.y);
     let w = select(depth, 1.0, uniform.clipZParams.z != 0.0);


### PR DESCRIPTION
Fix a v3 regression that doubled the maximum rendered gaussian radius. Apply the cap in screen pixels and scale both axes uniformly to preserve aspect ratio, keeping rendering, picking and footprint selection aligned. Validated with lint, a production build and 96 numerical checks.